### PR TITLE
Add GitHub action: install with Nix + run all tests

### DIFF
--- a/.github/workflows/install-via-nix-and-test.yml
+++ b/.github/workflows/install-via-nix-and-test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest]
         py: [38]
     steps:
       - uses: actions/checkout@v2
@@ -18,10 +18,10 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-20.09
       - name: Install dependencies via Nix
-        run: NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nix-shell --argstr py ${{ matrix.py }}
+        run: nix-shell --argstr py ${{ matrix.py }}
       - name: Build Nexus with SCons
-        run: NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nix-shell --argstr py ${{ matrix.py }} --run "scons"
+        run: nix-shell --argstr py ${{ matrix.py }} --run "scons"
       - name: Run bin/nexus-test
-        run: NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nix-shell --argstr py ${{ matrix.py }} --run "bin/nexus-test"
+        run: nix-shell --argstr py ${{ matrix.py }} --run "bin/nexus-test"
       - name: Run pytests
-        run: NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nix-shell --argstr py ${{ matrix.py }} --run "pytest -x"
+        run: nix-shell --argstr py ${{ matrix.py }} --run "pytest -x"

--- a/.github/workflows/install-via-nix-and-test.yml
+++ b/.github/workflows/install-via-nix-and-test.yml
@@ -1,0 +1,27 @@
+name: Install via Nix and Test
+on:
+  pull_request:
+  push:
+jobs:
+
+  build-and-test:
+    if: "! contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-10.15]
+        py: [38]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=channel:nixos-20.09
+      - name: Install dependencies via Nix
+        run: NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nix-shell --argstr py ${{ matrix.py }}
+      - name: Build Nexus with SCons
+        run: NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nix-shell --argstr py ${{ matrix.py }} --run "scons"
+      - name: Run bin/nexus-test
+        run: NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nix-shell --argstr py ${{ matrix.py }} --run "bin/nexus-test"
+      - name: Run pytests
+        run: NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nix-shell --argstr py ${{ matrix.py }} --run "pytest -x"


### PR DESCRIPTION
Now that the repo is public, the 2000 minute per month GitHub Actions limit no longer apples, so I can't see any obvious reason why we shouldn't run automatic tests on GHA.

The proposed action 

1. uses the recently-approved Nix installation method to install the Nexus dependencies
2. builds Nexus with SCons
3. runs `bin/nexus-test`
4. runs `pytest`