### PR TITLE
Fix margin between edge of NEXT-100 SiPM board and external crown of SiPMs

### DIFF
--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -32,12 +32,12 @@ using namespace nexus;
 
 Next100SiPMBoard::Next100SiPMBoard():
   BaseGeometry     (),
-  size_            (123.40 * mm),
-  pitch_           ( 15.55 * mm),
-  margin_          (  7.33 * mm),
-  hole_diam_       (  7.00 * mm),
-  board_thickness_ (  0.5  * mm),
-  mask_thickness_  (  2.1  * mm), // Made slightly thicker to fit SiPM
+  size_            (123.40  * mm),
+  pitch_           ( 15.55  * mm),
+  margin_          (  7.275 * mm),
+  hole_diam_       (  7.00  * mm),
+  board_thickness_ (  0.5   * mm),
+  mask_thickness_  (  2.1   * mm), // Made slightly thicker to fit SiPM
   time_binning_    (1. * microsecond),
   visibility_      (true),
   sipm_visibility_ (false),


### PR DESCRIPTION
The margin between the edge of the NEXT-100 SiPM board and the first crown of SiPMs is changed from 7.33 mm to 7.275 mm. That way, the sensors are symmetrically positioned with respect to the center of the board: 
```
board_size = pitch * 7 + margin * 2 = 15.55 * 7 + 7.275  * 2 = 123.40 mm
```