### PR TITLE
Fix condition to save optical photons.

### DIFF
--- a/source/persistency/PersistencyManager.cc
+++ b/source/persistency/PersistencyManager.cc
@@ -166,7 +166,9 @@ void PersistencyManager::StoreTrajectories(G4TrajectoryContainer* tc)
       std::string key, value;
       std::getline(init_read, key, ' ');
       std::getline(init_read, value);
-      if ((key == "/Actions/RegisterTrackingAction") && (value == "OPTICAL")) {
+      auto found_key   = key.find("/Actions/RegisterTrackingAction");
+      auto found_value = value.find("OPTICAL");
+      if ((found_key != std::string::npos) && (found_value != std::string::npos)) {
         save_opt_phot = true;
         break;
       }


### PR DESCRIPTION
The current code has been found not to work as expected, meaning that the condition to find the `OPTICAL` tracking option in the macro file was never met. This PR fixes this bug.