### PR TITLE
Generic photosensor visibility

### DIFF
--- a/macros/NextFlex_fullKr.config.mac
+++ b/macros/NextFlex_fullKr.config.mac
@@ -74,11 +74,13 @@
 /Geometry/NextFlex/tp_verbosity  true
 
 # VISIBILITIES
-/Geometry/NextFlex/fc_visibility  true
-/Geometry/NextFlex/ep_visibility  true
-/Geometry/PmtR11410/visibility    true
-/Geometry/NextFlex/tp_visibility  true
-/Geometry/NextFlex/ics_visibility true
+/Geometry/NextFlex/fc_visibility           true
+/Geometry/NextFlex/fiber_sensor_visibility false
+/Geometry/NextFlex/ep_visibility           true
+/Geometry/PmtR11410/visibility             true
+/Geometry/NextFlex/tp_visibility           true
+/Geometry/NextFlex/tp_sipm_visibility      false
+/Geometry/NextFlex/ics_visibility          false
 
 
 ### GENERATOR

--- a/macros/geometries/NEXT100DefaultVisibility.mac
+++ b/macros/geometries/NEXT100DefaultVisibility.mac
@@ -6,11 +6,12 @@
 ## The NEXT Collaboration
 ## ----------------------------------------------------------------------------
 
-/Geometry/Next100/shielding_vis         false
-/Geometry/Next100/vessel_vis            false
-/Geometry/Next100/ics_vis               false
-/Geometry/Next100/field_cage_vis         true
-/Geometry/Next100/energy_plane_vis       true
-/Geometry/Next100/tracking_plane_vis     true
-/Geometry/SiPM/visibility               false
-/Geometry/PmtR11410/visibility           true
+/Geometry/Next100/shielding_vis       false
+/Geometry/Next100/vessel_vis          false
+/Geometry/Next100/ics_vis             false
+/Geometry/Next100/field_cage_vis      true
+/Geometry/Next100/energy_plane_vis    true
+/Geometry/Next100/tracking_plane_vis  true
+/Geometry/Next100/sipm_board_vis      true
+/Geometry/Next100/sipm_vis            false
+/Geometry/PmtR11410/visibility        true

--- a/source/geometries/GenericPhotosensor.cc
+++ b/source/geometries/GenericPhotosensor.cc
@@ -31,7 +31,6 @@ GenericPhotosensor::GenericPhotosensor(G4String name,
                                        G4double height,
                                        G4double thickness):
   BaseGeometry     (),
-  msg_             (nullptr),
   name_            (name),
   width_           (width),      // Width of the Sensitive Area
   height_          (height),     // Height of the Sensitive Area
@@ -45,12 +44,6 @@ GenericPhotosensor::GenericPhotosensor(G4String name,
   time_binning_    (1.0 * us),
   visibility_      (false)
 {
-  // User control commands for generic photosensor
-  msg_ = new G4GenericMessenger(this, "/Geometry/" + name_ + '/',
-                                "Control commands of the generic photosensor geometry");
-
-  msg_->DeclareProperty("visibility", visibility_,
-                        "Visibility of the GenericPhotosensor volumes.");
 }
 
 
@@ -62,7 +55,6 @@ GenericPhotosensor::GenericPhotosensor(G4String name, G4double size):
 
 GenericPhotosensor::~GenericPhotosensor()
 {
-  delete msg_;
 }
 
 

--- a/source/geometries/GenericPhotosensor.h
+++ b/source/geometries/GenericPhotosensor.h
@@ -25,7 +25,7 @@ namespace nexus {
     // The default thickness corresponds to a typical value for
     // a silicon photomultiplier.
     GenericPhotosensor(G4String name,   G4double width,
-                       G4double height, G4double thickness = 2.0*mm);
+                       G4double height, G4double thickness = 2.0 * mm);
     
     // Constructor for a square sensor
     GenericPhotosensor(G4String name, G4double size);
@@ -42,6 +42,7 @@ namespace nexus {
     G4double GetThickness()   const;
     const G4String& GetName() const;
 
+    void SetVisibility           (G4bool visibility);
     void SetWithWLSCoating       (G4bool with_wls_coating);
     void SetWindowRefractiveIndex(G4MaterialPropertyVector* rindex);
     void SetOpticalProperties    (G4MaterialPropertiesTable* mpt);
@@ -54,8 +55,6 @@ namespace nexus {
 
     void ComputeDimensions();
     void DefineMaterials();
-
-    G4GenericMessenger* msg_;
 
     G4String name_;
     
@@ -86,6 +85,9 @@ namespace nexus {
   inline G4double GenericPhotosensor::GetHeight()      const { return height_; }
   inline G4double GenericPhotosensor::GetThickness()   const { return thickness_; }
   inline const G4String& GenericPhotosensor::GetName() const { return name_; }
+
+  inline void GenericPhotosensor::SetVisibility(G4bool visibility)
+  { visibility_ = visibility; }
 
   inline void GenericPhotosensor::SetWithWLSCoating(G4bool with_wls_coating)
   { with_wls_coating_ = with_wls_coating; }

--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -40,6 +40,7 @@ Next100SiPMBoard::Next100SiPMBoard():
   mask_thickness_  (  2.1  * mm), // Made slightly thicker to fit SiPM
   time_binning_    (1. * microsecond),
   visibility_      (true),
+  sipm_visibility_ (false),
   mpv_             (nullptr),
   vtxgen_          (nullptr),
   sipm_            (new GenericPhotosensor("SiPM", 1.3 * mm))
@@ -49,6 +50,9 @@ Next100SiPMBoard::Next100SiPMBoard():
 
   msg_->DeclareProperty("sipm_board_vis", visibility_,
                         "Visibility of Next100SiPMBoard.");
+
+  msg_->DeclareProperty("sipm_vis", sipm_visibility_,
+                        "Visibility of Next100 SiPMs.");
 
   G4GenericMessenger::Command& time_binning_cmd =
   msg_->DeclareProperty("sipm_time_binning", time_binning_,
@@ -185,6 +189,7 @@ void Next100SiPMBoard::Construct()
   G4double efficiency[]   = {1.0     ,  1.0};
   photosensor_mpt->AddProperty("REFLECTIVITY", energy, reflectivity, 2);
   photosensor_mpt->AddProperty("EFFICIENCY",   energy, efficiency,   2);
+  sipm_->SetVisibility(sipm_visibility_);
   sipm_->SetOpticalProperties(photosensor_mpt);
   sipm_->SetWithWLSCoating(true);
   sipm_->SetTimeBinning(time_binning_);

--- a/source/geometries/Next100SiPMBoard.h
+++ b/source/geometries/Next100SiPMBoard.h
@@ -51,7 +51,7 @@ namespace nexus {
     G4double board_thickness_, mask_thickness_;
     G4double time_binning_;
     std::vector<G4ThreeVector> sipm_positions_;
-    G4bool   visibility_;
+    G4bool   visibility_, sipm_visibility_;
     G4VPhysicalVolume*  mpv_;
     BoxPointSampler*    vtxgen_;
     GenericPhotosensor* sipm_;

--- a/source/geometries/NextFlexFieldCage.cc
+++ b/source/geometries/NextFlexFieldCage.cc
@@ -40,28 +40,29 @@ using namespace nexus;
 
 NextFlexFieldCage::NextFlexFieldCage():
   BaseGeometry(),
-  mother_logic_      (nullptr),
-  verbosity_         (false),
-  visibility_        (false),
-  msg_               (nullptr),
-  fc_with_fibers_    (true), 
-  active_diam_       (984. * mm),          // Same as NEXT100 (something btwn 1000 & 984 mm)
-  active_length_     (116. * cm),          // Distance GATE - CATHODE (meshes not included)
-  drift_transv_diff_ (1. * mm/sqrt(cm)),   // Drift field transversal diffusion
-  drift_long_diff_   (.3 * mm/sqrt(cm)),   // Drift field longitudinal diffusion
-  cathode_transparency_ (0.95),            // Cathode transparency
-  buffer_length_     (280. * mm),          // Distance CATHODE - sapphire window surfaces
-  el_gap_length_     (10. * mm),           // Distance ANODE - GATE (meshes included)
-  el_field_on_       (false),              // EL field ON-OFF
-  el_field_int_      (16.0 * kilovolt/cm), // EL field intensity
-  el_transv_diff_    (0. * mm/sqrt(cm)),   // EL field transversal diffusion
-  el_long_diff_      (0. * mm/sqrt(cm)),   // EL field longitudinal diffusion
-  anode_transparency_(0.95),               // Anode transparency
-  gate_transparency_ (0.95),               // Gate transparency
-  fiber_claddings_   (2),                  // Number of fiber claddings (0, 1 or 2)
-  fiber_sensor_binning_ (100. * ns),       // Size of fiber sensors time binning
-  wls_mat_name_      ("TPB"),              // UV wls material name
-  fiber_mat_name_    ("EJ280")             // Fiber core material name
+  mother_logic_            (nullptr),
+  verbosity_               (false),
+  visibility_              (false),
+  fiber_sensor_visibility_ (false),
+  msg_                     (nullptr),
+  fc_with_fibers_          (true), 
+  active_diam_             (984. * mm),          // Same as NEXT100 (something btwn 1000 & 984 mm)
+  active_length_           (116. * cm),          // Distance GATE - CATHODE (meshes not included)
+  drift_transv_diff_       (1. * mm/sqrt(cm)),   // Drift field transversal diffusion
+  drift_long_diff_         (.3 * mm/sqrt(cm)),   // Drift field longitudinal diffusion
+  cathode_transparency_    (0.95),               // Cathode transparency
+  buffer_length_           (280. * mm),          // Distance CATHODE - sapphire window surfaces
+  el_gap_length_           (10. * mm),           // Distance ANODE - GATE (meshes included)
+  el_field_on_             (false),              // EL field ON-OFF
+  el_field_int_            (16.0 * kilovolt/cm), // EL field intensity
+  el_transv_diff_          (0. * mm/sqrt(cm)),   // EL field transversal diffusion
+  el_long_diff_            (0. * mm/sqrt(cm)),   // EL field longitudinal diffusion
+  anode_transparency_      (0.95),               // Anode transparency
+  gate_transparency_       (0.95),               // Gate transparency
+  fiber_claddings_         (2),                  // Number of fiber claddings (0, 1 or 2)
+  fiber_sensor_binning_    (100. * ns),          // Size of fiber sensors time binning
+  wls_mat_name_            ("TPB"),              // UV wls material name
+  fiber_mat_name_          ("EJ280")             // Fiber core material name
 {
 
   // Messenger
@@ -112,8 +113,11 @@ void NextFlexFieldCage::DefineConfigurationParameters()
   // Verbosity
   msg_->DeclareProperty("fc_verbosity", verbosity_, "Verbosity");
 
-  // Visibility
-  msg_->DeclareProperty("fc_visibility", visibility_, "FIELD_CAGE Visibility");
+  // Visibilities
+  msg_->DeclareProperty("fc_visibility", visibility_, "FIELD_CAGE visibility");
+
+  msg_->DeclareProperty("fiber_sensor_visibility", fiber_sensor_visibility_,
+                        "Fiber sensors visibility");
 
   // FIELD_CAGE configuration
   msg_->DeclareProperty("fc_with_fibers", fc_with_fibers_, "FIELD_CAGE with fibers");
@@ -866,6 +870,10 @@ void NextFlexFieldCage::BuildFiberSensors()
   right_sensor_->SetSensorDepth(1);
   right_sensor_->SetMotherDepth(2);
   right_sensor_->SetNamingOrder(1);
+
+  // Set visibilities
+  left_sensor_ ->SetVisibility(fiber_sensor_visibility_);
+  right_sensor_->SetVisibility(fiber_sensor_visibility_);
 
   // Construct
   left_sensor_ ->Construct();

--- a/source/geometries/NextFlexFieldCage.cc
+++ b/source/geometries/NextFlexFieldCage.cc
@@ -898,6 +898,9 @@ void NextFlexFieldCage::BuildFiberSensors()
                                                 sensor_rad * cos(phi),
                                                 sensor_left_posZ);
 
+    if (verbosity_) G4cout << "* Left  fiber sensor " << first_left_sensor_id_ + sensor_id
+                           << " position: " << case_left_pos << G4endl;
+
     new G4PVPlacement(G4Transform3D(sensor_left_rot, case_left_pos), left_sensor_logic,
                       left_sensor_logic->GetName(), mother_logic_, true,
                       first_left_sensor_id_ + sensor_id, false);
@@ -908,6 +911,9 @@ void NextFlexFieldCage::BuildFiberSensors()
     G4ThreeVector case_right_pos = G4ThreeVector(sensor_rad * sin(phi),
                                                  sensor_rad * cos(phi),
                                                  sensor_right_posZ);
+
+    if (verbosity_) G4cout << "* Right fiber sensor " << first_right_sensor_id_ + sensor_id
+                           << " position: " << case_right_pos << G4endl;
 
     new G4PVPlacement(G4Transform3D(sensor_right_rot, case_right_pos), right_sensor_logic,
                                     right_sensor_logic->GetName(), mother_logic_, true,

--- a/source/geometries/NextFlexFieldCage.h
+++ b/source/geometries/NextFlexFieldCage.h
@@ -95,6 +95,7 @@ namespace nexus {
 
     // Visibilities
     G4bool visibility_;
+    G4bool fiber_sensor_visibility_;
 
     // The messenger
     G4GenericMessenger* msg_; // Messenger for configuration parameters

--- a/source/geometries/NextFlexTrackingPlane.cc
+++ b/source/geometries/NextFlexTrackingPlane.cc
@@ -46,8 +46,9 @@ NextFlexTrackingPlane::NextFlexTrackingPlane():
   mother_logic_      (nullptr),
   verbosity_         (false),
   visibility_        (false),
+  SiPM_visibility_   (false),
   msg_               (nullptr),
-  wls_mat_name_       ("TPB"),
+  wls_mat_name_      ("TPB"),
   SiPM_ANODE_dist_   (10.  * mm),   // Distance from ANODE to SiPM surface
   SiPM_size_x_       ( 1.3 * mm),   // Size X (width) of SiPMs
   SiPM_size_y_       ( 1.3 * mm),   // Size Y (height) of SiPMs
@@ -90,8 +91,11 @@ void NextFlexTrackingPlane::DefineConfigurationParameters()
   // Verbosity
   msg_->DeclareProperty("tp_verbosity", verbosity_, "Verbosity");
 
-  // Visibility
+  // Visibilities
   msg_->DeclareProperty("tp_visibility", visibility_, "TRACKING_PLANE Visibility");
+
+  msg_->DeclareProperty("tp_sipm_visibility", SiPM_visibility_,
+                        "TRACKING_PLANE SiPMs Visibility");
 
   // Copper dimensions
   G4GenericMessenger::Command& copper_thickness_cmd =
@@ -426,6 +430,9 @@ G4LogicalVolume* NextFlexTrackingPlane::BuildSiPM()
   SiPM_->SetMotherDepth(2);
   SiPM_->SetNamingOrder(1);
 
+  // Set visibility
+  SiPM_->SetVisibility(SiPM_visibility_);
+  
   // Construct
   SiPM_->Construct();
 

--- a/source/geometries/NextFlexTrackingPlane.h
+++ b/source/geometries/NextFlexTrackingPlane.h
@@ -91,6 +91,7 @@ namespace nexus {
 
     // Visibilities
     G4bool visibility_;
+    G4bool SiPM_visibility_;
 
     // The messenger
     G4GenericMessenger* msg_; // Messenger for configuration parameters


### PR DESCRIPTION
This PR removes the messenger and the visibility parameter from the GenericPhotosensor class, and introduces a setter to set it.

Classes making use of these sensors now have a specific parameter to set these sensors visibility.

Macro files have been updated accordingly.