### PR TITLE
Demopp refinement

### DIFF
--- a/macros/DEMOPP_fullKr.config.mac
+++ b/macros/DEMOPP_fullKr.config.mac
@@ -14,6 +14,7 @@
 
 
 # GEOMETRY
+/Geometry/NextDemo/config run5
 /Geometry/NextDemo/elfield true
 /Geometry/NextDemo/pressure 8.5 bar
 /Geometry/NextDemo/max_step_size 1. mm

--- a/macros/DEMOPP_grid.config.mac
+++ b/macros/DEMOPP_grid.config.mac
@@ -14,12 +14,10 @@
 
 
 # GEOMETRY
+/Geometry/NextDemo/config run7
 /Geometry/NextDemo/max_step_size 1. mm
 /Geometry/NextDemo/pressure 8. bar
-/Geometry/NextDemo/plate false
-/Geometry/NextDemo/tracking_plane_type type1
 
-######################################################
 
 # GENERATION
 /Generator/SingleParticle/particle e-

--- a/macros/DEMOPP_plate.config.mac
+++ b/macros/DEMOPP_plate.config.mac
@@ -14,12 +14,10 @@
 
 
 # GEOMETRY
+/Geometry/NextDemo/config run5
 /Geometry/NextDemo/max_step_size 1. mm
 /Geometry/NextDemo/pressure 10. bar
-/Geometry/NextDemo/plate true
-/Geometry/NextDemo/tracking_plane_type original
 
-######################################################
 
 # GENERATION
 /Generator/SingleParticle/particle e-

--- a/source/geometries/NextDemoEnergyPlane.cc
+++ b/source/geometries/NextDemoEnergyPlane.cc
@@ -288,7 +288,7 @@ namespace nexus {
 
 
     /// Visibilities ///
-    pmt_hole_logic->SetVisAttributes(G4VisAttributes::Invisible);
+    pedot_coating_logic->SetVisAttributes(G4VisAttributes::Invisible);
     if (visibility_) {
       G4VisAttributes vacuum_col = nexus::Red();
       pmt_hole_logic->SetVisAttributes(vacuum_col);
@@ -309,6 +309,7 @@ namespace nexus {
       tpb_col.SetForceSolid(true);
       tpb_logic->SetVisAttributes(tpb_col);
     } else {
+      pmt_hole_logic->SetVisAttributes(G4VisAttributes::Invisible);
       carrier_plate_logic->SetVisAttributes(G4VisAttributes::Invisible);
       wndw_ring_logic->SetVisAttributes(G4VisAttributes::Invisible);
       sapphire_window_logic->SetVisAttributes(G4VisAttributes::Invisible);

--- a/source/geometries/NextDemoFieldCage.h
+++ b/source/geometries/NextDemoFieldCage.h
@@ -73,9 +73,9 @@ namespace nexus {
 
     // Dimensions
     const G4double gate_cathode_centre_dist_;
-    const G4double grid_thickn_, gate_transparency_;
+    const G4double grid_thickn_, gate_transparency_, anode_transparency_;
+    const G4double cathode_transparency_;
     const G4double buffer_length_;
-    const G4double cath_grid_transparency_;
     const G4double el_gap_length_plate_, el_gap_length_mesh_;
     const G4double elgap_ring_diam_;
     const G4double light_tube_drift_start_z_, light_tube_drift_end_z_;

--- a/source/geometries/NextDemoFieldCage.h
+++ b/source/geometries/NextDemoFieldCage.h
@@ -32,6 +32,9 @@ namespace nexus {
     /// Destructor
     ~NextDemoFieldCage();
 
+    /// Sets the FieldCage configuration
+    void SetConfig(G4String config);
+
     /// Sets as mother the volume where the class is placed
     void SetMotherLogicalVolume(G4LogicalVolume* mother_logic);
 
@@ -55,6 +58,9 @@ namespace nexus {
   private:
 
     G4Navigator* geom_navigator_;
+
+    // Configuration
+    G4String config_;
 
     // Logical volume where the class is placed
     G4LogicalVolume* mother_logic_;
@@ -106,7 +112,6 @@ namespace nexus {
     G4double ELtransv_diff_, ELlong_diff_;
     G4bool elfield_;
     G4double ELelectric_field_;
-    G4bool plate_;
 
     // Vertex generators
     CylinderPointSampler2020* active_gen_;
@@ -115,6 +120,15 @@ namespace nexus {
     G4GenericMessenger* msg_;
 
   };
+
+  inline void NextDemoFieldCage::SetConfig(G4String config)
+  { config_ = config; }
+
+  inline void NextDemoFieldCage::SetMotherLogicalVolume(G4LogicalVolume* mother_logic)
+  { mother_logic_ = mother_logic; }
+
+  inline void NextDemoFieldCage::SetMotherPhysicalVolume(G4VPhysicalVolume* mother_phys)
+  { mother_phys_ = mother_phys; }
 
 } //end namespace nexus
 #endif

--- a/source/geometries/NextDemoInnerElements.cc
+++ b/source/geometries/NextDemoInnerElements.cc
@@ -30,23 +30,37 @@ using namespace nexus;
 
 NextDemoInnerElements::NextDemoInnerElements():
   BaseGeometry(),
-  gate_sapphire_wdw_distance_(427.5 * mm),
-  mother_logic_vol_(nullptr),
-  mother_phys_vol_(nullptr),
-  verbosity_(0)
+  config_                     (""),
+  gate_sapphire_wdw_distance_ (427.5 * mm),
+  mother_logic_vol_           (nullptr),
+  mother_phys_vol_            (nullptr),
+  verbosity_                  (0)
 {
   msg_ = new G4GenericMessenger(this, "/Geometry/NextDemo/", "Control commands of geometry NextDemo.");
+
   msg_->DeclareProperty("inner_elements_verbosity", verbosity_, "Inner Elements verbosity");
 
+  msg_->DeclareProperty("config", config_, "NextDemo configuration");
+
   // Build the internal objects that live there
-  field_cage_ = new NextDemoFieldCage();
+  field_cage_     = new NextDemoFieldCage();
   tracking_plane_ = new NextDemoTrackingPlane();
-  energy_plane_ = new NextDemoEnergyPlane();
+  energy_plane_   = new NextDemoEnergyPlane();
 }
 
 
 void NextDemoInnerElements::Construct()
 {
+  // Make sure that the configuration has been set, and properly set
+  if (config_ == "")
+    G4Exception("[NextDemoInnerElements]", "Construct()",
+                FatalException, "NextDemo configuration has not been set.");
+  else if ((config_ != "run5") &
+           (config_ != "run7"))
+    G4Exception("[NextDemoInnerElements]", "Construct()",
+                FatalException, "Wrong NextDemo configuration.");
+
+
   // Position in Z of the beginning of the drift region
   G4double gate_zpos = GetELzCoord();
 
@@ -59,10 +73,12 @@ void NextDemoInnerElements::Construct()
   field_cage_->SetMotherLogicalVolume(mother_logic_vol_);
   field_cage_->SetMotherPhysicalVolume(mother_phys_vol_);
   field_cage_->SetELzCoord(gate_zpos);
+  field_cage_->SetConfig(config_);
   field_cage_->Construct();
 
   tracking_plane_->SetMotherPhysicalVolume(mother_phys_vol_);
   tracking_plane_->SetELzCoord(gate_zpos);
+  tracking_plane_->SetConfig(config_);
   tracking_plane_->Construct();
 
   energy_plane_->SetMotherLogicalVolume(mother_logic_vol_);

--- a/source/geometries/NextDemoInnerElements.h
+++ b/source/geometries/NextDemoInnerElements.h
@@ -36,6 +36,8 @@ namespace nexus {
     void SetMotherPhysicalVolume(G4VPhysicalVolume*);
 
   private:
+    G4String config_;
+
     G4double gate_sapphire_wdw_distance_;
 
     G4LogicalVolume* mother_logic_vol_;
@@ -57,6 +59,7 @@ namespace nexus {
 
   inline void NextDemoInnerElements::SetMotherLogicalVolume(G4LogicalVolume* v)
   { mother_logic_vol_ = v; }
+
   inline void NextDemoInnerElements::SetMotherPhysicalVolume(G4VPhysicalVolume* v)
   { mother_phys_vol_ = v; }
 

--- a/source/geometries/NextDemoTrackingPlane.cc
+++ b/source/geometries/NextDemoTrackingPlane.cc
@@ -36,21 +36,18 @@ NextDemoTrackingPlane::NextDemoTrackingPlane():
   BaseGeometry(),
   verbosity_       (false),
   visibility_      (false),
+  config_          (""),
   plate_side_      (16. * cm),
   plate_thickn_    (12. * mm),
   plate_hole_side_ (49. * mm),
-  tp_type_         ("original"),
   num_boards_      (4),
   sipm_board_      (new NextDemoSiPMBoard()),
-  plate_gen_(nullptr),
-  mother_phys_(nullptr),
-  msg_(nullptr)
+  plate_gen_       (nullptr),
+  mother_phys_     (nullptr),
+  msg_             (nullptr)
 {
   msg_ = new G4GenericMessenger(this, "/Geometry/NextDemo/",
                                 "Control commands of the NextDemo geometry.");
-
-  msg_->DeclareProperty("tracking_plane_type", tp_type_,
-                        "Tracking Plane type");
 
   msg_->DeclareProperty("tracking_plane_verbosity", verbosity_,
                         "Tracking Plane verbosity");
@@ -79,27 +76,28 @@ void NextDemoTrackingPlane::Construct()
   /// Verbosity
   if(verbosity_) G4cout << G4endl << "*** NEXT Demo Tracking Plane ";
 
-  /// Defining Tracking Plane Type parameters
+  /// Check that the configuration has been set
+  if (config_ == "")
+    G4Exception("[NextDemoTrackingPlane]", "Construct()", FatalException,
+                "NextDemoTrackingPlane configuration has not been set.");
+
+  /// Defining Tracking Plane parameters
   G4double gate_board_dist = 0.; // Distance from GATE to SiPM Board kapton surface
   G4double membrane_thickn = 0.;
   G4double coating_thickn  = 0.;
 
-  if (tp_type_ == "original") {
-    if(verbosity_) G4cout << "(original) ..." << G4endl;
+  if (config_ == "run5") {
+    if(verbosity_) G4cout << "run5 ..." << G4endl;
     gate_board_dist = 16.76 * mm;
     membrane_thickn = 0.;
     coating_thickn  = 0.;
   }
-  else if (tp_type_ == "type1") {
-    if(verbosity_) G4cout << "(type1) ..." << G4endl;
+  else if (config_ == "run7") {
+    if(verbosity_) G4cout << "run7 ..." << G4endl;
     gate_board_dist = 9.16 * mm;
     membrane_thickn = 0.25 * mm;
     coating_thickn  = 2.0  * micrometer;
   }
-  else
-    G4Exception("[NextDemoTrackingPlane]", "Construct()",
-                FatalException, "Tracking Plane Type not valid.");
-
 
   /// Make sure the pointer to the mother volume is actually defined
   if (!mother_phys_)

--- a/source/geometries/NextDemoTrackingPlane.h
+++ b/source/geometries/NextDemoTrackingPlane.h
@@ -31,7 +31,9 @@ namespace nexus {
 
     // Destructor
     ~NextDemoTrackingPlane();
-    
+
+    void SetConfig(G4String config);
+
     void SetMotherPhysicalVolume(G4VPhysicalVolume* mother_phys);
     
     void Construct() override;
@@ -45,9 +47,11 @@ namespace nexus {
     G4bool verbosity_;
     G4bool visibility_;
 
+    // Configuration
+    G4String config_;
+
     const G4double plate_side_, plate_thickn_, plate_hole_side_;
 
-    G4String           tp_type_;
     G4int              num_boards_;
     NextDemoSiPMBoard* sipm_board_;
     G4ThreeVector      board_size_;
@@ -62,6 +66,9 @@ namespace nexus {
     // Geometry Navigator
     G4Navigator* geom_navigator_;
   };
+
+  inline void NextDemoTrackingPlane::SetConfig(G4String config)
+  { config_ = config; }
 
   inline void NextDemoTrackingPlane::SetMotherPhysicalVolume(G4VPhysicalVolume* mother_phys)
     { mother_phys_ = mother_phys; }

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -855,6 +855,30 @@ G4MaterialPropertiesTable* OpticalMaterialProperties::TPB()
 
 
 
+/// Degraded TPB ///
+G4MaterialPropertiesTable* OpticalMaterialProperties::DegradedTPB(G4double wls_eff)
+{
+  // It has all the same properties of TPB except the WaveLengthShifting robability
+  // that is set by parameter, trying to model a degraded behaviour of the TPB coating
+
+  G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
+
+  // All Optical Material Properties from normal TPB ...
+  mpt->AddProperty("RINDEX",       OpticalMaterialProperties::TPB()->GetProperty("RINDEX"));
+  mpt->AddProperty("ABSLENGTH",    OpticalMaterialProperties::TPB()->GetProperty("ABSLENGTH"));
+  mpt->AddProperty("WLSABSLENGTH", OpticalMaterialProperties::TPB()->GetProperty("WLSABSLENGTH"));
+  mpt->AddProperty("WLSCOMPONENT", OpticalMaterialProperties::TPB()->GetProperty("WLSCOMPONENT"));
+  mpt->AddConstProperty("WLSTIMECONSTANT",
+                        OpticalMaterialProperties::TPB()->GetConstProperty("WLSTIMECONSTANT"));
+  
+  // Except WLS Quantum Efficiency
+  mpt->AddConstProperty("WLSMEANNUMBERPHOTONS", wls_eff);
+
+  return mpt;
+}
+
+
+
 /// TPH ///
 G4MaterialPropertiesTable* OpticalMaterialProperties::TPH()
 {

--- a/source/materials/OpticalMaterialProperties.h
+++ b/source/materials/OpticalMaterialProperties.h
@@ -65,6 +65,8 @@ namespace nexus {
 
     static G4MaterialPropertiesTable* TPB();
 
+    static G4MaterialPropertiesTable* DegradedTPB(G4double wls_eff);
+
     static G4MaterialPropertiesTable* TPH();
 
     static G4MaterialPropertiesTable* PTFE();


### PR DESCRIPTION
This PR makes some refinements to DEMOpp.

* It adds the possibility of defining different transparencies for ANODE and GATE.
* It unifies the different config parameters from the TP and FC into a single one.
* It adds the Optical Material Properties degradedTPB, which aims to simulate a posible degradation of PLATE coatings in NEXT detectors, and that has shown promising preliminary results.

Macro files have been updated accordingly.