### PR TITLE
Clean unused and commented DEMO++ Vertex Generators

### DIFF
--- a/source/geometries/NextDemo.h
+++ b/source/geometries/NextDemo.h
@@ -95,7 +95,6 @@ namespace nexus {
     
   private:
     CylinderPointSampler* source_gen_side_;
-    MuonsPointSampler* muons_sampling_;
 
  
     // Pointers to materials definition

--- a/source/geometries/NextDemoInnerElements.cc
+++ b/source/geometries/NextDemoInnerElements.cc
@@ -105,26 +105,21 @@ namespace nexus {
     G4ThreeVector vertex(0.,0.,0.);
 
     // Field Cage
-    if ((region == "ACTIVE") ||
-      // (region == "DRIFT_TUBE") ||
-	    // (region == "ANODE_QUARTZ") ||
-	    // (region == "CENTER") ||
-	    // (region == "CATHODE") ||
-	    // (region == "XENON") ||
-	    // (region == "BUFFER") ||
-	     (region == "EL_TABLE") ||
-	     (region == "AD_HOC")) {
+    if (region == "ACTIVE") {
       vertex = field_cage_->GenerateVertex(region);
     }
+
     // Tracking PLane
     else if ((region == "TP_PLATE") ||
              (region == "SIPM_BOARD")) {
       vertex = tracking_plane_->GenerateVertex(region);
     }
+    
     else {
       G4Exception("[NextDemoInnerElements]", "GenerateVertex()", FatalException,
 		  "Unknown vertex generation region!");
     }
+    
     return vertex;
   }
 


### PR DESCRIPTION
This PR cleans commented / not implemented / unused vertex generators from the DEMO++ geometry.
Vertex generator frrom VESSEL to be cleaned along with the VESSEL geometry implementation.