### PR TITLE
Add photoelectric effect physics for optical photons

### DIFF
--- a/macros/NEW.config.mac
+++ b/macros/NEW.config.mac
@@ -25,6 +25,7 @@
 /PhysicsList/Nexus/clustering          false
 /PhysicsList/Nexus/drift               false
 /PhysicsList/Nexus/electroluminescence false
+/PhysicsList/Nexus/photoelectric       false
 
 /nexus/persistency/eventType background
 /nexus/persistency/outputFile NextNew.Bi214.DICE_BOARD.next

--- a/macros/NEW_S2_table.config.mac
+++ b/macros/NEW_S2_table.config.mac
@@ -21,4 +21,6 @@
 
 /Generator/ELTableGenerator/num_ie 100
 
+/PhysicsList/Nexus/photoelectric false
+
 /nexus/persistency/outputFile table.NEW.next

--- a/macros/NEW_argon.config.mac
+++ b/macros/NEW_argon.config.mac
@@ -30,5 +30,6 @@
 /PhysicsList/Nexus/clustering          false
 /PhysicsList/Nexus/drift               false
 /PhysicsList/Nexus/electroluminescence false
+/PhysicsList/Nexus/photoelectric       false
 
 /nexus/persistency/outputFile New.Na22_Ar.next

--- a/macros/NEW_fullKr.config.mac
+++ b/macros/NEW_fullKr.config.mac
@@ -21,6 +21,8 @@
 /Geometry/PmtR11410/time_binning 100. nanosecond
 /Geometry/SiPMSensl/time_binning 1. microsecond
 
+/PhysicsList/Nexus/photoelectric false
+
 # GENERATOR
 /Generator/Kr83mGenerator/region ACTIVE
 

--- a/macros/NEXT_options.config.mac
+++ b/macros/NEXT_options.config.mac
@@ -38,7 +38,7 @@
 # VESSEL_TRACKING_ENDCAP, VESSEL_ENERGY_ENDCAP, ICS,
 # DB_PLUG, CENTER, ACTIVE, BUFFER, XENON, LIGHT_TUBE,
 # EP_COPPER_PLATE, SAPPHIRE_WINDOW, OPTICAL_PAD,
-# PMT_BODY, PMT, INTERNAL_PMT_BASE, EXTERNAL_PMT_BASE, 
+# PMT_BODY, PMT, INTERNAL_PMT_BASE, EXTERNAL_PMT_BASE,
 # TP_COPPER_PLATE, DICE_BOARD, AXIAL_PORT, AD_HOC
 
 # Some of possible regions for NEW:
@@ -92,6 +92,7 @@
 /PhysicsList/Nexus/clustering          false
 /PhysicsList/Nexus/drift               false
 /PhysicsList/Nexus/electroluminescence false
+/PhysicsList/Nexus/photoelectric       false
 
 
 ##### PERSISTENCY #####

--- a/macros/physics/IonizationElectron.mac
+++ b/macros/physics/IonizationElectron.mac
@@ -10,3 +10,4 @@
 /PhysicsList/Nexus/clustering          false
 /PhysicsList/Nexus/drift               false
 /PhysicsList/Nexus/electroluminescence false
+/PhysicsList/Nexus/photoelectric       false

--- a/source/geometries/NextNewFieldCage.cc
+++ b/source/geometries/NextNewFieldCage.cc
@@ -82,7 +82,9 @@ namespace nexus {
     // EL field ON or OFF
     elfield_(0),
     el_table_index_(0),
-    el_table_binning_(5. * mm)
+    el_table_binning_(5. * mm),
+
+    photoe_prob_(0)
   {
     // Derived dimensions
     buffer_length_ =
@@ -186,6 +188,9 @@ namespace nexus {
 			    "Z coordinate for EL generation");
     eltable_z_cmd.SetUnitCategory("Length");
     eltable_z_cmd.SetParameterName("el_table_z", false);
+
+    msg_->DeclareProperty("photoe_prob", photoe_prob_,
+          "Probability of photon to ie- conversion");
 
   }
 
@@ -423,10 +428,15 @@ void NextNewFieldCage::BuildBuffer()
 
     G4Material* fgate_mat =
       MaterialsList::FakeDielectric(gas_, "el_grid_gate_mat");
+    // We have to set the defaults explicitely because C++ doesn't support
+    // named arguments
     fgate_mat->SetMaterialPropertiesTable(OpticalMaterialProperties::FakeGrid(pressure_,
                                                                               temperature_,
                                                                               gate_transparency_,
-                                                                              grid_thickness_));
+                                                                              grid_thickness_,
+                                                                              25510/MeV,
+                                                                              1000.*ms,
+                                                                              photoe_prob_));
 
     // Dimensions & position: the grids are simulated inside the EL gap.
     // Their thickness is symbolic.

--- a/source/geometries/NextNewFieldCage.h
+++ b/source/geometries/NextNewFieldCage.h
@@ -134,6 +134,8 @@ namespace nexus {
     mutable std::vector<G4ThreeVector> el_table_vertices_;
     G4double el_table_binning_;
     G4double el_table_z_;
+
+    G4double photoe_prob_;
   };
 
 } //end namespace nexus

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -660,6 +660,17 @@ G4MaterialPropertiesTable* OpticalMaterialProperties::FakeGrid(G4double pressure
   mpt->AddProperty("FASTCOMPONENT", sc_energy, intensity, sc_entries);
   mpt->AddProperty("SLOWCOMPONENT", sc_energy, intensity, sc_entries);
 
+
+  // PHOTOELECTRIC REEMISSION
+  // https://aip.scitation.org/doi/10.1063/1.1708797
+  G4double stainless_wf = 4.3 * eV; // work function
+  G4double prob         = 1e-3;
+  G4double ph_energy [] = {optPhotMinE_, stainless_wf - 0.1*eV, stainless_wf, optPhotMaxE_};
+  G4double emission_p[] = {           0,                     0,         prob,         prob};
+  mpt->AddProperty("OP_PHOTOELECTRIC_PROBABILITY",
+                   ph_energy, emission_p, 4);
+
+
   // CONST PROPERTIES
   mpt->AddConstProperty("SCINTILLATIONYIELD", sc_yield);
   mpt->AddConstProperty("RESOLUTIONSCALE",    1.0);

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -665,11 +665,8 @@ G4MaterialPropertiesTable* OpticalMaterialProperties::FakeGrid(G4double pressure
   // PHOTOELECTRIC REEMISSION
   // https://aip.scitation.org/doi/10.1063/1.1708797
   G4double stainless_wf = 4.3 * eV; // work function
-  G4double prob         = photoe_p;
-  G4double ph_energy [] = {optPhotMinE_, stainless_wf - 0.1*eV, stainless_wf, optPhotMaxE_};
-  G4double emission_p[] = {           0,                     0,         prob,         prob};
   mpt->AddConstProperty("WORK_FUNCTION", stainless_wf);
-  mpt->AddProperty("OP_PHOTOELECTRIC_PROBABILITY", ph_energy, emission_p, 4);
+  mpt->AddConstProperty("OP_PHOTOELECTRIC_PROBABILITY", photoe_p);
 
 
   // CONST PROPERTIES

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -668,8 +668,8 @@ G4MaterialPropertiesTable* OpticalMaterialProperties::FakeGrid(G4double pressure
   G4double prob         = photoe_p;
   G4double ph_energy [] = {optPhotMinE_, stainless_wf - 0.1*eV, stainless_wf, optPhotMaxE_};
   G4double emission_p[] = {           0,                     0,         prob,         prob};
-  mpt->AddProperty("OP_PHOTOELECTRIC_PROBABILITY",
-                   ph_energy, emission_p, 4);
+  mpt->AddConstProperty("WORK_FUNCTION", stainless_wf);
+  mpt->AddProperty("OP_PHOTOELECTRIC_PROBABILITY", ph_energy, emission_p, 4);
 
 
   // CONST PROPERTIES

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -616,7 +616,8 @@ G4MaterialPropertiesTable* OpticalMaterialProperties::FakeGrid(G4double pressure
                                                                G4double transparency,
                                                                G4double thickness,
                                                                G4int    sc_yield,
-                                                               G4double e_lifetime)
+                                                               G4double e_lifetime,
+                                                               G4double photoe_p)
 {
   XenonGasProperties GXe_prop(pressure, temperature);
   G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
@@ -664,7 +665,7 @@ G4MaterialPropertiesTable* OpticalMaterialProperties::FakeGrid(G4double pressure
   // PHOTOELECTRIC REEMISSION
   // https://aip.scitation.org/doi/10.1063/1.1708797
   G4double stainless_wf = 4.3 * eV; // work function
-  G4double prob         = 1e-3;
+  G4double prob         = photoe_p;
   G4double ph_energy [] = {optPhotMinE_, stainless_wf - 0.1*eV, stainless_wf, optPhotMaxE_};
   G4double emission_p[] = {           0,                     0,         prob,         prob};
   mpt->AddProperty("OP_PHOTOELECTRIC_PROBABILITY",

--- a/source/materials/OpticalMaterialProperties.h
+++ b/source/materials/OpticalMaterialProperties.h
@@ -61,7 +61,8 @@ namespace nexus {
                                                G4double transparency=.9,
                                                G4double thickness=1.*mm,
                                                G4int sc_yield=25510/MeV,
-                                               G4double e_lifetime=1000.*ms);
+                                               G4double e_lifetime=1000.*ms,
+                                               G4double photoe_p=0);
 
     static G4MaterialPropertiesTable* TPB();
 

--- a/source/physics/OpPhotoelectricEffect.cc
+++ b/source/physics/OpPhotoelectricEffect.cc
@@ -1,0 +1,114 @@
+// ----------------------------------------------------------------------------
+// nexus | OpPhotoelectricEffect.h
+//
+// Add photoelectric effect physics to optical photons hitting
+// specific materials.
+//
+// The NEXT Collaboration
+// ----------------------------------------------------------------------------
+
+#include "OpPhotoelectricEffect.h"
+
+#include "IonizationElectron.h"
+
+#include <G4Material.hh>
+#include <G4ParticleDefinition.hh>
+#include <G4OpticalPhoton.hh>
+#include <G4RandomDirection.hh>
+#include <G4Poisson.hh>
+
+
+namespace nexus {
+
+
+  using namespace CLHEP;
+
+  OpPhotoelectricEffect::OpPhotoelectricEffect(const G4String& process_name,
+                                             G4ProcessType type):
+    G4VDiscreteProcess(process_name, type), particle_change_(0)
+  {
+    // Create particle change object
+    particle_change_ = new G4ParticleChange();
+    pParticleChange = particle_change_;
+  }
+
+
+
+  OpPhotoelectricEffect::~OpPhotoelectricEffect()
+  {
+    delete particle_change_;
+  }
+
+
+
+  G4bool OpPhotoelectricEffect::IsApplicable(const G4ParticleDefinition& pdef)
+  {
+    return pdef == *G4OpticalPhoton::Definition();
+  }
+
+  G4VParticleChange*
+  OpPhotoelectricEffect::PostStepDoIt(const G4Track& track, const G4Step& step)
+  {
+    // Initialize particle change with current track values
+    particle_change_->Initialize(track);
+
+    const G4Material* material = track.GetMaterial();
+
+    G4MaterialPropertiesTable* mpt = material->GetMaterialPropertiesTable();
+    if (!mpt)
+      return G4VDiscreteProcess::PostStepDoIt(track, step);
+
+    G4MaterialPropertyVector*
+    probabilities = mpt->GetProperty("OP_PHOTOELECTRIC_PROBABILITY");
+
+    if (!probabilities)
+      return G4VDiscreteProcess::PostStepDoIt(track, step);
+
+    G4double photon_energy = track.GetDynamicParticle()->GetTotalEnergy();
+    G4int    n_ie          = G4Poisson(probabilities->Value(photon_energy));
+
+    if (!n_ie)
+      return G4VDiscreteProcess::PostStepDoIt(track, step);
+
+    particle_change_->ProposeTrackStatus(fStopAndKill);
+    particle_change_->SetNumberOfSecondaries(n_ie);
+
+    for (G4int i=0; i < n_ie; i++) {
+      G4ThreeVector momentum_direction = G4RandomDirection();
+      G4double      kinetic_energy     = photon_energy/n_ie;
+
+      G4DynamicParticle*
+      ie = new G4DynamicParticle(IonizationElectron::Definition(),
+                                 momentum_direction, kinetic_energy);
+
+
+      G4StepPoint* post = step.GetPostStepPoint();
+      G4Track* new_track = new G4Track(ie,
+                                       post->GetGlobalTime(),
+                                       post->GetPosition  ());
+
+      new_track->SetTouchableHandle(post->GetTouchableHandle());
+      new_track->SetParentID(track.GetTrackID());
+      particle_change_->AddSecondary(new_track);
+    }
+
+    return particle_change_;
+  }
+
+
+  G4double OpPhotoelectricEffect::GetMeanFreePath(const G4Track&, G4double,
+                                                 G4ForceCondition* condition)
+  {
+    *condition = StronglyForced;
+    return DBL_MAX;
+  }
+
+
+  G4double OpPhotoelectricEffect::GetMeanLifeTime(const G4Track&,
+                                                 G4ForceCondition* condition)
+  {
+    *condition = Forced;
+    return DBL_MAX;
+  }
+
+} // end namespace nexus

--- a/source/physics/OpPhotoelectricEffect.cc
+++ b/source/physics/OpPhotoelectricEffect.cc
@@ -86,11 +86,18 @@ namespace nexus {
     ie = new G4DynamicParticle(IonizationElectron::Definition(),
                                momentum_direction, kinetic_energy);
 
-    G4StepPoint* post = step.GetPostStepPoint();
-    G4Track* new_track = new G4Track(ie,
-                                     post->GetGlobalTime(),
-                                     post->GetPosition  ());
+    // Setting the emission point to either the pre or the post
+    // step points results in a warning about the new particle
+    // having a negative local time. This seems to be caused by
+    // the positions being in a boundary between two volumes.
+    // Taking the midpoint avoids the warning without affecting
+    // the physics.
+    G4StepPoint*  pre  = step.GetPreStepPoint();
+    G4StepPoint*  post = step.GetPostStepPoint();
+    G4double      time = post->GetGlobalTime();
+    G4ThreeVector pos  = (pre->GetPosition() + post->GetPosition()) / 2;
 
+    G4Track* new_track = new G4Track(ie, time, pos);
     new_track->SetTouchableHandle(post->GetTouchableHandle());
     new_track->SetParentID(track.GetTrackID());
 

--- a/source/physics/OpPhotoelectricEffect.h
+++ b/source/physics/OpPhotoelectricEffect.h
@@ -1,0 +1,59 @@
+// ----------------------------------------------------------------------------
+// nexus | OpPhotoelectricEffect.h
+//
+// Add photoelectric effect physics to optical photons hitting
+// specific materials.
+//
+// The NEXT Collaboration
+// ----------------------------------------------------------------------------
+
+#ifndef OPTICAL_PHOTOELECTRIC_H
+#define OPTICAL_PHOTOELECTRIC_H
+
+
+#include <G4VDiscreteProcess.hh>
+
+class G4Material;
+
+namespace nexus {
+
+  class OpPhotoelectricEffect: public G4VDiscreteProcess
+  {
+  public:
+
+    /// Constructor
+    OpPhotoelectricEffect(const G4String& process_name="OpPhotoelectricEffect",
+			                   G4ProcessType type = fUserDefined);
+    /// Destructor
+    ~OpPhotoelectricEffect();
+
+    /// Whether a particle is sensitive to this physics.
+    /// Only optical photons apply
+    G4bool IsApplicable(const G4ParticleDefinition&);
+
+    /// Calculates ionization electron emission probability
+    /// and generates new particles if necessary.
+    G4VParticleChange* PostStepDoIt(const G4Track&, const G4Step&);
+
+  private:
+
+    /// Returns infinity; i. e. the process does not limit the step,
+    /// but sets the 'StronglyForced' condition for the PostStepDoIt
+    /// to be invoked at every step
+    G4double GetMeanFreePath(const G4Track&, G4double, G4ForceCondition*);
+
+    /// Returns infinity; i. e. the process does not limit the time,
+    /// but sets the 'StronglyForced' condition for the AtRestDoIt
+    /// to be invoked at every step
+    G4double GetMeanLifeTime(const G4Track&, G4ForceCondition*);
+
+    G4bool ValidMaterial(const G4Material*);
+
+  private:
+    G4ParticleChange* particle_change_;
+
+  };
+
+} // end namespace nexus
+
+#endif

--- a/source/physics_lists/NexusPhysics.cc
+++ b/source/physics_lists/NexusPhysics.cc
@@ -13,6 +13,7 @@
 #include "IonizationDrift.h"
 #include "Electroluminescence.h"
 #include "WavelengthShifting.h"
+#include "OpPhotoelectricEffect.h"
 
 #include <G4GenericMessenger.hh>
 #include <G4OpticalPhoton.hh>
@@ -78,6 +79,9 @@ namespace nexus {
     }
     WavelengthShifting* wls = new WavelengthShifting();
     pmanager->AddDiscreteProcess(wls);
+
+    OpPhotoelectricEffect* photoe = new OpPhotoelectricEffect();
+    pmanager->AddDiscreteProcess(photoe);
 
     pmanager = IonizationElectron::Definition()->GetProcessManager();
     if (!pmanager) {

--- a/source/physics_lists/NexusPhysics.h
+++ b/source/physics_lists/NexusPhysics.h
@@ -33,6 +33,7 @@ namespace nexus {
     G4bool clustering_;          ///< Switch on/of the ionization clustering
     G4bool drift_;               ///< Switch on/of the ionization drift
     G4bool electroluminescence_; ///< Switch on/off the electroluminescence
+    G4bool photoelectric_;       ///< Switch on/off the photoelectric effect
 
     G4GenericMessenger* msg_;
   };


### PR DESCRIPTION
Add physics of photoelectric effect in metals for optical photons.
Currently implemented only for stainless steel in the fate mesh.
