### PR TITLE
Lab generator

### DIFF
--- a/macros/NEXT100_muons_lsc.config.mac
+++ b/macros/NEXT100_muons_lsc.config.mac
@@ -2,7 +2,8 @@
 ## nexus | NEXT100_muons_lsc.config.mac
 ##
 ## Configuration macro to simulate muons according to the distribution
-## measured at LSC, in the NEXT-100 geometry.
+## measured at LSC, in the NEXT-100 geometry launching from just outside
+## the lead shielding.
 ##
 ## The NEXT Collaboration
 ## ----------------------------------------------------------------------------

--- a/macros/NEXT100_muons_lsc.init.mac
+++ b/macros/NEXT100_muons_lsc.init.mac
@@ -2,7 +2,8 @@
 ## nexus | NEXT100_muons_lsc.init.mac
 ##
 ## Initialization macro to simulate muons according to the distribution
-## measured at LSC, in the NEXT-100 geometry.
+## measured at LSC, in the NEXT-100 geometry launching from just outside
+## the lead shielding.
 ##
 ## The NEXT Collaboration
 ## ----------------------------------------------------------------------------

--- a/source/generators/MuonAngleGenerator.cc
+++ b/source/generators/MuonAngleGenerator.cc
@@ -187,12 +187,26 @@ void MuonAngleGenerator::GetDirection(G4ThreeVector& dir)
 
 G4ThreeVector MuonAngleGenerator::ProjectToVertex(const G4ThreeVector& dir)
 {
+  /////////////////////////////////////////////////////////////////////////
+  // This method of vertex generation decides the starting vertex
+  // of the primary particle in three steps:
+  // 1) A random point is generated on a disc centred on the main
+  //    volumes.
+  // 2) This disc is rotated so that it is perpendicular to the
+  //    direction vector which is the only argument of the function.
+  //    The new point is a point through which the vector passes.
+  // 3) The vertex is found by projecting backwards along the direction
+  //    vector from that point to find the point where the ray
+  //    (point - t*dir) intersects with the region configured as the
+  //    starting point for all vertices.
+  /////////////////////////////////////////////////////////////////////////
   // Postion in disc
   G4double rad = gen_rad_ * std::sqrt(G4UniformRand());
   G4double ang = 2 * G4UniformRand() * pi;
 
   // Continue assuming that Y is vertical and z drift,
-  // valid for NEW and NEXT-100 (at least)
+  // valid for NEW and NEXT-100 (at least).
+  // Rotate the disc (origin-point vector) to be perpendicular to dir.
   G4ThreeVector point(rad * std::cos(ang), 0., rad * std::sin(ang));
   point.rotate(pi / 2 - dir.angle(point), dir.cross(point));
 

--- a/source/generators/MuonAngleGenerator.cc
+++ b/source/generators/MuonAngleGenerator.cc
@@ -19,7 +19,6 @@
 #include <G4RandomDirection.hh>
 #include <Randomize.hh>
 #include <G4OpticalPhoton.hh>
-#include "MuonsPointSampler.h"
 #include "AddUserInfoToPV.h"
 
 #include <TMath.h>
@@ -34,7 +33,7 @@ using namespace CLHEP;
 MuonAngleGenerator::MuonAngleGenerator():
   G4VPrimaryGenerator(), msg_(0), particle_definition_(0),
   angular_generation_(true), rPhi_(NULL), energy_min_(0.),
-  energy_max_(0.), gen_rad_(223.33*cm), distribution_(0), geom_(0)//, geom_solid_(0)
+  energy_max_(0.), gen_rad_(223.33*cm), distribution_(0), geom_(0)
 {
   msg_ = new G4GenericMessenger(this, "/Generator/MuonAngleGenerator/",
 				"Control commands of muongenerator.");
@@ -188,7 +187,7 @@ void MuonAngleGenerator::GetDirection(G4ThreeVector& dir)
 
 G4ThreeVector MuonAngleGenerator::ProjectToVertex(const G4ThreeVector& dir)
 {
-  // Postion in disc (need to sort size, member function)
+  // Postion in disc
   G4double rad = gen_rad_ * std::sqrt(G4UniformRand());
   G4double ang = 2 * G4UniformRand() * pi;
 

--- a/source/generators/MuonAngleGenerator.h
+++ b/source/generators/MuonAngleGenerator.h
@@ -16,7 +16,7 @@
 class G4GenericMessenger;
 class G4Event;
 class G4ParticleDefinition;
-class G4VSolid;
+//class G4VSolid;
 
 class TH2F;
 
@@ -52,8 +52,7 @@ namespace nexus {
 
     void GetDirection(G4ThreeVector& dir);
 
-    G4bool CheckOverlap(const G4ThreeVector& vtx,
-    			const G4ThreeVector& dir);
+    G4ThreeVector ProjectToVertex(const G4ThreeVector& dir);
 
   private:
     G4GenericMessenger* msg_;
@@ -70,12 +69,11 @@ namespace nexus {
     G4String region_; ///< Name of generator region
     G4String ang_file_; ///< Name of file with distributions
     G4String dist_name_; ///< Name of distribution in file
+    G4double gen_rad_; ///< Radius of disc for generation
 
     TH2F * distribution_; ///< Anglular distribution
 
     const BaseGeometry* geom_; ///< Pointer to the detector geometry
-
-    G4VSolid * geom_solid_;
 
   };
 

--- a/source/generators/MuonAngleGenerator.h
+++ b/source/generators/MuonAngleGenerator.h
@@ -16,7 +16,6 @@
 class G4GenericMessenger;
 class G4Event;
 class G4ParticleDefinition;
-//class G4VSolid;
 
 class TH2F;
 

--- a/source/geometries/BaseGeometry.h
+++ b/source/geometries/BaseGeometry.h
@@ -34,6 +34,12 @@ namespace nexus {
     /// Returns a point within a given region of the geometry
     virtual G4ThreeVector GenerateVertex(const G4String&) const;
 
+    /// Returns a point within a region projecting from a
+    /// given point backwards along a line.
+    virtual G4ThreeVector ProjectToRegion(const G4String&,
+					  const G4ThreeVector&,
+					  const G4ThreeVector&) const;
+
     /// Returns the span (maximum dimension) of the geometry
     G4double GetSpan();
 
@@ -93,6 +99,11 @@ namespace nexus {
   { logicVol_ = lv; }
 
   inline G4ThreeVector BaseGeometry::GenerateVertex(const G4String&) const
+  { return G4ThreeVector(0., 0., 0.); }
+
+  inline G4ThreeVector BaseGeometry::ProjectToRegion(const G4String&,
+						     const G4ThreeVector&,
+						     const G4ThreeVector&) const
   { return G4ThreeVector(0., 0., 0.); }
 
   inline void BaseGeometry::SetSpan(G4double s) { span_ = s; }

--- a/source/geometries/LSCHallA.cc
+++ b/source/geometries/LSCHallA.cc
@@ -123,7 +123,7 @@ namespace nexus {
 					  const G4ThreeVector& point,
 					  const G4ThreeVector& dir) const
   {
-    // Project backwards along dir from point to find the first intersection
+    // Project along dir from point to find the first intersection
     // with region.
     G4ThreeVector vertex(0., 0., 0.);
     if (region == "HALLA_INNER")

--- a/source/geometries/LSCHallA.cc
+++ b/source/geometries/LSCHallA.cc
@@ -119,4 +119,23 @@ namespace nexus {
     return vertex;
   }
 
+  G4ThreeVector LSCHallA::ProjectToRegion(const G4String& region,
+					  const G4ThreeVector& point,
+					  const G4ThreeVector& dir) const
+  {
+    // Project backwards along dir from point to find the first intersection
+    // with region.
+    G4ThreeVector vertex(0., 0., 0.);
+    if (region == "HALLA_INNER")
+      return hallA_vertex_gen_->GetIntersect(point, dir);
+    else if (region == "HALLA_OUTER")
+      return hallA_outer_gen_->GetIntersect(point, dir);
+    else {
+      G4Exception("[LSCHallA]", "ProjectToRegion()", FatalException,
+		  "Unknown vertex generation region!");
+    }
+
+    return vertex;
+  }
+
 }

--- a/source/geometries/LSCHallA.h
+++ b/source/geometries/LSCHallA.h
@@ -30,6 +30,12 @@ namespace nexus {
     /// Generate a vertex within a given region of the geometry
     G4ThreeVector GenerateVertex(const G4String& region) const;
 
+    /// Returns a point within a region projecting from a
+    /// given point backwards along a line.
+    G4ThreeVector ProjectToRegion(const G4String& region,
+				  const G4ThreeVector& point,
+				  const G4ThreeVector& dir) const;
+
     /// Builder
     void Construct();
 

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -260,7 +260,7 @@ namespace nexus {
 					 const G4ThreeVector& point,
 					 const G4ThreeVector& dir) const
   {
-    // Project backwards along dir from point to find the first intersection
+    // Project along dir from point to find the first intersection
     // with region.
     G4ThreeVector vertex(0., 0., 0.);
     if (region == "EXTERNAL"){

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -256,4 +256,23 @@ namespace nexus {
   }
 
 
+  G4ThreeVector Next100::ProjectToRegion(const G4String& region,
+					 const G4ThreeVector& point,
+					 const G4ThreeVector& dir) const
+  {
+    // Project backwards along dir from point to find the first intersection
+    // with region.
+    G4ThreeVector vertex(0., 0., 0.);
+    if (region == "EXTERNAL"){
+      return shielding_->ProjectToRegion(region, point, dir);
+    }
+    else {
+      G4Exception("[Next100]", "ProjectToRegion()", FatalException,
+		  "Unknown vertex generation region!");
+    }
+
+    return vertex + G4ThreeVector(0., 0., -gate_zpos_in_vessel_);
+  }
+
+
 } //end namespace nexus

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -266,6 +266,12 @@ namespace nexus {
     if (region == "EXTERNAL"){
       return shielding_->ProjectToRegion(region, point, dir);
     }
+    else if ((region == "HALLA_OUTER") || (region == "HALLA_INNER")){
+      if (!lab_walls_)
+	G4Exception("[Next100]", "ProjectToRegion()", FatalException,
+                    "To project to this region you need lab_walls == true!");
+      return hallA_walls_->ProjectToRegion(region, point, dir);
+    }
     else {
       G4Exception("[Next100]", "ProjectToRegion()", FatalException,
 		  "Unknown vertex generation region!");

--- a/source/geometries/Next100.h
+++ b/source/geometries/Next100.h
@@ -38,6 +38,12 @@ namespace nexus {
     /// Generate a vertex within a given region of the geometry
     G4ThreeVector GenerateVertex(const G4String& region) const;
 
+    /// Returns a point within a region projecting from a
+    /// given point backwards along a line.
+    G4ThreeVector ProjectToRegion(const G4String& region,
+				  const G4ThreeVector& point,
+				  const G4ThreeVector& dir) const;
+
 
   private:
     void BuildLab();

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -469,7 +469,7 @@ namespace nexus {
 						  const G4ThreeVector& point,
 						  const G4ThreeVector& dir) const
   {
-    // Project backwards along dir from point to find the first intersection
+    // Project along dir from point to find the first intersection
     // with region.
     G4ThreeVector vertex(0., 0., 0.);
     if (region == "EXTERNAL"){

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -235,8 +235,11 @@ namespace nexus {
     // Only shooting from the innest 5 cm.
     lead_gen_  = new BoxPointSampler(steel_x, steel_y, steel_z, 5.*cm, G4ThreeVector(0.,0.,0.), 0);
 
+    G4double shield_diag = std::sqrt(lead_x_*lead_x_ + lead_y_*lead_y_ + lead_z_*lead_z_);
     G4double ext_offset = 1. * cm;
-    external_gen_ = new BoxPointSampler(lead_x_ + ext_offset, lead_y_ + ext_offset, lead_z_ + ext_offset,
+    external_gen_ = new BoxPointSampler(shield_diag / 2. + ext_offset,
+					shield_diag / 2. + ext_offset,
+					shield_diag / 2. + ext_offset,
                                         1. * mm, G4ThreeVector(0.,0.,0.), 0);
 
 
@@ -455,6 +458,25 @@ namespace nexus {
     }
     else {
       G4Exception("[Next100Shielding]", "GenerateVertex()", FatalException,
+		  "Unknown vertex generation region!");
+    }
+
+    return vertex;
+  }
+
+
+  G4ThreeVector Next100Shielding::ProjectToRegion(const G4String& region,
+						  const G4ThreeVector& point,
+						  const G4ThreeVector& dir) const
+  {
+    // Project backwards along dir from point to find the first intersection
+    // with region.
+    G4ThreeVector vertex(0., 0., 0.);
+    if (region == "EXTERNAL"){
+      return external_gen_->GetIntersect(point, dir);
+    }
+    else {
+      G4Exception("[Next100Shielding]", "ProjectToRegion()", FatalException,
 		  "Unknown vertex generation region!");
     }
 

--- a/source/geometries/Next100Shielding.h
+++ b/source/geometries/Next100Shielding.h
@@ -36,6 +36,12 @@ namespace nexus {
     /// Generate a vertex within a given region of the geometry
     G4ThreeVector GenerateVertex(const G4String& region) const;
 
+    /// Returns a point within a region projecting from a
+    /// given point backwards along a line.
+    G4ThreeVector ProjectToRegion(const G4String& region,
+				  const G4ThreeVector& point,
+				  const G4ThreeVector& dir) const;
+
 
     /// Builder
     void Construct();

--- a/source/geometries/NextNew.cc
+++ b/source/geometries/NextNew.cc
@@ -585,5 +585,23 @@ namespace nexus {
     return vertex;
   }
 
+  G4ThreeVector NextNew::ProjectToRegion(const G4String& region,
+					 const G4ThreeVector& point,
+					 const G4ThreeVector& dir) const
+  {
+    // Project backwards along dir from point to find the first intersection
+    // with region.
+    G4ThreeVector vertex(0., 0., 0.);
+    if (region == "EXTERNAL"){
+      return shielding_->ProjectToRegion(region, point, dir);
+    }
+    else {
+      G4Exception("[NextNew]", "ProjectToRegion()", FatalException,
+		  "Unknown vertex generation region!");
+    }
+
+    return vertex + displ_;
+  }
+
 
 } //end namespace nexus

--- a/source/geometries/NextNew.cc
+++ b/source/geometries/NextNew.cc
@@ -589,7 +589,7 @@ namespace nexus {
 					 const G4ThreeVector& point,
 					 const G4ThreeVector& dir) const
   {
-    // Project backwards along dir from point to find the first intersection
+    // Project along dir from point to find the first intersection
     // with region.
     G4ThreeVector vertex(0., 0., 0.);
     if (region == "EXTERNAL"){

--- a/source/geometries/NextNew.cc
+++ b/source/geometries/NextNew.cc
@@ -595,6 +595,12 @@ namespace nexus {
     if (region == "EXTERNAL"){
       return shielding_->ProjectToRegion(region, point, dir);
     }
+    else if ((region == "HALLA_OUTER") || (region == "HALLA_INNER")){
+      if (!lab_walls_)
+	G4Exception("[NextNew]", "ProjectToRegion()", FatalException,
+                    "To project to this region you need lab_walls == true!");
+      return hallA_walls_->ProjectToRegion(region, point, dir);
+    }
     else {
       G4Exception("[NextNew]", "ProjectToRegion()", FatalException,
 		  "Unknown vertex generation region!");

--- a/source/geometries/NextNew.h
+++ b/source/geometries/NextNew.h
@@ -46,6 +46,12 @@ namespace nexus {
     /// Generate a vertex within a given region of the geometry
     G4ThreeVector GenerateVertex(const G4String& region) const;
 
+    /// Returns a point within a region projecting from a
+    /// given point backwards along a line.
+    G4ThreeVector ProjectToRegion(const G4String& region,
+				  const G4ThreeVector& point,
+				  const G4ThreeVector& dir) const;
+
   private:
     void BuildExtScintillator(G4ThreeVector pos, const G4RotationMatrix& rot);
     void Construct();

--- a/source/tests/utils/BoxPointSamplerTests.cc
+++ b/source/tests/utils/BoxPointSamplerTests.cc
@@ -92,12 +92,10 @@ TEST_CASE("Box Arbitrary valid intersect") {
   rotation->rotateY(CLHEP::twopi * G4UniformRand());
   rotation->rotateZ(CLHEP::twopi * G4UniformRand());
   
-  auto sampler = nexus::BoxPointSampler(inner_dim, inner_dim, inner_dim, thickness,
-					origin, rotation);
+  auto sampler = nexus::BoxPointSampler(inner_dim, inner_dim, inner_dim,
+					thickness, origin, rotation);
   
-  auto point = G4ThreeVector(inner_dim * G4UniformRand(),
-			     inner_dim * G4UniformRand(),
-			     inner_dim * G4UniformRand());
+  auto point = sampler.GenerateVertex("INSIDE");
   auto dir   = G4ThreeVector(G4UniformRand(),
 			     G4UniformRand(),
 			     G4UniformRand()).unit();

--- a/source/tests/utils/BoxPointSamplerTests.cc
+++ b/source/tests/utils/BoxPointSamplerTests.cc
@@ -50,3 +50,62 @@ TEST_CASE("BoxPointSampler") {
   }
 
 }
+
+
+TEST_CASE("Expected intersect") {
+  // This test checks that the GetIntersect method
+  // of BoxPointSampler produces the expected
+  // intersect points for the simple cases of
+  // a central point with directions parallel to
+  // the faces of the box.
+  auto inner_dim = 100;
+  auto thickness =  10;
+  auto sampler   = nexus::BoxPointSampler(inner_dim, inner_dim, inner_dim, thickness);
+  auto origin    = G4ThreeVector(0., 0., 0.);
+
+  G4double xdir[] = {1., 0., 0., -1., 0., 0.};
+  G4double ydir[] = {0., 1., 0., 0., -1., 0.};
+  G4double zdir[] = {0., 0., 1., 0., 0., -1.};
+  for (G4int i=0; i<6; ++i){
+    auto dir = G4ThreeVector(xdir[i], ydir[i], zdir[i]);
+    auto intersect = sampler.GetIntersect(origin, dir);
+    
+    REQUIRE(intersect.x() == Approx(inner_dim * dir.x()));
+    REQUIRE(intersect.y() == Approx(inner_dim * dir.y()));
+    REQUIRE(intersect.z() == Approx(inner_dim * dir.z()));
+  }
+
+}
+
+TEST_CASE("Box Arbitrary valid intersect") {
+  // This test checks that for a sampler of arbitrary
+  // position and arbitrary rotation a valid intersect
+  // point is found for a randomly generated ray.
+  auto inner_dim  = 100;
+  auto thickness  =  10;
+
+  auto origin  = G4ThreeVector(inner_dim * G4UniformRand(),
+			       inner_dim * G4UniformRand(),
+			       inner_dim * G4UniformRand());
+  auto rotation = new G4RotationMatrix();
+  rotation->rotateX(CLHEP::twopi * G4UniformRand());
+  rotation->rotateY(CLHEP::twopi * G4UniformRand());
+  rotation->rotateZ(CLHEP::twopi * G4UniformRand());
+  
+  auto sampler = nexus::BoxPointSampler(inner_dim, inner_dim, inner_dim, thickness,
+					origin, rotation);
+  
+  auto point = G4ThreeVector(inner_dim * G4UniformRand(),
+			     inner_dim * G4UniformRand(),
+			     inner_dim * G4UniformRand());
+  auto dir   = G4ThreeVector(G4UniformRand(),
+			     G4UniformRand(),
+			     G4UniformRand()).unit();
+  
+  auto intersect = sampler.GetIntersect(point, dir);
+  
+  // Check that the new ray passes through the original point.
+  auto origin_point = point - intersect;
+  REQUIRE(std::abs(origin_point.dot(dir)) == Approx(origin_point.mag()));
+
+}

--- a/source/tests/utils/CylinderPointSamplerTests.cc
+++ b/source/tests/utils/CylinderPointSamplerTests.cc
@@ -60,9 +60,12 @@ TEST_CASE("Cylinder Arbitrary valid intersect") {
   auto sampler = nexus::CylinderPointSampler2020(minRad, maxRad, halfLen,
 						 0., CLHEP::twopi,
 						 rotation, origin);
-  auto point   = G4ThreeVector(minRad * G4UniformRand(),
-			       minRad * G4UniformRand(),
-			       minRad * G4UniformRand());
+  auto point   = G4ThreeVector(minRad  * (2 * G4UniformRand() - 1),
+			       minRad  * (2 * G4UniformRand() - 1),
+			       halfLen * (2 * G4UniformRand() - 1));
+  // Rotate and translate so inside Sampler Volume.
+  point       *= *rotation;
+  point       += origin;
   auto dir     = G4ThreeVector(G4UniformRand(),
 			       G4UniformRand(),
 			       G4UniformRand()).unit();

--- a/source/tests/utils/CylinderPointSamplerTests.cc
+++ b/source/tests/utils/CylinderPointSamplerTests.cc
@@ -1,0 +1,76 @@
+#include <CylinderPointSampler2020.h>
+#include <Randomize.hh>
+
+#include <catch.hpp>
+
+TEST_CASE("Barrel and Caps intersection") {
+  // Tests that rays from the origin parallel
+  // to the axes are found to intersect with the
+  // Cylinder sampler at the expected points.
+  auto minRad  = 200;
+  auto maxRad  = 220;
+  auto halfLen = 500;
+  auto sampler = nexus::CylinderPointSampler2020(minRad, maxRad, halfLen);
+  auto origin  = G4ThreeVector(0., 0., 0.);
+
+  // Check caps.
+  auto intersect = sampler.GetIntersect(origin, G4ThreeVector(0., 0., 1.));
+  REQUIRE(intersect.x() == Approx(0.));
+  REQUIRE(intersect.y() == Approx(0.));
+  REQUIRE(intersect.z() == Approx(halfLen));
+  intersect = sampler.GetIntersect(origin, G4ThreeVector(0., 0., -1.));
+  REQUIRE(intersect.x() == Approx(0.));
+  REQUIRE(intersect.y() == Approx(0.));
+  REQUIRE(intersect.z() == Approx(-halfLen));
+
+  // Now the barrel.
+  intersect = sampler.GetIntersect(origin, G4ThreeVector(1., 0., 0.));
+  REQUIRE(intersect.x() == Approx(minRad));
+  REQUIRE(intersect.y() == Approx(0.));
+  REQUIRE(intersect.z() == Approx(0.));
+  intersect = sampler.GetIntersect(origin, G4ThreeVector(-1., 0., 0.));
+  REQUIRE(intersect.x() == Approx(-minRad));
+  REQUIRE(intersect.y() == Approx(0.));
+  REQUIRE(intersect.z() == Approx(0.));
+  intersect = sampler.GetIntersect(origin, G4ThreeVector(0., 1., 0.));
+  REQUIRE(intersect.x() == Approx(0.));
+  REQUIRE(intersect.y() == Approx(minRad));
+  REQUIRE(intersect.z() == Approx(0.));
+  intersect = sampler.GetIntersect(origin, G4ThreeVector(0., -1., 0.));
+  REQUIRE(intersect.x() == Approx(0.));
+  REQUIRE(intersect.y() == Approx(-minRad));
+  REQUIRE(intersect.z() == Approx(0.));
+
+}
+
+TEST_CASE("Cylinder Arbitrary valid intersect") {
+  // This test checks that for a sampler of arbitrary
+  // position and arbitrary rotation a valid intersect
+  // point is found for a randomly generated ray.
+  auto minRad   = 200;
+  auto maxRad   = 220;
+  auto halfLen  = 500;
+  auto origin   = G4ThreeVector(maxRad  * G4UniformRand(),
+				maxRad  * G4UniformRand(),
+				halfLen * G4UniformRand());
+  auto rotation = new G4RotationMatrix();
+  rotation->rotateX(CLHEP::twopi * G4UniformRand());
+  rotation->rotateY(CLHEP::twopi * G4UniformRand());
+  rotation->rotateZ(CLHEP::twopi * G4UniformRand());
+  auto sampler = nexus::CylinderPointSampler2020(minRad, maxRad, halfLen,
+						 0., CLHEP::twopi,
+						 rotation, origin);
+  auto point   = G4ThreeVector(minRad * G4UniformRand(),
+			       minRad * G4UniformRand(),
+			       minRad * G4UniformRand());
+  auto dir     = G4ThreeVector(G4UniformRand(),
+			       G4UniformRand(),
+			       G4UniformRand()).unit();
+
+  auto intersect = sampler.GetIntersect(point, dir);
+  
+  // Check that the new ray passes through the original point.
+  auto origin_point = point - intersect;
+  REQUIRE(std::abs(origin_point.dot(dir)) == Approx(origin_point.mag()));
+  
+}

--- a/source/utils/BoxPointSampler.cc
+++ b/source/utils/BoxPointSampler.cc
@@ -206,4 +206,23 @@ namespace nexus {
     return real_pos;
   }
 
+  G4ThreeVector BoxPointSampler::GetIntersect(const G4ThreeVector& point,
+					      const G4ThreeVector& dir)
+  {
+    // Get the +ve movements to intersect with the faces of the box.
+    G4double tx = (-inner_x_ - point.x())  / dir.x();
+    if (tx < 0) tx = (inner_x_ - point.x()) / dir.x();
+
+    G4double ty = (-inner_y_ - point.y()) / dir.y();
+    if (ty < 0) ty = (inner_y_ - point.y()) / dir.y();
+
+    G4double tz = (-inner_z_ - point.z()) / dir.z();
+    if (tz < 0) tz = (inner_z_ - point.z()) / dir.z();
+
+    // The minimum of the tx, ty, tz gives the intersection point.
+    G4double tmin = std::min({tx, ty, tz});
+
+    return RotateAndTranslate(point + tmin * dir);
+  }
+
 } // end namespace nexus

--- a/source/utils/BoxPointSampler.cc
+++ b/source/utils/BoxPointSampler.cc
@@ -206,23 +206,44 @@ namespace nexus {
     return real_pos;
   }
 
+  void BoxPointSampler::InvertRotationAndTranslation(G4ThreeVector& vec,
+						     bool translate)
+  {
+    if (translate)
+      vec -= origin_;
+    if (rotation_)
+      vec.rotate(-rotation_->delta(), rotation_->axis());
+  }
+
   G4ThreeVector BoxPointSampler::GetIntersect(const G4ThreeVector& point,
 					      const G4ThreeVector& dir)
   {
+    // The point and direction should be in the lab frame.
+    // Need to rotate into the Sampler frame to get the intersection
+    // then rotate back into lab frame.
+    G4ThreeVector local_point = point;
+    InvertRotationAndTranslation(local_point);
+    G4ThreeVector local_dir = dir;
+    InvertRotationAndTranslation(local_dir, false);
+
     // Get the +ve movements to intersect with the faces of the box.
-    G4double tx = (-inner_x_ - point.x())  / dir.x();
-    if (tx < 0) tx = (inner_x_ - point.x()) / dir.x();
+    G4double tx = (-inner_x_ - local_point.x())  / local_dir.x();
+    if (tx < 0) tx = (inner_x_ - local_point.x()) / local_dir.x();
 
-    G4double ty = (-inner_y_ - point.y()) / dir.y();
-    if (ty < 0) ty = (inner_y_ - point.y()) / dir.y();
+    G4double ty = (-inner_y_ - local_point.y()) / local_dir.y();
+    if (ty < 0) ty = (inner_y_ - local_point.y()) / local_dir.y();
 
-    G4double tz = (-inner_z_ - point.z()) / dir.z();
-    if (tz < 0) tz = (inner_z_ - point.z()) / dir.z();
+    G4double tz = (-inner_z_ - local_point.z()) / local_dir.z();
+    if (tz < 0) tz = (inner_z_ - local_point.z()) / local_dir.z();
 
+    // Protect against outside the region.
+    if (tx < 0 || ty < 0 || tz < 0)
+      G4Exception("[BoxPointSampler]", "GetIntersect()", FatalException,
+		  "Point outside region, projection fail!");
     // The minimum of the tx, ty, tz gives the intersection point.
     G4double tmin = std::min({tx, ty, tz});
 
-    return RotateAndTranslate(point + tmin * dir);
+    return RotateAndTranslate(local_point + tmin * local_dir);
   }
 
 } // end namespace nexus

--- a/source/utils/BoxPointSampler.h
+++ b/source/utils/BoxPointSampler.h
@@ -32,6 +32,10 @@ namespace nexus {
     /// Return vertex within region <region> of the chamber
     G4ThreeVector GenerateVertex(const G4String& region);
 
+    /// Return the intersect point along dir
+    G4ThreeVector GetIntersect(const G4ThreeVector& point,
+			       const G4ThreeVector& dir);
+
   private:
     G4double GetLength(G4double origin, G4double max_length);
     G4ThreeVector RotateAndTranslate(G4ThreeVector position);

--- a/source/utils/BoxPointSampler.h
+++ b/source/utils/BoxPointSampler.h
@@ -39,6 +39,7 @@ namespace nexus {
   private:
     G4double GetLength(G4double origin, G4double max_length);
     G4ThreeVector RotateAndTranslate(G4ThreeVector position);
+    void InvertRotationAndTranslation(G4ThreeVector& vec, bool translate=true);
 
   private:
     G4double inner_x_, inner_y_, inner_z_; ///< Internal dimensions

--- a/source/utils/CylinderPointSampler2020.h
+++ b/source/utils/CylinderPointSampler2020.h
@@ -41,6 +41,10 @@ namespace nexus {
     // Returns vertex within region <region> of the chamber
     G4ThreeVector GenerateVertex(const G4String& region);
 
+    /// Return the intersect point along dir
+    G4ThreeVector GetIntersect(const G4ThreeVector& point,
+    			       const G4ThreeVector& dir);
+
   private:
     G4double      GetRadius(G4double innerRad, G4double outerRad);
     G4double      GetPhi();

--- a/source/utils/CylinderPointSampler2020.h
+++ b/source/utils/CylinderPointSampler2020.h
@@ -50,6 +50,7 @@ namespace nexus {
     G4double      GetPhi();
     G4double      GetLength(G4double halfLength);
     G4ThreeVector RotateAndTranslate(G4ThreeVector position);
+    void InvertRotationAndTranslation(G4ThreeVector& vec, bool translate=true);
 
   private:
     G4double          minRad_, maxRad_, halfLength_;  // Solid Dimensions


### PR DESCRIPTION
Improves the way muons are generated using the angular correlations expected in a lab.

Introduces `ProjectToRegion` methods in the geometries (NEW, NEXT100 and NEXT100Shielding and LSCHallA for now) and `GetIntersect` to the `BoxPointSampler` and `CylinderPointSampler2020`.

Tests added to nexus-test

Replaces #54 which was closed in the transition to a public repository.