### PR TITLE
Change tracking action to default for EL table generation.

### DIFF
--- a/macros/NEXT100_S2_table.init.mac
+++ b/macros/NEXT100_S2_table.init.mac
@@ -18,6 +18,6 @@
 
 /Actions/RegisterRunAction DEFAULT
 /Actions/RegisterEventAction SAVE_ALL
-/Actions/RegisterTrackingAction OPTICAL
+/Actions/RegisterTrackingAction DEFAULT
 
 /nexus/RegisterMacro macros/NEXT100_S2_table.config.mac


### PR DESCRIPTION
This PR simply changes the tracking action of the example macro for the EL table generation in NEXT 100 to the default one. It was set to OPTICAL by mistake, since in these simulations there's no need to save all the information of the tracking of the optical photons.