### PR TITLE
Removed warnings printed when testing Interpolation and XenonGasPrope…

### DIFF
--- a/source/materials/XenonGasProperties.cc
+++ b/source/materials/XenonGasProperties.cc
@@ -73,8 +73,7 @@ G4double XenonGasProperties::Density(G4double pressure)
       density = data[n_pressures-1][1];
     }
     else {
-      G4Exception("[XenonGaseousProperties]", "Density()", FatalException,
-      "Unknown xenon density for this pressure!");
+      throw "Unknown xenon density for this pressure!";
     }
   }
 
@@ -234,11 +233,11 @@ void XenonGasProperties::MakeDataTable()
   // Open file
   G4String path(std::getenv("NEXUSDIR"));
   G4String filename = path + "/data/gxe_density_table.txt";
+
   std::ifstream inFile;
   inFile.open(filename);
   if (!inFile) {
-    G4Exception("[XenonGaseousProperties]", "Density()", FatalErrorInArgument,
-    "File could not be opened!");
+    throw "File could not be opened";
   }
 
   std::vector<std::vector<G4double>> data;
@@ -251,6 +250,7 @@ void XenonGasProperties::MakeDataTable()
   G4double thistemp = 0;
   G4double temp, press, dens;
   char comma;
+
   while (inFile>>temp>>comma>>press>>comma>>dens){
     std::vector<G4double> thisdata {temp*kelvin, press*bar, dens*(kg/m3)};
     data_.push_back(thisdata);
@@ -279,7 +279,6 @@ G4double XenonGasProperties::GetDensity(G4double pressure, G4double temperature)
 {
   // Interpolate to calculate the density
   // at a given pressure and temperature
-
   G4double density = 5.324 * kg/m3;
   MakeDataTable();
 
@@ -291,7 +290,6 @@ G4double XenonGasProperties::GetDensity(G4double pressure, G4double temperature)
   G4double t1, t2, p1, p2, d11, d12, d21, d22, d1, d2;
 
   while (tcount < ntemps_-1) {
-
     t1 = data_[count][0];
     t2 = data_[count+npressures_][0];
 
@@ -323,8 +321,7 @@ G4double XenonGasProperties::GetDensity(G4double pressure, G4double temperature)
           density = LinearInterpolation(temperature, t1, t2, d1, d2);
           found = true;
         } else {
-          G4Exception("[XenonGaseousProperties]", "GetDensity()", FatalErrorInArgument,
-                      "Unknown xenon density for this pressure!");
+          throw "Unknown xenon density for this pressure!";
         }
       }
 
@@ -357,15 +354,12 @@ G4double XenonGasProperties::GetDensity(G4double pressure, G4double temperature)
           density = data_[count][2];
           found = true;
         } else {
-          G4Exception("[XenonGaseousProperties]", "GetDensity()", FatalErrorInArgument,
-                      "Unknown xenon density for this pressure!");
+          throw "Unknown xenon density for this pressure!";
         }
       }
     } else {
-        G4Exception("[XenonGaseousProperties]", "GetDensity()", FatalErrorInArgument,
-                    "Unknown xenon density for this temperature!");
+        throw "Unknown xenon density for this temperature";
     }
   }
-
   return density;
 }

--- a/source/tests/utils/InterpolationTests.cc
+++ b/source/tests/utils/InterpolationTests.cc
@@ -1,6 +1,8 @@
 #include <Interpolation.h>
 
 #include <catch.hpp>
+using Catch::Matchers::Contains;
+
 
 TEST_CASE("Linear Interpolation") {
   // These tests check thet Interpolation::LinearInterpolation
@@ -41,19 +43,15 @@ TEST_CASE("Linear Interpolation") {
     y = nexus::LinearInterpolation(2.0, 1.0, 2.0, 3.0, 4.0);
     REQUIRE (y == 4.0);
 
-    y = nexus::LinearInterpolation(1.0, 1.0, 1.0, 1.0, 2.0);
-    REQUIRE (std::isnan(y));
+    REQUIRE_THROWS (nexus::LinearInterpolation(1.0, 1.0, 1.0, 1.0, 2.0), Contains("x interval not valid"));
 
     y = nexus::LinearInterpolation(1.5, 1.0, 2.0, 2.0, 2.0);
     REQUIRE (y == 2.0);
   }
 
   SECTION ("x not in range"){
-    G4double y = nexus::LinearInterpolation(5.0, 1.0, 2.0, 3.0, 4.0);
-    REQUIRE (std::isnan(y));
-
-    y = nexus::LinearInterpolation(0.0, 1.0, 2.0, 3.0, 4.0);
-    REQUIRE (std::isnan(y));
+    REQUIRE_THROWS (nexus::LinearInterpolation(5.0, 1.0, 2.0, 3.0, 4.0),
+                    Contains("x is not in the given interval"));
   }
 
 }
@@ -93,7 +91,6 @@ TEST_CASE("Bilinear Interpolation"){
   }
 
   SECTION ("Input zeros"){
-    // FIXME
     Approx target = Approx(0.1).epsilon(0.1);
     G4double y = nexus::BilinearInterpolation(0.5, 0.0, 1.0,
                                               0.5, 0.0, 1.0,
@@ -102,7 +99,6 @@ TEST_CASE("Bilinear Interpolation"){
   }
 
   SECTION ("Edge cases"){
-    // FIXME
     G4double y = nexus::BilinearInterpolation(1.0, 1.0, 2.0,
                                               1.0, 1.0, 2.0,
                                               1.0, 2.0, 3.0, 4.0);
@@ -122,27 +118,42 @@ TEST_CASE("Bilinear Interpolation"){
                                      2.0, 1.0, 2.0,
                                      1.0, 2.0, 3.0, 4.0);
     REQUIRE (y == 4.0);
+
+    REQUIRE_THROWS (nexus::BilinearInterpolation(1.0, 1.0, 1.0,
+                                                 1.5, 1.0, 2.0,
+                                                1.0, 2.0, 3.0, 4.0),
+                    "One or more interval is invalid");
+
+    REQUIRE_THROWS (nexus::BilinearInterpolation(1.5, 1.0, 2.0,
+                                                 1.0, 1.0, 1.0,
+                                                 1.0, 2.0, 3.0, 4.0),
+                    "One or more interval is invalid");
+
+    REQUIRE_THROWS (nexus::BilinearInterpolation(1.0, 1.0, 1.0,
+                                                 1.0, 1.0, 1.0,
+                                                 1.0, 2.0, 3.0, 4.0),
+                    "One or more interval is invalid");
   }
 
   SECTION ("x or y not in input range"){
-    G4double y = nexus::BilinearInterpolation(0.0, 1.0, 2.0,
-                                              1.5, 1.0, 2.0,
-                                              1.0, 2.0, 3.0, 4.0);
-    REQUIRE (std::isnan(y));
+    REQUIRE_THROWS (nexus::BilinearInterpolation(0.0, 1.0, 2.0,
+                                                 1.5, 1.0, 2.0,
+                                                 1.0, 2.0, 3.0, 4.0),
+                    "x or y is not in the given interval");
 
-    y = nexus::BilinearInterpolation(3.0, 1.0, 2.0,
-                                     1.5, 1.0, 2.0,
-                                     1.0, 2.0, 3.0, 4.0);
-    REQUIRE (std::isnan(y));
+    REQUIRE_THROWS (nexus::BilinearInterpolation(3.0, 1.0, 2.0,
+                                                 1.5, 1.0, 2.0,
+                                                 1.0, 2.0, 3.0, 4.0),
+                    "x or y is not in the given interval");
 
-    y = nexus::BilinearInterpolation(1.5, 1.0, 2.0,
-                                     0.0, 1.0, 2.0,
-                                     1.0, 2.0, 3.0, 4.0);
-    REQUIRE (std::isnan(y));
+    REQUIRE_THROWS (nexus::BilinearInterpolation(1.5, 1.0, 2.0,
+                                                 0.0, 1.0, 2.0,
+                                                 1.0, 2.0, 3.0, 4.0),
+                    "x or y is not in the given interval");
 
-    y = nexus::BilinearInterpolation(1.5, 1.0, 2.0,
-                                     3.0, 1.0, 2.0,
-                                     1.0, 2.0, 3.0, 4.0);
-    REQUIRE (std::isnan(y));
+    REQUIRE_THROWS (nexus::BilinearInterpolation(1.5, 1.0, 2.0,
+                                                 3.0, 1.0, 2.0,
+                                                 1.0, 2.0, 3.0, 4.0),
+                    "x or y is not in the given interval");
   }
 }

--- a/source/utils/Interpolation.h
+++ b/source/utils/Interpolation.h
@@ -19,15 +19,11 @@ namespace nexus {
     G4double result = 0.0;
 
     if (xmax == xmin){
-      G4Exception("[Interpolation]", "LinearInterpolation()", JustWarning,
-      "x interval not valid, result is NAN");
-      result = NAN;
+      throw "x interval not valid";
     }
 
     else if (x < xmin || x > xmax){
-      G4Exception("[Interpolation]", "LinearInterpolation()", JustWarning,
-      "x is not in the given interval, result is NAN");
-      result = NAN;
+      throw "x is not in the given interval";
     }
 
     else {
@@ -45,15 +41,11 @@ namespace nexus {
     G4double result = 0.0;
 
     if ((xmax == xmin) || (ymax == ymin)){
-      G4Exception("[Interpolation]", "BilinearInterpolation()", JustWarning,
-      "One or more interval is invalid, result is NAN");
-      result = NAN;
+      throw "One or more interval is invalid";
     }
 
     else if ((x<xmin) || (x>xmax) || (y<ymin) || (y>ymax)){
-      G4Exception("[Interpolation]", "BilinearInterpolation()", JustWarning,
-      "x or y is not in the given interval, result is NAN");
-      result = NAN;
+      throw "x or y is not in the given interval";
     }
 
     else {


### PR DESCRIPTION
…rties

In order to remove the warnings printed while testing, I changed the G4Exceptions to c++ exceptions. This way the exceptions can be caught using catch2, and not printed to the terminal. 