### PR TITLE
Pyrex panel optical properties

### DIFF
--- a/source/geometries/PetBox.cc
+++ b/source/geometries/PetBox.cc
@@ -299,7 +299,7 @@ namespace nexus {
       new G4Box("ENTRY_PANEL", entry_panel_x_size_/2., entry_panel_y_size_/2., panel_thickness_/2.);
 
     G4Material* pyrex = G4NistManager::Instance()->FindOrBuildMaterial("G4_Pyrex_Glass");
-    pyrex->SetMaterialPropertiesTable(OpticalMaterialProperties::Pyrex_vidrasa(panel_thickness_));
+    pyrex->SetMaterialPropertiesTable(OpticalMaterialProperties::Pyrex_vidrasa());
 
     G4LogicalVolume* entry_panel_logic =
       new G4LogicalVolume(entry_panel_solid, pyrex, "ENTRY_PANEL");

--- a/source/geometries/PetBox.cc
+++ b/source/geometries/PetBox.cc
@@ -299,6 +299,7 @@ namespace nexus {
       new G4Box("ENTRY_PANEL", entry_panel_x_size_/2., entry_panel_y_size_/2., panel_thickness_/2.);
 
     G4Material* pyrex = G4NistManager::Instance()->FindOrBuildMaterial("G4_Pyrex_Glass");
+    pyrex->SetMaterialPropertiesTable(OpticalMaterialProperties::Pyrex_vidrasa(panel_thickness_));
 
     G4LogicalVolume* entry_panel_logic =
       new G4LogicalVolume(entry_panel_solid, pyrex, "ENTRY_PANEL");

--- a/source/geometries/PetBox.cc
+++ b/source/geometries/PetBox.cc
@@ -411,9 +411,9 @@ namespace nexus {
       new G4PVPlacement(0, G4ThreeVector(0., 0., -panel_sipms_zpos),
                         panel_sipms_logic, "PANEL_SiPMs", LXe_logic_, false, 1, false);
 
-      G4RotationMatrix rot;
-      rot.rotateY(pi);
-      new G4PVPlacement(G4Transform3D(rot, G4ThreeVector(0., 0., panel_sipms_zpos)),
+      G4RotationMatrix rot_panel;
+      rot_panel.rotateY(pi);
+      new G4PVPlacement(G4Transform3D(rot_panel, G4ThreeVector(0., 0., panel_sipms_zpos)),
                          panel_sipms_logic, "PANEL_SiPMs", LXe_logic_, false, 2, false);
 
       if (visibility_){

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -1068,6 +1068,9 @@ G4MaterialPropertiesTable* OpticalMaterialProperties::Pyrex_vidrasa()
 {
   G4MaterialPropertiesTable* pyrex_mpt = new G4MaterialPropertiesTable();
 
+  // Refractive index and absorption lenth taken from:
+  // http://www.vidrasa.com/esp/productos/borofloat/borofloat_pf.html#:~:text=Borofloat%20(vidrio%20plano%20borosilicato%203.3)%3A%20Propiedades%20f%C3%ADsicas%20y%20qu%C3%ADmicas&text=Las%20planchas%20de%20BOROFLOAT%C2%AE,tiempo%20es%20de%20500%20%C2%BAC.
+
   const G4int ri_entries = 20;
   G4double ri_energy[ri_entries] = {0.9263*eV, 2.2542*eV, 2.6338*eV, 3.2370*eV, 3.4768*eV,
                                     3.6304*eV, 3.7125*eV, 3.7549*eV, 3.8204*eV, 3.8882*eV,

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -1074,10 +1074,10 @@ G4MaterialPropertiesTable* OpticalMaterialProperties::Pyrex_vidrasa(G4double thi
                                     3.9114*eV, 3.9585*eV, 4.0562*eV, 4.3003*eV, 4.3198*eV,
                                     4.3394*eV, 4.3792*eV, 4.4403*eV, 4.5678*eV, 6.1992*eV};
 
-  G4double transparencies[ri_entries] = {0.910581, 0.917073, 0.910843, 0.905295, 0.893837,
-                                        0.874847, 0.848417, 0.807379, 0.747031, 0.701202,
-                                        0.65286,  0.597306, 0.505553, 0.071773, 0.054838,
-                                        0.037903, 0.025806, 0.013709, 0.004032, 0.0};
+  G4double transparencies[ri_entries] = {0.9800, 0.9800, 0.9800, 0.9700, 0.9600,
+                                         0.9400, 0.9100, 0.8850, 0.8000, 0.7500,
+                                         0.7000, 0.6500, 0.5500, 0.0718, 0.0548, 
+                                         0.0379, 0.0258, 0.0137, 0.0040, 0.};
   G4double abs_length[ri_entries];
   G4double ri_index[ri_entries];
   for (int i=0; i<ri_entries; i++) {

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -1064,7 +1064,7 @@ G4MaterialPropertiesTable* OpticalMaterialProperties::PTFE_non_reflectant()
 }
 
 
-G4MaterialPropertiesTable* OpticalMaterialProperties::Pyrex_vidrasa(G4double thickness)
+G4MaterialPropertiesTable* OpticalMaterialProperties::Pyrex_vidrasa()
 {
   G4MaterialPropertiesTable* pyrex_mpt = new G4MaterialPropertiesTable();
 
@@ -1074,14 +1074,13 @@ G4MaterialPropertiesTable* OpticalMaterialProperties::Pyrex_vidrasa(G4double thi
                                     3.9114*eV, 3.9585*eV, 4.0562*eV, 4.3003*eV, 4.3198*eV,
                                     4.3394*eV, 4.3792*eV, 4.4403*eV, 4.5678*eV, 6.1992*eV};
 
-  G4double transparencies[ri_entries] = {0.9800, 0.9800, 0.9800, 0.9700, 0.9600,
-                                         0.9400, 0.9100, 0.8850, 0.8000, 0.7500,
-                                         0.7000, 0.6500, 0.5500, 0.0718, 0.0548, 
-                                         0.0379, 0.0258, 0.0137, 0.0040, 0.};
-  G4double abs_length[ri_entries];
+  G4double abs_length[ri_entries] = {99.800*mm, 99.999*mm, 95.000*mm, 70.000*mm,
+                                     48.500*mm, 32.323*mm, 22.000*mm, 14.000*mm,
+                                      8.963*mm, 7.170*mm,  5.800*mm,   4.643*mm,
+                                      3.345*mm, 0.800*mm,  0.710*mm,   0.630*mm,
+                                      0.570*mm, 0.485*mm,  0.370*mm,   0.0*mm};
   G4double ri_index[ri_entries];
   for (int i=0; i<ri_entries; i++) {
-    abs_length[i] = -thickness/log(transparencies[i]);
     ri_index[i] = 1.472;
   }
 
@@ -1090,6 +1089,7 @@ G4MaterialPropertiesTable* OpticalMaterialProperties::Pyrex_vidrasa(G4double thi
 
   return pyrex_mpt;
 }
+
 
 G4MaterialPropertiesTable* OpticalMaterialProperties::TPB(G4double pressure, G4double temperature)
 {

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -1069,7 +1069,7 @@ G4MaterialPropertiesTable* OpticalMaterialProperties::Pyrex_vidrasa()
   G4MaterialPropertiesTable* pyrex_mpt = new G4MaterialPropertiesTable();
 
   // Refractive index and absorption lenth taken from:
-  // http://www.vidrasa.com/esp/productos/borofloat/borofloat_pf.html#:~:text=Borofloat%20(vidrio%20plano%20borosilicato%203.3)%3A%20Propiedades%20f%C3%ADsicas%20y%20qu%C3%ADmicas&text=Las%20planchas%20de%20BOROFLOAT%C2%AE,tiempo%20es%20de%20500%20%C2%BAC.
+  // http://www.vidrasa.com/esp/productos/borofloat/borofloat_pf.html
 
   const G4int ri_entries = 20;
   G4double ri_energy[ri_entries] = {0.9263*eV, 2.2542*eV, 2.6338*eV, 3.2370*eV, 3.4768*eV,

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -1064,6 +1064,33 @@ G4MaterialPropertiesTable* OpticalMaterialProperties::PTFE_non_reflectant()
 }
 
 
+G4MaterialPropertiesTable* OpticalMaterialProperties::Pyrex_vidrasa(G4double thickness)
+{
+  G4MaterialPropertiesTable* pyrex_mpt = new G4MaterialPropertiesTable();
+
+  const G4int ri_entries = 20;
+  G4double ri_energy[ri_entries] = {0.9263*eV, 2.2542*eV, 2.6338*eV, 3.2370*eV, 3.4768*eV,
+                                    3.6304*eV, 3.7125*eV, 3.7549*eV, 3.8204*eV, 3.8882*eV,
+                                    3.9114*eV, 3.9585*eV, 4.0562*eV, 4.3003*eV, 4.3198*eV,
+                                    4.3394*eV, 4.3792*eV, 4.4403*eV, 4.5678*eV, 6.1992*eV};
+
+  G4double transparencies[ri_entries] = {0.910581, 0.917073, 0.910843, 0.905295, 0.893837,
+                                        0.874847, 0.848417, 0.807379, 0.747031, 0.701202,
+                                        0.65286,  0.597306, 0.505553, 0.071773, 0.054838,
+                                        0.037903, 0.025806, 0.013709, 0.004032, 0.0};
+  G4double abs_length[ri_entries];
+  G4double ri_index[ri_entries];
+  for (int i=0; i<ri_entries; i++) {
+    abs_length[i] = -thickness/log(transparencies[i]);
+    ri_index[i] = 1.472;
+  }
+
+  pyrex_mpt->AddProperty("RINDEX", ri_energy, ri_index, ri_entries);
+  pyrex_mpt->AddProperty("ABSLENGTH", ri_energy, abs_length, ri_entries);
+
+  return pyrex_mpt;
+}
+
 G4MaterialPropertiesTable* OpticalMaterialProperties::TPB(G4double pressure, G4double temperature)
 {
 

--- a/source/materials/OpticalMaterialProperties.h
+++ b/source/materials/OpticalMaterialProperties.h
@@ -79,7 +79,7 @@ namespace nexus {
     static G4MaterialPropertiesTable* PTFE_LXe(G4double reflectivity=0.95);
     static G4MaterialPropertiesTable* PTFE_with_TPB();
     static G4MaterialPropertiesTable* PTFE_non_reflectant();
-    static G4MaterialPropertiesTable* Pyrex_vidrasa(G4double thickness=1.75*mm);
+    static G4MaterialPropertiesTable* Pyrex_vidrasa();
     static G4MaterialPropertiesTable* LYSO();
     static G4MaterialPropertiesTable* LYSO_nconst();
     static G4MaterialPropertiesTable* FakeLYSO();

--- a/source/materials/OpticalMaterialProperties.h
+++ b/source/materials/OpticalMaterialProperties.h
@@ -79,6 +79,7 @@ namespace nexus {
     static G4MaterialPropertiesTable* PTFE_LXe(G4double reflectivity=0.95);
     static G4MaterialPropertiesTable* PTFE_with_TPB();
     static G4MaterialPropertiesTable* PTFE_non_reflectant();
+    static G4MaterialPropertiesTable* Pyrex_vidrasa(G4double thickness=1.75*mm);
     static G4MaterialPropertiesTable* LYSO();
     static G4MaterialPropertiesTable* LYSO_nconst();
     static G4MaterialPropertiesTable* FakeLYSO();


### PR DESCRIPTION
In the `PetBox` geometry there are three possible tiles the user can choose with a configuration parameter. One of them is the `TileHamamatsuBlue`, which has an additional pyrex panel defined in front of the sensors close to the the wavelength shifter, both defined in the `PetBox` class, not in the `TileHamamatsuBlue` class.

New optical properties for this pyrex have been defined according with the datasheet of the company ([Vidrasa](http://www.vidrasa.com/esp/productos/borofloat/borofloat_pf.html#:~:text=Borofloat%20(vidrio%20plano%20borosilicato%203.3)%3A%20Propiedades%20f%C3%ADsicas%20y%20qu%C3%ADmicas&text=Las%20planchas%20de%20BOROFLOAT%C2%AE,tiempo%20es%20de%20500%20%C2%BAC.)) in the class `OpticalMaterialProperties` and applied only for these two panels, which are the only ones where the optical photons pass through.