### PR TITLE
Use pytest-order instead of pytest-ordering2.

### DIFF
--- a/scripts/test_environment.yml
+++ b/scripts/test_environment.yml
@@ -8,4 +8,4 @@ dependencies:
   - hypothesis=5.37.4
   - pip=20.2.4
   - pip:
-    - pytest-ordering2==0.7.0
+    - pytest-order==0.9.2

--- a/tests/pytest/macros_test.py
+++ b/tests/pytest/macros_test.py
@@ -74,7 +74,7 @@ def execute_example_jobs(capsys, config_tmpdir, output_tmpdir, NEXUSDIR, macro_l
         p  = subprocess.run(command, check=True, env=my_env)
 
 
-@pytest.mark.second_to_last
+@pytest.mark.order('second_to_last')
 def test_run_fast_examples(capsys, config_tmpdir, output_tmpdir, NEXUSDIR, macro_list):
     """Run fast simulation macros"""
 
@@ -85,7 +85,7 @@ def test_run_fast_examples(capsys, config_tmpdir, output_tmpdir, NEXUSDIR, macro
     execute_example_jobs(capsys, config_tmpdir, output_tmpdir, NEXUSDIR, macro_list[0])
 
 
-@pytest.mark.last
+@pytest.mark.order('last')
 def test_run_full_examples(capsys, config_tmpdir, output_tmpdir, NEXUSDIR, macro_list):
     """Run full simulation macros"""
 

--- a/tests/pytest/produce_output_test.py
+++ b/tests/pytest/produce_output_test.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 
 
-@pytest.mark.first
+@pytest.mark.order(1)
 def test_create_nexus_output_file_next100(config_tmpdir, output_tmpdir, NEXUSDIR,
                                           full_base_name_next100,
                                           nexus_full_output_file_next100):
@@ -67,7 +67,7 @@ def test_create_nexus_output_file_next100(config_tmpdir, output_tmpdir, NEXUSDIR
 
 
 
-@pytest.mark.first
+@pytest.mark.order(2)
 def test_create_nexus_output_file_new(config_tmpdir, output_tmpdir, NEXUSDIR,
                                       full_base_name_new,
                                       nexus_full_output_file_new):
@@ -130,7 +130,7 @@ def test_create_nexus_output_file_new(config_tmpdir, output_tmpdir, NEXUSDIR,
 
 
 
-@pytest.mark.first
+@pytest.mark.order(3)
 def test_create_nexus_output_file_flex100(config_tmpdir, output_tmpdir, NEXUSDIR,
                                           full_base_name_flex100,
                                           nexus_full_output_file_flex100):

--- a/tests/pytest/sensitive_detectors_test.py
+++ b/tests/pytest/sensitive_detectors_test.py
@@ -1,6 +1,4 @@
 import pandas     as pd
-#from   pytest import mark
-
 
 
 def test_sensors_numbering(detectors):


### PR DESCRIPTION
The pytest-order package replaces pytest-ordering2, which was a
temporary fix. The syntax of the code has been updated accordingly.