### PR TITLE
DEMO++ energy plane

### DIFF
--- a/source/geometries/NextDemoEnergyPlane.cc
+++ b/source/geometries/NextDemoEnergyPlane.cc
@@ -41,25 +41,18 @@ namespace nexus {
   using namespace CLHEP;
 
   NextDemoEnergyPlane::NextDemoEnergyPlane():
-
+    dist_gate_support_surface_(445.5 * mm),
     num_PMTs_ (3),
-    //   energy_plane_posz_ (-209.5 * mm),  //  from STEP-FILE:: Sapphire PosZ (-21.55 * cm)
-
-    // Carrier Plate dimensions
-    // STEP file:  0610-3  PMTs  FLANGE_PMTs::
     carrier_plate_thickness_ (45. * mm),
-     // OUTER ACTIVE is 229*mm // (194.227mm) It must be consistent with ACTIVE diameter (from drawings)/(194.97mm)/160mm in Next1El
-    carrier_plate_diam_ ( 234. * mm), //WidthOut 280.003 mm,thick 23.049 mm,netRAD 233.905 mm
-    carrier_plate_central_hole_diam_ (10. * mm), // It is instead of central OLD-PMT(It is 10cm for Next100: nozzle_external_diam + 1 cm(equal to the ICS hole))  //  external hole only with NO extra 1 cm, here. //  16 mm or 10 mm
-
-    // Ruty - from  Next100EnergyPlane.cc
-    // Enclosures dimensions - like in Next100 ? Since they are the same PMT's
-    enclosure_length_ (18.434 * cm),
-    enclosure_diam_ (9.6 * cm),
-    enclosure_flange_length_ (19.5 * mm),
-    enclosure_window_thickness_ (7.1 * mm),
-    enclosure_window_diam_ (85. * mm),
-    enclosure_pad_thickness_ (1.0 * mm),
+    carrier_plate_diam_ ( 234. * mm),
+    carrier_plate_central_hole_diam_ (10. * mm),
+    pmt_hole_length_ (18.434 * cm),
+    pmt_hole_diam_ (9.6 * cm),
+    pmt_flange_length_ (19.5 * mm),
+    sapphire_window_thickness_ (6. * mm),
+    sapphire_window_diam_ (85. * mm),
+    pedot_coating_thickness_ (3. * micrometer),
+    optical_pad_thickness_ (1.0 * mm),
     pmt_base_diam_ (47. *mm),
     pmt_base_thickness_ (5. *mm),
     tpb_thickness_ (1.*micrometer),
@@ -67,21 +60,20 @@ namespace nexus {
     visibility_(1),
     verbosity_(0)
   {
-    // //////////////////////////////////////////////////////////////////////////
+    /// Initializing the geometry navigator (used in vertex generation) ///
+    geom_navigator_ =
+      G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking();
 
-    /// Initializing the geometry navigator (used in vertex generation)
-    geom_navigator_ = G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking();
+    /// Messenger ///
+    msg_ = new G4GenericMessenger(this, "/Geometry/NextDemo/",
+                                  "Control commands of geometry NextDemo.");
+    msg_->DeclareProperty("energy_plane_vis", visibility_,
+                          "Energy Plane Visibility");
 
+    msg_->DeclareProperty("energy_plane_verbosity", verbosity_,
+                          "Energy Plane verbosity");
 
-    /// Messenger
-    msg_ = new G4GenericMessenger(this, "/Geometry/NextDemo/", "Control commands of geometry NextDemo.");
-    msg_->DeclareProperty("energy_plane_vis", visibility_, "Energy Plane Visibility");
-
-    msg_->DeclareProperty("energy_plane_verbosity", verbosity_, "Energy Plane verbosity");
-
-    /// The PMT
     pmt_ = new PmtR11410();
-
   }
 
 
@@ -105,187 +97,199 @@ namespace nexus {
   {
     GeneratePositions();
 
-    ///////////////////////////
-    /////   Carrier Plate   ///
-
+    /// Support Plate ///
     G4Tubs* carrier_plate_nh_solid =
-      new G4Tubs("CARRIER_PLATE_NH", 0., carrier_plate_diam_/2., carrier_plate_thickness_/2., 0., twopi);
+      new G4Tubs("EP_PLATE_NH", 0., carrier_plate_diam_/2.,
+                 carrier_plate_thickness_/2., 0., twopi);
 
-    // Making central hole for vacuum manifold
+    /// Making central hole for vacuum manifold ///
     G4Tubs* carrier_plate_central_hole_solid =
-      new G4Tubs("CARRIER_PLATE_CENTRAL_HOLE", 0., carrier_plate_central_hole_diam_/2., (carrier_plate_thickness_+1.*cm)/2., 0., twopi);
+      new G4Tubs("EP_PLATE_CENTRAL_HOLE", 0.,
+                 carrier_plate_central_hole_diam_/2.,
+                 (carrier_plate_thickness_+1.*cm)/2., 0., twopi);
 
-    G4SubtractionSolid* carrier_plate_solid = new G4SubtractionSolid("CARRIER_PLATE", carrier_plate_nh_solid,
-								     carrier_plate_central_hole_solid, 0, G4ThreeVector(0. , 0., 0.) );
+    G4SubtractionSolid* carrier_plate_solid =
+      new G4SubtractionSolid("EP_PLATE", carrier_plate_nh_solid,
+                             carrier_plate_central_hole_solid, 0,
+                             G4ThreeVector(0., 0., 0.) );
 
-    // Making PMT holes
+    /// Making PMT holes ///
     G4Tubs* carrier_plate_pmt_hole_solid =
-      new G4Tubs("CARRIER_PLATE_PMT_HOLE", 0., enclosure_diam_/2., (carrier_plate_thickness_+1.*cm)/2., 0., twopi);
+      new G4Tubs("EP_PLATE_PMT_HOLE", 0., pmt_hole_diam_/2.,
+                 (carrier_plate_thickness_+1.*cm)/2., 0., twopi);
 
     for (int i=0; i<num_PMTs_; i++) {
-      carrier_plate_solid = new G4SubtractionSolid("CARRIER_PLATE", carrier_plate_solid,
-						   carrier_plate_pmt_hole_solid, 0, pmt_positions_[i]);
+      carrier_plate_solid =
+        new G4SubtractionSolid("EP_PLATE", carrier_plate_solid,
+                               carrier_plate_pmt_hole_solid, 0,
+                               pmt_positions_[i]);
     }
 
-    G4LogicalVolume* carrier_plate_logic = new G4LogicalVolume(carrier_plate_solid,
-							       G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"),
-							       "CARRIER_PLATE");
+    G4LogicalVolume* carrier_plate_logic =
+      new G4LogicalVolume(carrier_plate_solid,
+                          G4NistManager::Instance()->FindOrBuildMaterial("G4_Aluminum"),
+                          "EP_PLATE");
 
     G4double carrier_plate_posz =
-      GetELzCoord() + end_of_sapphire_posz_ + carrier_plate_thickness_/2.;
-    new G4PVPlacement(0, G4ThreeVector(0., 0., carrier_plate_posz), carrier_plate_logic,
-		      "CARRIER_PLATE", mother_logic_, false, 0, false);
+      GetELzCoord() + dist_gate_support_surface_ + carrier_plate_thickness_/2.;
+    new G4PVPlacement(0, G4ThreeVector(0., 0., carrier_plate_posz),
+                      carrier_plate_logic, "EP_PLATE", mother_logic_,
+                      false, 0, false);
 
-
-    ////////////////////////
-    /////   Enclosures   ///
 
     /// Assign optical properties to materials ///
-    G4Material* sapphire = MaterialsList::Sapphire();
-    sapphire->SetMaterialPropertiesTable(OpticalMaterialProperties::Sapphire());
-    G4Material* vacuum =
-      G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic");
-    vacuum->SetMaterialPropertiesTable(OpticalMaterialProperties::Vacuum());
-    G4Material* optical_coupler = MaterialsList::OpticalSilicone();
-    optical_coupler->SetMaterialPropertiesTable(OpticalMaterialProperties::OptCoupler());
-
-    // // A "pseudo-enclosure"of vacuum is constructed to hold the elements that are replicated
-    G4Tubs* enclosure_gas_solid = new G4Tubs("ENCLOSURE_GAS", 0., enclosure_diam_/2., enclosure_length_/2., 0., twopi);
-    G4LogicalVolume* enclosure_gas_logic =
-      new G4LogicalVolume(enclosure_gas_solid, vacuum, "ENCLOSURE_GAS");
-
-    G4Tubs* enclosure_flange_solid =
-      new G4Tubs("ENCLOSURE_FLANGE", enclosure_window_diam_/2., enclosure_diam_/2., enclosure_flange_length_/2., 0., twopi);
-
-    G4LogicalVolume* enclosure_flange_logic =
-      new G4LogicalVolume(enclosure_flange_solid, G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"),
-			  "ENCLOSURE_FLANGE");
-
-    G4ThreeVector flange_pos(0., 0., - enclosure_length_/2. + enclosure_flange_length_/2.);
-    new G4PVPlacement(0, flange_pos, enclosure_flange_logic,
-      		      "ENCLOSURE_FLANGE", enclosure_gas_logic, false, 0, false);
-
-
-    // Adding the sapphire window
-    G4Tubs* enclosure_window_solid =
-      new G4Tubs("ENCLOSURE_WINDOW", 0.,enclosure_window_diam_/2., enclosure_window_thickness_/2., 0., twopi);
-
-    G4LogicalVolume* enclosure_window_logic =
-      new G4LogicalVolume(enclosure_window_solid, sapphire, "ENCLOSURE_WINDOW");
-
-    G4double window_posz = - enclosure_length_/2. + enclosure_window_thickness_/2. ;
-    new G4PVPlacement(0, G4ThreeVector(0.,0.,window_posz), enclosure_window_logic,
-		      "ENCLOSURE_WINDOW", enclosure_gas_logic, false, 0, false);
-
-    // Add TPB coating on sapphire window
     G4Material* tpb = MaterialsList::TPB();
     tpb->SetMaterialPropertiesTable(OpticalMaterialProperties::TPB());
 
-    G4Tubs* tpb_solid = new G4Tubs("ENCLOSURE_TPB", 0., enclosure_window_diam_/2,
-				   tpb_thickness_/2., 0., twopi);
+    G4Material* sapphire = MaterialsList::Sapphire();
+    sapphire->SetMaterialPropertiesTable(OpticalMaterialProperties::Sapphire());
+
+    G4Material* vacuum =
+      G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic");
+    vacuum->SetMaterialPropertiesTable(OpticalMaterialProperties::Vacuum());
+
+    G4Material* optical_coupler = MaterialsList::OpticalSilicone();
+    optical_coupler->SetMaterialPropertiesTable(OpticalMaterialProperties::OptCoupler());
+
+    G4Material* pedot = MaterialsList::PEDOT();
+    pedot->SetMaterialPropertiesTable(OpticalMaterialProperties::PEDOT());
+
+    /// A volume of vacuum is constructed to hold the elements ///
+    /// that are replicated ///
+    G4Tubs* pmt_hole_solid =
+      new G4Tubs("PMT_HOLE", 0., pmt_hole_diam_/2., pmt_hole_length_/2.,
+                 0., twopi);
+    G4LogicalVolume* pmt_hole_logic =
+      new G4LogicalVolume(pmt_hole_solid, vacuum, "PMT_HOLE");
+
+    G4Tubs* pmt_flange_solid =
+      new G4Tubs("PMT_FLANGE", sapphire_window_diam_/2.,
+                 pmt_hole_diam_/2., pmt_flange_length_/2., 0., twopi);
+
+    G4LogicalVolume* pmt_flange_logic =
+      new G4LogicalVolume(pmt_flange_solid,
+                          G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"),
+			  "PMT_FLANGE");
+
+    G4ThreeVector flange_pos(0., 0., -pmt_hole_length_/2. + pmt_flange_length_/2.);
+    new G4PVPlacement(0, flange_pos, pmt_flange_logic,
+      		      "PMT_FLANGE", pmt_hole_logic, false, 0, false);
+
+
+    /// Sapphire window ///
+    G4Tubs* sapphire_window_solid =
+      new G4Tubs("SAPPHIRE_WINDOW", 0., sapphire_window_diam_/2.,
+                 sapphire_window_thickness_/2., 0., twopi);
+
+    G4LogicalVolume* sapphire_window_logic =
+      new G4LogicalVolume(sapphire_window_solid, sapphire, "SAPPHIRE_WINDOW");
+
+    G4double window_zpos = -pmt_hole_length_/2. + sapphire_window_thickness_/2. ;
+    new G4PVPlacement(0, G4ThreeVector(0.,0.,window_zpos),
+                      sapphire_window_logic, "SAPPHIRE_WINDOW",
+                      pmt_hole_logic, false, 0, false);
+
+    /// TPB coating on pedot ///
+    G4Tubs* tpb_solid =
+      new G4Tubs("SAPPHIRE_WNDW_TPB", 0., sapphire_window_diam_/2,
+                 tpb_thickness_/2., 0., twopi);
     G4LogicalVolume* tpb_logic =
-      new G4LogicalVolume(tpb_solid, tpb, "ENCLOSURE_TPB");
+      new G4LogicalVolume(tpb_solid, tpb, "SAPPHIRE_WNDW_TPB");
 
-    G4double tpb_posz = - enclosure_window_thickness_/2. + tpb_thickness_/2.;
+    G4double tpb_posz = - sapphire_window_thickness_/2. + tpb_thickness_/2.;
     new G4PVPlacement(0, G4ThreeVector(0., 0., tpb_posz), tpb_logic,
-                      "ENCLOSURE_TPB", enclosure_window_logic, false, 0, false);
+                      "SAPPHIRE_WNDW_TPB", sapphire_window_logic,
+                      false, 0, false);
 
-    // Adding the optical pad
-    G4Tubs* enclosure_pad_solid =
-      new G4Tubs("ENCLOSURE_PAD", 0., enclosure_window_diam_/2., enclosure_pad_thickness_/2., 0., twopi);
+    /// PEDOT coating on sapphire windows ///
+    G4Tubs* pedot_coating_solid =
+      new G4Tubs("SAPPHIRE_WNDW_PEDOT", 0., sapphire_window_diam_/2.,
+                 pedot_coating_thickness_/2., 0., twopi);
 
-    // G4LogicalVolume* enclosure_pad_logic =
-    //   new G4LogicalVolume(enclosure_pad_solid, MaterialsList::OpticalSilicone(),
-    // 							       "ENCLOSURE_PAD");
-    G4LogicalVolume* enclosure_pad_logic =
-      new G4LogicalVolume(enclosure_pad_solid, optical_coupler, "ENCLOSURE_PAD");
+    G4LogicalVolume* pedot_coating_logic =
+      new G4LogicalVolume(pedot_coating_solid, pedot, "SAPPHIRE_WNDW_PEDOT");
 
-    G4double pad_posz = window_posz + enclosure_window_thickness_/2. + enclosure_pad_thickness_/2.;
-    new G4PVPlacement(0, G4ThreeVector(0.,0.,pad_posz), enclosure_pad_logic,
-		      "ENCLOSURE_PAD", enclosure_gas_logic, false, 0, false);
+    G4double pedot_coating_zpos =
+      - sapphire_window_thickness_/2. + tpb_thickness_ + pedot_coating_thickness_/2.;
+    new G4PVPlacement(nullptr, G4ThreeVector(0., 0., pedot_coating_zpos),
+                      pedot_coating_logic, "SAPPHIRE_WNDW_PEDOT",
+                      sapphire_window_logic, false, 0, false);
+
+    /// Optical pad ///
+    G4Tubs* optical_pad_solid =
+      new G4Tubs("OPTICAL_PAD", 0., sapphire_window_diam_/2.,
+                 optical_pad_thickness_/2., 0., twopi);
+
+    G4LogicalVolume* optical_pad_logic =
+      new G4LogicalVolume(optical_pad_solid, optical_coupler, "OPTICAL_PAD");
+
+    G4double pad_zpos =
+      window_zpos + sapphire_window_thickness_/2. + optical_pad_thickness_/2.;
+    new G4PVPlacement(0, G4ThreeVector(0.,0.,pad_zpos), optical_pad_logic,
+		      "OPTICAL_PAD", pmt_hole_logic, false, 0, false);
 
 
-
-    // Adding the PMT
+    /// PMT ///
     pmt_->SetSensorDepth(4);
     pmt_->Construct();
     G4LogicalVolume* pmt_logic = pmt_->GetLogicalVolume();
-    G4double pmt_rel_posz = pmt_->GetRelPosition().z();
-    pmt_zpos_ = pad_posz + enclosure_pad_thickness_/2. + pmt_rel_posz;
+    G4double pmt_rel_zpos = pmt_->GetRelPosition().z();
+    pmt_zpos_ = pad_zpos + optical_pad_thickness_/2. + pmt_rel_zpos;
     G4ThreeVector pmt_pos = G4ThreeVector(0., 0., pmt_zpos_);
 
     pmt_rot_ = new G4RotationMatrix();
     pmt_rot_->rotateY(pi);
 
     new G4PVPlacement(G4Transform3D(*pmt_rot_, pmt_pos), pmt_logic,
-		      "PMT", enclosure_gas_logic, false, 0, true);  // false
-    G4VisAttributes * vis3 = new G4VisAttributes;
-    vis3->SetColor(0.5, 0.5, .5);
-    vis3->SetForceSolid(true);
-    pmt_logic->SetVisAttributes(vis3);
+		      "PMT", pmt_hole_logic, false, 0, false);
 
-    // Adding the PMT base
+
+    /// PMT base ///
     G4Tubs* pmt_base_solid =
-      new G4Tubs("PMT_BASE", 0., pmt_base_diam_/2., pmt_base_thickness_, 0.,twopi);
+      new G4Tubs("PMT_BASE", 0., pmt_base_diam_/2., pmt_base_thickness_,
+                 0.,twopi);
     G4LogicalVolume* pmt_base_logic =
-      new G4LogicalVolume(pmt_base_solid, G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON"),
+      new G4LogicalVolume(pmt_base_solid,
+                          G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON"),
 			  "PMT_BASE");
 
-    G4double pmt_base_pos = enclosure_length_/2. - pmt_base_thickness_; //to be checked
+    G4double pmt_base_pos = pmt_hole_length_/2. - pmt_base_thickness_;
     new G4PVPlacement(0, G4ThreeVector(0.,0., pmt_base_pos),
-		      pmt_base_logic, "PMT_BASE", enclosure_gas_logic, false, 0, false);
+		      pmt_base_logic, "PMT_BASE", pmt_hole_logic,
+                      false, 0, false);
 
 
+    G4double pmt_hole_zpos = GetELzCoord() + end_of_sapphire_posz_
+      + pmt_hole_length_/2.;
 
-    // Placing the "pseudo-enclosures" with all internal components in place + TPB in front
-    // G4double enclosure_posz =  energy_plane_posz_ - enclosure_length_/2.;
-    G4double enclosure_posz = GetELzCoord() + end_of_sapphire_posz_ + enclosure_length_/2.;
-
-   if (verbosity_) {
-          G4cout << " *********  PMT  POSITION   PRINTING  ********* " << G4endl;
-    G4cout << "EnclosureEndsZ = "
-           << enclosure_posz << " pls " << enclosure_length_/2. << " EQ "
-           <<  enclosure_posz + enclosure_length_/2.<< G4endl;
-    // G4cout << "Enclosure ends at z = " << enclosure_posz + _enclosure_length/2. << G4endl;
-    // G4cout << "TPB ends at z = " << _energy_plane_posz + _tpb_thickness << G4endl;
-   }
     G4ThreeVector pos;
     G4ThreeVector tpb_pos;
+    if (verbosity_) G4cout << "*** XY position of PMTs ***" << G4endl;
+
     for (int i=0; i<num_PMTs_; i++) {
       pos = pmt_positions_[i];
-      if (verbosity_) {
-          G4cout << "Enclosure Pos XY = " << pos << G4endl;}
-      pos.setZ(enclosure_posz);
-      new G4PVPlacement(0, pos, enclosure_gas_logic,
-			"PSEUDO-ENCLOSURE", mother_logic_, false, i, false);
-
+      if (verbosity_) G4cout << pos.getX() << ", " << pos.getY() << G4endl;
+      pos.setZ(pmt_hole_zpos);
+      new G4PVPlacement(0, pos, pmt_hole_logic,
+			"PMT_HOLE", mother_logic_, false, i, false);
     }
 
-   if (verbosity_) {
-    G4cout << " *******  END   PMT  POSITION   PRINTING  END  ******* " << G4endl;
-   }
-    // G4PVPlacement* enclosure_physi = new G4PVPlacement(0, G4ThreeVector(0.,0.,0.), enclosure_logic,
-    // 						     "ENCLOSURE", _mother_logic, false, 0);
 
-
-    /////////////////////////////////////
-    //  SETTING VISIBILITIES   //////////
-    enclosure_gas_logic->SetVisAttributes(G4VisAttributes::Invisible);
+    /// Visibilities ///
+    pmt_hole_logic->SetVisAttributes(G4VisAttributes::Invisible);
     if (visibility_) {
-      G4VisAttributes gas = nexus::Red();
-      enclosure_gas_logic->SetVisAttributes(gas);
+      G4VisAttributes vacuum_col = nexus::Red();
+      pmt_hole_logic->SetVisAttributes(vacuum_col);
       G4VisAttributes copper_col = CopperBrown();
       // copper_col.SetForceSolid(true);
       carrier_plate_logic->SetVisAttributes(copper_col);
-      G4VisAttributes enclosure_col = nexus::Brown();
-      // enclosure_col.SetForceSolid(true);
-      enclosure_flange_logic->SetVisAttributes(enclosure_col);
+      pmt_flange_logic->SetVisAttributes(copper_col);
       G4VisAttributes sapphire_col = nexus::Lilla();
       sapphire_col.SetForceSolid(true);
-      enclosure_window_logic->SetVisAttributes(sapphire_col);
+      sapphire_window_logic->SetVisAttributes(sapphire_col);
       G4VisAttributes pad_col = nexus::LightGreen();
       pad_col.SetForceSolid(true);
-      enclosure_pad_logic->SetVisAttributes(pad_col);
+      optical_pad_logic->SetVisAttributes(pad_col);
       G4VisAttributes base_col = nexus::Yellow();
       base_col.SetForceSolid(true);
       pmt_base_logic->SetVisAttributes(base_col);
@@ -294,9 +298,9 @@ namespace nexus {
       tpb_logic->SetVisAttributes(tpb_col);
     } else {
       carrier_plate_logic->SetVisAttributes(G4VisAttributes::Invisible);
-      enclosure_flange_logic->SetVisAttributes(G4VisAttributes::Invisible);
-      enclosure_window_logic->SetVisAttributes(G4VisAttributes::Invisible);
-      enclosure_pad_logic->SetVisAttributes(G4VisAttributes::Invisible);
+      pmt_flange_logic->SetVisAttributes(G4VisAttributes::Invisible);
+      sapphire_window_logic->SetVisAttributes(G4VisAttributes::Invisible);
+      optical_pad_logic->SetVisAttributes(G4VisAttributes::Invisible);
       pmt_base_logic->SetVisAttributes(G4VisAttributes::Invisible);
       tpb_logic->SetVisAttributes(G4VisAttributes::Invisible);
     }
@@ -310,13 +314,11 @@ namespace nexus {
 
   void NextDemoEnergyPlane::GeneratePositions()
   {
-    /// Function that computes and stores the XY positions of PMTs in the carrier plate
-
+    /// Compute and store the XY positions of PMTs in the support plate ///
     G4int total_positions = 0;
     G4ThreeVector position(0.,0.,0.);
 
-
-    G4double rad = 7 * cm;   // Ruty: to be check !
+    G4double rad = 7 * cm;
     G4int num_places = 3;
     G4int step_deg = 360.0 / num_places;
     for (G4int place=0; place<num_places; place++) {
@@ -325,12 +327,8 @@ namespace nexus {
 	position.setY(rad * cos(angle * deg));
 	pmt_positions_.push_back(position);
 	total_positions++;
-        //G4cout << "\n\ntotal_positions= ", total_positions;
     }
 
-    //}
-
-    // Checking
     if (total_positions != num_PMTs_) {
       G4cout << "\n\nERROR: Number of PMTs doesn't match with number of positions calculated\n";
       exit(0);

--- a/source/geometries/NextDemoEnergyPlane.cc
+++ b/source/geometries/NextDemoEnergyPlane.cc
@@ -1,7 +1,7 @@
 // ----------------------------------------------------------------------------
 // nexus | NextDemoEnergyPlane.cc
 //
-// Energy plane geometry of the DEMO++ detector.
+// Geometry of the DEMO++ energy plane.
 //
 // The NEXT Collaboration
 // ----------------------------------------------------------------------------
@@ -28,8 +28,6 @@
 #include <G4RotationMatrix.hh>
 
 namespace nexus {
-
-  using namespace CLHEP;
 
   NextDemoEnergyPlane::NextDemoEnergyPlane():
     gate_support_surface_dist_ (445.5 * mm),
@@ -323,8 +321,8 @@ namespace nexus {
     }
 
     if (total_positions != num_PMTs_) {
-      G4cout << "\n\nERROR: Number of PMTs doesn't match with number of positions calculated\n";
-      exit(0);
+      G4Exception("[NextDemoEnergyPlane]", "GeneratePmtPositions()",
+                  FatalException, " Number of PMTs doesn't match with number of positions calculated");
     }
 
   }

--- a/source/geometries/NextDemoEnergyPlane.cc
+++ b/source/geometries/NextDemoEnergyPlane.cc
@@ -261,13 +261,15 @@ namespace nexus {
     G4ThreeVector pos;
     for (int i=0; i<num_PMTs_; i++) {
       pos = pmt_positions_[i];
-      if (verbosity_) G4cout << pos.getX() << ", " << pos.getY() << G4endl;
+      G4int copy_no = i+2;
+      if (verbosity_) G4cout << "PMT " << copy_no << ": "
+                             << pos.getX() << ", " << pos.getY() << G4endl;
       pos.setZ(pmt_hole_zpos);
       new G4PVPlacement(0, pos, pmt_hole_logic, "PMT_HOLE", mother_logic_,
-                        false, i+2, false);
+                        false, copy_no, false);
       pos.setZ(wndw_ring_zpos);
       new G4PVPlacement(0, pos, wndw_ring_logic, "WINDOW_RING", mother_logic_,
-                        false, i+2, false);
+                        false, copy_no, false);
     }
 
 

--- a/source/geometries/NextDemoEnergyPlane.cc
+++ b/source/geometries/NextDemoEnergyPlane.cc
@@ -261,7 +261,7 @@ namespace nexus {
     G4ThreeVector pos;
     for (int i=0; i<num_PMTs_; i++) {
       pos = pmt_positions_[i];
-      G4int copy_no = i+2;
+      G4int copy_no = i+10;
       if (verbosity_) G4cout << "PMT " << copy_no << ": "
                              << pos.getX() << ", " << pos.getY() << G4endl;
       pos.setZ(pmt_hole_zpos);

--- a/source/geometries/NextDemoEnergyPlane.cc
+++ b/source/geometries/NextDemoEnergyPlane.cc
@@ -174,7 +174,7 @@ namespace nexus {
                       pmt_hole_logic, false, 0, false);
 
 
-    /// TPB coating on pedot ///
+    /// TPB coating on PEDOT ///
     G4Tubs* tpb_solid =
       new G4Tubs("SAPPHIRE_WNDW_TPB", 0., sapphire_window_diam_/2,
                  tpb_thickness_/2., 0., twopi);
@@ -185,6 +185,13 @@ namespace nexus {
     new G4PVPlacement(0, G4ThreeVector(0., 0., tpb_posz), tpb_logic,
                       "SAPPHIRE_WNDW_TPB", sapphire_window_logic,
                       false, 0, false);
+
+    /// Add optical surface to TPB ///
+    G4OpticalSurface* tpb_coating_opsurf =
+      new G4OpticalSurface("SAPPHIRE_WNDW_TPB_OPSURF", glisur, ground,
+                           dielectric_dielectric, .01);
+    new G4LogicalSkinSurface("SAPPHIRE_WNDW_TPB_OPSURF",
+                             tpb_logic, tpb_coating_opsurf);
 
     /// PEDOT coating on sapphire windows ///
     G4Tubs* pedot_coating_solid =
@@ -199,6 +206,13 @@ namespace nexus {
     new G4PVPlacement(nullptr, G4ThreeVector(0., 0., pedot_coating_zpos),
                       pedot_coating_logic, "SAPPHIRE_WNDW_PEDOT",
                       sapphire_window_logic, false, 0, false);
+
+    /// Add optical surface to PEDOT ///
+    G4OpticalSurface* pedot_coating_opsurf =
+      new G4OpticalSurface("SAPPHIRE_WNDW_PEDOT_OPSURF", glisur, ground,
+                           dielectric_dielectric, .01);
+    new G4LogicalSkinSurface("SAPPHIRE_WNDW_PEDOT_OPSURF",
+                             pedot_coating_logic, pedot_coating_opsurf);
 
     /// Optical pad ///
     G4Tubs* optical_pad_solid =

--- a/source/geometries/NextDemoEnergyPlane.cc
+++ b/source/geometries/NextDemoEnergyPlane.cc
@@ -264,10 +264,10 @@ namespace nexus {
       if (verbosity_) G4cout << pos.getX() << ", " << pos.getY() << G4endl;
       pos.setZ(pmt_hole_zpos);
       new G4PVPlacement(0, pos, pmt_hole_logic, "PMT_HOLE", mother_logic_,
-                        false, i, false);
+                        false, i+2, false);
       pos.setZ(wndw_ring_zpos);
       new G4PVPlacement(0, pos, wndw_ring_logic, "WINDOW_RING", mother_logic_,
-                        false, i, false);
+                        false, i+2, false);
     }
 
 

--- a/source/geometries/NextDemoEnergyPlane.cc
+++ b/source/geometries/NextDemoEnergyPlane.cc
@@ -74,7 +74,7 @@ namespace nexus {
   }
 
 
-  void NextDemoEnergyPlane::SetLogicalVolume(G4LogicalVolume* mother_logic)
+  void NextDemoEnergyPlane::SetMotherLogicalVolume(G4LogicalVolume* mother_logic)
   {
     mother_logic_ = mother_logic;
   }

--- a/source/geometries/NextDemoEnergyPlane.h
+++ b/source/geometries/NextDemoEnergyPlane.h
@@ -69,13 +69,16 @@ namespace nexus {
     G4double end_of_sapphire_posz_;
 
     // Dimensions
+    const G4double dist_gate_support_surface_;
     const G4int num_PMTs_;
     //const G4double energy_plane_posz_;
-    const G4double carrier_plate_thickness_, carrier_plate_diam_, carrier_plate_central_hole_diam_;
-    const G4double enclosure_length_, enclosure_diam_;
-    const G4double enclosure_flange_length_;
-    const G4double enclosure_window_thickness_,enclosure_window_diam_;
-    const G4double enclosure_pad_thickness_;
+    const G4double carrier_plate_thickness_, carrier_plate_diam_;
+    const G4double carrier_plate_central_hole_diam_;
+    const G4double pmt_hole_length_, pmt_hole_diam_;
+    const G4double pmt_flange_length_;
+    const G4double sapphire_window_thickness_, sapphire_window_diam_;
+    const G4double pedot_coating_thickness_;
+    const G4double optical_pad_thickness_;
     const G4double pmt_base_diam_, pmt_base_thickness_;
     const G4double tpb_thickness_;
 

--- a/source/geometries/NextDemoEnergyPlane.h
+++ b/source/geometries/NextDemoEnergyPlane.h
@@ -1,26 +1,17 @@
 // ----------------------------------------------------------------------------
-///  \file   
-///  \brief  
-///
-///  \author   <jmunoz@ific.uv.es>
-///  \date     25 Apr 2012
-///  \version  $Id$
-///
-///  Copyright (c) 2012 NEXT Collaboration
+// nexus | NextDemoEnergyPlane.h
 //
-//  Updated to NextDemo++  by  Ruth Weiss Babai <ruty.wb@gmail.com>
-//  From:   "Next100EnergyPlane.h"
-//  Date:       June 2019
+// Energy plane geometry of the DEMO++ detector.
+//
+// The NEXT Collaboration
 // ----------------------------------------------------------------------------
 
-#ifndef __NEXT_DEMO_ENERGY_PLANE__
-#define __NEXT_DEMO_ENERGY_PLANE__
+#ifndef NEXT_DEMO_ENERGY_PLANE_H
+#define NEXT_DEMO_ENERGY_PLANE_H
 
 #include <vector>
 #include <G4Navigator.hh>
-#include <G4TransportationManager.hh>
 
-#include "CylinderPointSampler.h"
 #include "PmtR11410.h"
 
 
@@ -47,7 +38,7 @@ namespace nexus {
     void SetLogicalVolume(G4LogicalVolume* mother_logic);
 
     /// Sets the z position of the surface of the sapphire windows
-    void SetSapphireSurfaceZPos(G4double z);
+    void SetGateSapphireSurfaceDistance(G4double z);
 
     /*/// Generate a vertex within a given region of the geometry
     G4ThreeVector GenerateVertex(const G4String& region) const;
@@ -58,20 +49,13 @@ namespace nexus {
 
 
   private:
-    void GeneratePositions();
+    void GeneratePmtPositions();
 
   private:
 
-    // Mother Logical Volume of the whole Energy PLane
-    G4LogicalVolume* mother_logic_;
-    G4Material* gas_;
-    G4double pressure_, temperature_;
-    G4double end_of_sapphire_posz_;
-
     // Dimensions
-    const G4double dist_gate_support_surface_;
+    const G4double gate_support_surface_dist_;
     const G4int num_PMTs_;
-    //const G4double energy_plane_posz_;
     const G4double carrier_plate_thickness_, carrier_plate_diam_;
     const G4double carrier_plate_central_hole_diam_;
     const G4double pmt_hole_length_, pmt_hole_diam_;
@@ -82,8 +66,7 @@ namespace nexus {
     const G4double pmt_base_diam_, pmt_base_thickness_;
     const G4double tpb_thickness_;
 
-
-    // Visibility
+    // Visibility and verbosity
     G4bool visibility_, verbosity_;
 
     // Geometry Navigator
@@ -93,14 +76,15 @@ namespace nexus {
     G4GenericMessenger* msg_; 
 
     // PMT
-    G4RotationMatrix* pmt_rot_;
     PmtR11410*  pmt_;
     std::vector<G4ThreeVector> pmt_positions_;
-    G4double pmt_zpos_;
 
+    // Mother logical volume of the whole energy pLane
+    G4LogicalVolume* mother_logic_;
 
-    
-
+    // Position of the syrface of the sapphire windows,
+    // starting from z = 0 in GATE
+    G4double gate_sapphire_dist_;
 
   };
 

--- a/source/geometries/NextDemoEnergyPlane.h
+++ b/source/geometries/NextDemoEnergyPlane.h
@@ -35,7 +35,7 @@ namespace nexus {
     ~NextDemoEnergyPlane();
 
     /// Sets the Logical Volume where Inner Elements will be placed
-    void SetLogicalVolume(G4LogicalVolume* mother_logic);
+    void SetMotherLogicalVolume(G4LogicalVolume* mother_logic);
 
     /// Sets the z position of the surface of the sapphire windows
     void SetGateSapphireSurfaceDistance(G4double z);

--- a/source/geometries/NextDemoEnergyPlane.h
+++ b/source/geometries/NextDemoEnergyPlane.h
@@ -58,9 +58,9 @@ namespace nexus {
     const G4int num_PMTs_;
     const G4double carrier_plate_thickness_, carrier_plate_diam_;
     const G4double carrier_plate_central_hole_diam_;
-    const G4double pmt_hole_length_, pmt_hole_diam_;
-    const G4double pmt_flange_length_;
+    const G4double pmt_hole_length_;
     const G4double sapphire_window_thickness_, sapphire_window_diam_;
+    const G4double wndw_ring_stand_out_;
     const G4double pedot_coating_thickness_;
     const G4double optical_pad_thickness_;
     const G4double pmt_base_diam_, pmt_base_thickness_;
@@ -73,7 +73,7 @@ namespace nexus {
     G4Navigator* geom_navigator_;
 
     // Messenger for the definition of control commands
-    G4GenericMessenger* msg_; 
+    G4GenericMessenger* msg_;
 
     // PMT
     PmtR11410*  pmt_;

--- a/source/geometries/NextDemoEnergyPlane.h
+++ b/source/geometries/NextDemoEnergyPlane.h
@@ -1,7 +1,7 @@
 // ----------------------------------------------------------------------------
 // nexus | NextDemoEnergyPlane.h
 //
-// Energy plane geometry of the DEMO++ detector.
+// Geometry of the DEMO++ energy plane.
 //
 // The NEXT Collaboration
 // ----------------------------------------------------------------------------

--- a/source/geometries/NextDemoInnerElements.cc
+++ b/source/geometries/NextDemoInnerElements.cc
@@ -87,7 +87,7 @@ namespace nexus {
     tracking_plane_->SetTPGateDistance(gate_tp_copper_distance_);
     tracking_plane_->Construct();
 
-    energy_plane_->SetLogicalVolume(mother_logic_);
+    energy_plane_->SetMotherLogicalVolume(mother_logic_);
     energy_plane_->SetELzCoord(gate_zpos);
     energy_plane_->SetGateSapphireSurfaceDistance(gate_sapphire_wdw_distance_);
     energy_plane_->Construct();

--- a/source/geometries/NextDemoInnerElements.cc
+++ b/source/geometries/NextDemoInnerElements.cc
@@ -89,7 +89,7 @@ namespace nexus {
 
     energy_plane_->SetLogicalVolume(mother_logic_);
     energy_plane_->SetELzCoord(gate_zpos);
-    energy_plane_->SetSapphireSurfaceZPos(gate_sapphire_wdw_distance_);
+    energy_plane_->SetGateSapphireSurfaceDistance(gate_sapphire_wdw_distance_);
     energy_plane_->Construct();
   }
 

--- a/source/geometries/NextDemoInnerElements.cc
+++ b/source/geometries/NextDemoInnerElements.cc
@@ -36,7 +36,7 @@ namespace nexus {
 
   NextDemoInnerElements::NextDemoInnerElements(const G4double vessel_length):
     BaseGeometry(),
-    gate_sapphire_wdw_distance_(427. * mm), // to be checked
+    gate_sapphire_wdw_distance_(427.5 * mm),
     gate_tp_copper_distance_(10.8 * mm + 5.79 * mm), // to be checked
     mother_logic_(nullptr),
     mother_phys_(nullptr),


### PR DESCRIPTION
This PR fixes the dimensions and relative distances of the DEMO++ energy plane. 
A copper ring is added to the sapphire windows and the flanges are removed, since they are not relevant for the optical response of the detector.
A number of cosmetic changes are also implemented, following the current coding conventions.