### PR TITLE
Implement the assymetric geometry and comment the symmetric one

### DIFF
--- a/source/geometries/PetBox.cc
+++ b/source/geometries/PetBox.cc
@@ -491,7 +491,9 @@ namespace nexus {
 
     /// ASYMMETRIC GEOMETRY
     vol_name = "TILE_" + std::to_string(copy_no);
-    new G4PVPlacement(G4Transform3D(rot, G4ThreeVector(0., 0., -z_pos)), tile_logic,
+    G4double x_pos = -full_row_size_/2. + tile_size_x/2.;
+    G4double y_pos = full_col_size_/2. - tile_size_y/2.;
+    new G4PVPlacement(G4Transform3D(rot, G4ThreeVector(x_pos, y_pos, -z_pos)), tile_logic,
                           vol_name, LXe_logic_, false, copy_no, false);
 
     /// SYMMETRIC GEOMETRY

--- a/source/geometries/PetBox.cc
+++ b/source/geometries/PetBox.cc
@@ -489,16 +489,22 @@ namespace nexus {
     G4RotationMatrix rot;
     rot.rotateY(pi);
 
-    for (G4int i=0; i<n_tile_columns_; i++) {
-      G4double x_pos = -full_row_size_/2. + tile_size_x/2. + i*tile_size_x;
-      for (G4int j=0; j<n_tile_columns_; j++) {
-        G4double y_pos = full_col_size_/2. - tile_size_y/2. - j*tile_size_y;
-        vol_name = "TILE_" + std::to_string(copy_no);
-        new G4PVPlacement(G4Transform3D(rot, G4ThreeVector(x_pos, y_pos, -z_pos)), tile_logic,
+    /// ASYMMETRIC GEOMETRY
+    vol_name = "TILE_" + std::to_string(copy_no);
+    new G4PVPlacement(G4Transform3D(rot, G4ThreeVector(0., 0., -z_pos)), tile_logic,
                           vol_name, LXe_logic_, false, copy_no, false);
-        copy_no += 1;
-      }
-    }
+
+    /// SYMMETRIC GEOMETRY
+    // for (G4int i=0; i<n_tile_columns_; i++) {
+    //   G4double x_pos = -full_row_size_/2. + tile_size_x/2. + i*tile_size_x;
+    //   for (G4int j=0; j<n_tile_columns_; j++) {
+    //     G4double y_pos = full_col_size_/2. - tile_size_y/2. - j*tile_size_y;
+    //     vol_name = "TILE_" + std::to_string(copy_no);
+    //     new G4PVPlacement(G4Transform3D(rot, G4ThreeVector(x_pos, y_pos, -z_pos)), tile_logic,
+    //                       vol_name, LXe_logic_, false, copy_no, false);
+    //     copy_no += 1;
+    //   }
+    // }
   }
 
 


### PR DESCRIPTION
The initial measurements with the PetBox geometry will be performed with an asymmetric configuration of the tiles. Four tiles in one side and one tile in the opposite side. This PR implements this change and the symmetric geometry has been commented in order to be used in the future.