### PR TITLE
 Set Next100 and FLEX SiPMs detection probability of UV light to 0

### DIFF
--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -184,11 +184,11 @@ void Next100SiPMBoard::Construct()
   // of the new Hamamatsu SiPMs are known.
 
   G4MaterialPropertiesTable* photosensor_mpt = new G4MaterialPropertiesTable();
-  G4double energy[]       = {0.2 * eV, 11.5 * eV};
-  G4double reflectivity[] = {0.0     ,  0.0};
-  G4double efficiency[]   = {1.0     ,  1.0};
-  photosensor_mpt->AddProperty("REFLECTIVITY", energy, reflectivity, 2);
-  photosensor_mpt->AddProperty("EFFICIENCY",   energy, efficiency,   2);
+  G4double energy[]       = {0.2 * eV, 3.5 * eV, 3.6 * eV, 11.5 * eV};
+  G4double reflectivity[] = {0.0     , 0.0     , 0.0     ,  0.0     };
+  G4double efficiency[]   = {1.0     , 1.0     , 0.0     ,  0.0     };
+  photosensor_mpt->AddProperty("REFLECTIVITY", energy, reflectivity, 4);
+  photosensor_mpt->AddProperty("EFFICIENCY",   energy, efficiency,   4);
   sipm_->SetVisibility(sipm_visibility_);
   sipm_->SetOpticalProperties(photosensor_mpt);
   sipm_->SetWithWLSCoating(true);

--- a/source/geometries/NextFlexFieldCage.cc
+++ b/source/geometries/NextFlexFieldCage.cc
@@ -845,11 +845,11 @@ void NextFlexFieldCage::BuildFiberSensors()
   /// Constructing the sensors
   // Optical Properties of the sensor
   G4MaterialPropertiesTable* photosensor_mpt = new G4MaterialPropertiesTable();
-  G4double energy[]       = {0.2 * eV, 11.5 * eV};
-  G4double reflectivity[] = {0.0     ,  0.0};
-  G4double efficiency[]   = {1.0     ,  1.0};
-  photosensor_mpt->AddProperty("REFLECTIVITY", energy, reflectivity, 2);
-  photosensor_mpt->AddProperty("EFFICIENCY",   energy, efficiency,   2);
+  G4double energy[]       = {0.2 * eV, 3.5 * eV, 3.6 * eV, 11.5 * eV};
+  G4double reflectivity[] = {0.0     , 0.0     , 0.0     ,  0.0     };
+  G4double efficiency[]   = {1.0     , 1.0     , 0.0     ,  0.0     };
+  photosensor_mpt->AddProperty("REFLECTIVITY", energy, reflectivity, 4);
+  photosensor_mpt->AddProperty("EFFICIENCY",   energy, efficiency,   4);
   left_sensor_ ->SetOpticalProperties(photosensor_mpt);
   right_sensor_->SetOpticalProperties(photosensor_mpt);
 

--- a/source/geometries/NextFlexTrackingPlane.cc
+++ b/source/geometries/NextFlexTrackingPlane.cc
@@ -416,11 +416,11 @@ G4LogicalVolume* NextFlexTrackingPlane::BuildSiPM()
   /// Constructing the TP SiPM ///
   // Optical Properties of the sensor
   G4MaterialPropertiesTable* photosensor_mpt = new G4MaterialPropertiesTable();
-  G4double energy[]       = {0.2 * eV, 11.5 * eV};
-  G4double reflectivity[] = {0.0     ,  0.0};
-  G4double efficiency[]   = {1.0     ,  1.0};
-  photosensor_mpt->AddProperty("REFLECTIVITY", energy, reflectivity, 2);
-  photosensor_mpt->AddProperty("EFFICIENCY",   energy, efficiency,   2);
+  G4double energy[]       = {0.2 * eV, 3.5 * eV, 3.6 * eV, 11.5 * eV};
+  G4double reflectivity[] = {0.0     , 0.0     , 0.0     ,  0.0     };
+  G4double efficiency[]   = {1.0     , 1.0     , 0.0     ,  0.0     };
+  photosensor_mpt->AddProperty("REFLECTIVITY", energy, reflectivity, 4);
+  photosensor_mpt->AddProperty("EFFICIENCY",   energy, efficiency,   4);
   SiPM_->SetOpticalProperties(photosensor_mpt);
 
   // Set WLS coating


### PR DESCRIPTION
This PR sets the detection probability of generic photosensors used in NEXT100 and FLEX geometries to 0.0 for UV light.