### PR TITLE
Add binary cache for Nix

### DIFF
--- a/.github/workflows/install-via-nix-and-test.yml
+++ b/.github/workflows/install-via-nix-and-test.yml
@@ -17,9 +17,10 @@ jobs:
       - uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=channel:nixos-20.09
-      - name: Enable Cachix binary cache
-        run: |
-          nix-env -iA cachix -f https://cachix.org/api/v1/install # Developers should prefer installation via home-manager
-          cachix use jacg-next-exp
+      - uses: cachix/cachix-action@v8
+        with:
+          name: jacg-next-exp
+          # If you chose API tokens for write access OR if you have a private cache
+          authToken: '${{ secrets.CACHIX_JACG_NEXT_EXP }}'
       - name: Install dependencies via Nix
         run: nix-shell --argstr py ${{ matrix.py }}

--- a/.github/workflows/install-via-nix-and-test.yml
+++ b/.github/workflows/install-via-nix-and-test.yml
@@ -24,9 +24,3 @@ jobs:
           authToken: '${{ secrets.CACHIX_JACG_NEXT_EXP }}'
       - name: Install dependencies via Nix
         run: nix-shell --argstr py ${{ matrix.py }}
-      - name: Build Nexus with SCons
-        run: nix-shell --argstr py ${{ matrix.py }} --run "scons"
-      - name: Run bin/nexus-test
-        run: nix-shell --argstr py ${{ matrix.py }} --run "bin/nexus-test"
-      - name: Run pytests
-        run: nix-shell --argstr py ${{ matrix.py }} --run "pytest -x"

--- a/.github/workflows/install-via-nix-and-test.yml
+++ b/.github/workflows/install-via-nix-and-test.yml
@@ -17,10 +17,9 @@ jobs:
       - uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=channel:nixos-20.09
-      - uses: cachix/cachix-action@v8
-        with:
-          name: jacg-next-exp
-          # If you chose API tokens for write access OR if you have a private cache
-          authToken: '${{ secrets.CACHIX_JACG_NEXT_EXP }}'
+      - name: Enable Cachix binary cache
+        run: |
+          nix-env -iA cachix -f https://cachix.org/api/v1/install # Developers should prefer installation via home-manager
+          cachix use jacg-next-exp
       - name: Install dependencies via Nix
         run: nix-shell --argstr py ${{ matrix.py }}

--- a/.github/workflows/install-via-nix-and-test.yml
+++ b/.github/workflows/install-via-nix-and-test.yml
@@ -17,6 +17,11 @@ jobs:
       - uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=channel:nixos-20.09
+      - uses: cachix/cachix-action@v8
+        with:
+          name: jacg-next-exp
+          # If you chose API tokens for write access OR if you have a private cache
+          authToken: '${{ secrets.CACHIX_JACG_NEXT_EXP }}'
       - name: Install dependencies via Nix
         run: nix-shell --argstr py ${{ matrix.py }}
       - name: Build Nexus with SCons

--- a/.github/workflows/install-via-nix-and-test.yml
+++ b/.github/workflows/install-via-nix-and-test.yml
@@ -24,3 +24,9 @@ jobs:
           authToken: '${{ secrets.CACHIX_JACG_NEXT_EXP }}'
       - name: Install dependencies via Nix
         run: nix-shell --argstr py ${{ matrix.py }}
+      - name: Build Nexus with SCons
+        run: nix-shell --argstr py ${{ matrix.py }} --run "scons"
+      - name: Run bin/nexus-test
+        run: nix-shell --argstr py ${{ matrix.py }} --run "bin/nexus-test"
+      - name: Run pytests
+        run: nix-shell --argstr py ${{ matrix.py }} --run "pytest -x"

--- a/nix/geant4.nix
+++ b/nix/geant4.nix
@@ -1,0 +1,11 @@
+self: super: {
+  geant4 = super.geant4.overrideAttrs (oldAttrs: rec {
+    version = "10.6.3";
+
+    src = super.fetchurl {
+    url = "https://geant4-data.web.cern.ch/geant4-data/releases/geant4.10.06.p03.tar.gz";
+    sha256 = "1wzv5xky1pfm7wdfdkvqcaaqlcnsrz35dc7zcrxh8l3j5rki6pqb";
+    };
+
+  });
+}

--- a/shell.nix
+++ b/shell.nix
@@ -12,7 +12,9 @@
 # writing this is nixos-20.03.
 let
   nixpkgs-url = "https://github.com/nixos/nixpkgs/archive/${nixpkgs-commit-id}.tar.gz";
-  pkgs = import (builtins.fetchTarball { url = nixpkgs-url; }) {};
+  pkgs = import (builtins.fetchTarball { url = nixpkgs-url; }) {
+    overlays = [ (import ./nix/geant4.nix) ];
+  };
   python = builtins.getAttr ("python" + py) pkgs;
   pypkgs = python.pkgs;
 


### PR DESCRIPTION
# Drastic improvement in build time

The headings in the following table are active links to two different GitHub action runs (PR #68), which build Nexus with Nix and run both `bin/nexus-test` and `pytest`.

|  |[without cache](https://github.com/jacg/nexus/runs/1750041091?check_suite_focus=true) | [with cache](https://github.com/jacg/nexus/runs/1754072031?check_suite_focus=true)|
--|-----------|----| 
Total time |115 minutes | 20 minutes |
Install dependencies via Nix |93 minutes |  2 minutes |

The point to note is that the cache reduces the run time by around 90 minutes.

# How?

This has been achieved by caching the result of compiling Geant4 10.6.3, which is not the version of Geant4 that comes with the `nixpgs` version that we are currently using, and is therefore not available in the default Nix binary cache.

The cache added in this PR is hosted by [Cachix](https://cachix.org), using their free *Community plan*. At present the cache is owned by me personally: Cachix is planning to add support for GitHub organizations on a time-scale of around a month, at which point the cache should be handed over to `next-exp`.

This PR ensures that the results of Nix compilations in our GitHub action are added to the cache, and that subsequent GHA runs use those results, thus avoiding the need to repeat the compilation.

# Cache is available to everyone

Everyone else can benefit from this cache by following these two simple steps:

1. installing `cachix` (a number of trivial ways, if Nix is installed)
2. `cachix use jacg-next-exp`

In step 2, `jacg-next-exp` is the name of the cache. We will probably choose to rename this to something like `next-exp` once Cachix supports organizations.

# Geant4 10.6.2 -> 10.6.3

In PR #64 we accepted a Nix expression which built Geant4 10.6.2: this is the version that comes with the `nixpkgs` version we are using, and was thus available in the standard Nix binary cache.
Now that we are caching our build-products, Geant4 10.6.3 is no longer prohibitively expensive to use, hence this PR bumps the Geant4 version from 10.6.2 to 10.6.3.