### PR TITLE
Change back PMT IDs to original values.

### DIFF
--- a/source/geometries/NextDemoEnergyPlane.cc
+++ b/source/geometries/NextDemoEnergyPlane.cc
@@ -275,7 +275,7 @@ namespace nexus {
     G4ThreeVector pos;
     for (int i=0; i<num_PMTs_; i++) {
       pos = pmt_positions_[i];
-      G4int copy_no = i+10;
+      G4int copy_no = i;
       if (verbosity_) G4cout << "PMT " << copy_no << ": "
                              << pos.getX() << ", " << pos.getY() << G4endl;
       pos.setZ(pmt_hole_zpos);

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -85,7 +85,7 @@ def flex100_detector(nexus_full_output_file_flex100):
 
 @pytest.fixture(scope = 'session')
 def demopp_detector(nexus_full_output_file_demopp):
-    pmt_ids         = [10, 11, 12]
+    pmt_ids         = [0, 1, 2]
     board_ids       = [14, 15, 16, 17]
     sipms_per_board = 64
     board_ordering  = 1000


### PR DESCRIPTION
The DEMO++ IC database has been updated, so there is no mismtach in the position of real sensors and simulation, so there's no need  for different IDs. This PR changes back the PMT IDs to [0, 1, 2].