### PR TITLE
Flex Tracking Plane Reference Distance

### DIFF
--- a/macros/NextFlex_fullKr.config.mac
+++ b/macros/NextFlex_fullKr.config.mac
@@ -56,7 +56,7 @@
 /Geometry/NextFlex/tp_teflon_thickness   5. mm
 /Geometry/NextFlex/tp_teflon_hole_diam   7. mm
 /Geometry/NextFlex/tp_wls_mat           TPB
-/Geometry/NextFlex/tp_sipm_anode_dist   10. mm
+/Geometry/NextFlex/tp_kapton_anode_dist 12. mm
 /Geometry/NextFlex/tp_sipm_sizeX        1.3 mm
 /Geometry/NextFlex/tp_sipm_sizeY        1.3 mm
 /Geometry/NextFlex/tp_sipm_sizeZ        2.0 mm

--- a/macros/NextFlex_fullKr.config.mac
+++ b/macros/NextFlex_fullKr.config.mac
@@ -68,10 +68,11 @@
 /Geometry/NextFlex/ics_thickness  12. cm
 
 # VERBOSITY
-/Geometry/NextFlex/verbosity     true
-/Geometry/NextFlex/fc_verbosity  true
-/Geometry/NextFlex/ep_verbosity  true
-/Geometry/NextFlex/tp_verbosity  true
+/Geometry/NextFlex/verbosity          true
+/Geometry/NextFlex/fc_verbosity       true
+/Geometry/NextFlex/ep_verbosity       true
+/Geometry/NextFlex/tp_verbosity       true
+/Geometry/NextFlex/tp_sipm_verbosity  true
 
 # VISIBILITIES
 /Geometry/NextFlex/fc_visibility           true

--- a/source/geometries/NextFlexTrackingPlane.cc
+++ b/source/geometries/NextFlexTrackingPlane.cc
@@ -49,7 +49,7 @@ NextFlexTrackingPlane::NextFlexTrackingPlane():
   SiPM_visibility_   (false),
   msg_               (nullptr),
   wls_mat_name_      ("TPB"),
-  SiPM_ANODE_dist_   (10.  * mm),   // Distance from ANODE to SiPM surface
+  kapton_anode_dist_ (15.  * mm),   // Distance from ANODE to Kapton surface
   SiPM_size_x_       ( 1.3 * mm),   // Size X (width) of SiPMs
   SiPM_size_y_       ( 1.3 * mm),   // Size Y (height) of SiPMs
   SiPM_size_z_       ( 2.0 * mm),   // Size Z (thickness) of SiPMs
@@ -125,12 +125,12 @@ void NextFlexTrackingPlane::DefineConfigurationParameters()
                         "TP UV wavelength shifting material name");
 
   // SiPMs
-  G4GenericMessenger::Command& sipm_anode_dist_cmd =
-    msg_->DeclareProperty("tp_sipm_anode_dist", SiPM_ANODE_dist_,
-                          "Distance from tracking SiPMs to ANODE.");
-  sipm_anode_dist_cmd.SetParameterName("tp_sipm_anode_dist", false);
-  sipm_anode_dist_cmd.SetUnitCategory("Length");
-  sipm_anode_dist_cmd.SetRange("tp_sipm_anode_dist>=0.");
+  G4GenericMessenger::Command& kapton_anode_dist_cmd =
+    msg_->DeclareProperty("tp_kapton_anode_dist", kapton_anode_dist_,
+                          "Distance from tracking kapton to ANODE.");
+  kapton_anode_dist_cmd.SetParameterName("tp_kapton_anode_dist", false);
+  kapton_anode_dist_cmd.SetUnitCategory("Length");
+  kapton_anode_dist_cmd.SetRange("tp_kapton_anode_dist>=0.");
 
   G4GenericMessenger::Command& sipm_sizeX_cmd =
     msg_->DeclareProperty("tp_sipm_sizeX", SiPM_size_x_,
@@ -179,7 +179,7 @@ void NextFlexTrackingPlane::DefineConfigurationParameters()
 
 void NextFlexTrackingPlane::ComputeDimensions()
 {
-  teflon_iniZ_ = origin_z_ - SiPM_ANODE_dist_ - SiPM_size_z_;
+  teflon_iniZ_ = origin_z_ - kapton_anode_dist_;
   copper_iniZ_ = teflon_iniZ_ - copper_thickness_;
 
   // Generate SiPM positions

--- a/source/geometries/NextFlexTrackingPlane.cc
+++ b/source/geometries/NextFlexTrackingPlane.cc
@@ -45,6 +45,7 @@ NextFlexTrackingPlane::NextFlexTrackingPlane():
   BaseGeometry(),
   mother_logic_      (nullptr),
   verbosity_         (false),
+  sipm_verbosity_    (false),
   visibility_        (false),
   SiPM_visibility_   (false),
   msg_               (nullptr),
@@ -90,6 +91,9 @@ void NextFlexTrackingPlane::DefineConfigurationParameters()
 {
   // Verbosity
   msg_->DeclareProperty("tp_verbosity", verbosity_, "Verbosity");
+
+  // SiPMs verbosity
+  msg_->DeclareProperty("tp_sipm_verbosity", sipm_verbosity_, "SiPMs verbosity");
 
   // Visibilities
   msg_->DeclareProperty("tp_visibility", visibility_, "TRACKING_PLANE Visibility");
@@ -376,8 +380,8 @@ void NextFlexTrackingPlane::BuildTeflon()
     new G4PVPlacement(nullptr, wls_hole_pos, wls_hole_logic, wls_hole_name,
                       teflon_wls_logic, true, SiPM_id, false);
 
-    if (verbosity_) G4cout << "* TP_SiPM " << SiPM_id << " position: " 
-                           << hole_pos << G4endl;
+    if (sipm_verbosity_) G4cout << "* TP_SiPM " << SiPM_id << " position: " 
+                                << hole_pos << G4endl;
   }
 
   // Placing the overall teflon sub-system

--- a/source/geometries/NextFlexTrackingPlane.h
+++ b/source/geometries/NextFlexTrackingPlane.h
@@ -86,8 +86,9 @@ namespace nexus {
     // Physical volume of the neighbouring gas
     G4VPhysicalVolume* neigh_gas_phys_;
 
-    // Verbosity of the geometry
+    // Verbosities of the geometry
     G4bool verbosity_;
+    G4bool sipm_verbosity_;
 
     // Visibilities
     G4bool visibility_;

--- a/source/geometries/NextFlexTrackingPlane.h
+++ b/source/geometries/NextFlexTrackingPlane.h
@@ -112,7 +112,7 @@ namespace nexus {
     // Dimensions & Positions
     G4double origin_z_;
     G4double diameter_;
-    G4double SiPM_ANODE_dist_;
+    G4double kapton_anode_dist_;
 
     G4double SiPM_size_x_;
     G4double SiPM_size_y_;

--- a/tests/pytest/produce_output_test.py
+++ b/tests/pytest/produce_output_test.py
@@ -196,7 +196,7 @@ def test_create_nexus_output_file_flex100(config_tmpdir, output_tmpdir, NEXUSDIR
 /Geometry/NextFlex/tp_teflon_thickness   2.1 mm
 /Geometry/NextFlex/tp_teflon_hole_diam   7. mm
 /Geometry/NextFlex/tp_wls_mat            TPB
-/Geometry/NextFlex/tp_sipm_anode_dist    13.1 mm
+/Geometry/NextFlex/tp_kapton_anode_dist  15. mm
 /Geometry/NextFlex/tp_sipm_sizeX         1.3 mm
 /Geometry/NextFlex/tp_sipm_sizeY         1.3 mm
 /Geometry/NextFlex/tp_sipm_sizeZ         2.0 mm


### PR DESCRIPTION
This PR changes the "FLEX" geometry configuration parameter used to set the Tracking Plane position, by using the distance between ANODE and Kapton surface instead of the distance between ANODE and the SiPMs surface.
Macro file is updated accordingly.