### PR TITLE
Fix bug in the generation of event vertices in EL gap

### DIFF
--- a/macros/NEW_elgap.config.mac
+++ b/macros/NEW_elgap.config.mac
@@ -1,7 +1,7 @@
 /control/verbose  0
 /run/verbose      0
 /event/verbose    0
-/tracking/verbose 1
+/tracking/verbose 0
 
 /Generator/ScintGenerator/region EL_GAP
 /Generator/ScintGenerator/nphotons 1

--- a/macros/NEW_elgap.config.mac
+++ b/macros/NEW_elgap.config.mac
@@ -1,0 +1,17 @@
+/control/verbose  0
+/run/verbose      0
+/event/verbose    0
+/tracking/verbose 1
+
+/Generator/ScintGenerator/region EL_GAP
+/Generator/ScintGenerator/nphotons 1
+
+/Geometry/NextNew/el_gap_gen_disk_diam 10 mm
+/Geometry/NextNew/el_gap_gen_disk_x    10 mm
+/Geometry/NextNew/el_gap_gen_disk_y    10 mm
+/Geometry/NextNew/el_gap_gen_disk_zmin 0.0
+/Geometry/NextNew/el_gap_gen_disk_zmax 1.0
+
+/nexus/random_seed 1
+/nexus/persistency/start_id 0
+/nexus/persistency/outputFile new_elgap.nexus

--- a/macros/NEW_elgap.init.mac
+++ b/macros/NEW_elgap.init.mac
@@ -1,0 +1,14 @@
+/Geometry/RegisterGeometry NEXT_NEW
+
+/Generator/RegisterGenerator    SCINTILLATION
+
+/Actions/RegisterTrackingAction LIGHT_TABLE
+
+/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
+/PhysicsList/RegisterPhysics G4DecayPhysics
+/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
+/PhysicsList/RegisterPhysics G4OpticalPhysics
+/PhysicsList/RegisterPhysics NexusPhysics
+/PhysicsList/RegisterPhysics G4StepLimiterPhysics
+
+/nexus/RegisterMacro macros/NEW_elgap.config.mac

--- a/source/geometries/NextNew.cc
+++ b/source/geometries/NextNew.cc
@@ -563,6 +563,21 @@ namespace nexus {
         (region == "HALLA_INNER"))
       return vertex;
 
+    // In EL_GAP, x and y coordinates are passed by the user,
+    // but the z coordinate is not. Therefore, rotation + displacement
+    // must be applied to get the correct z, but x and y must be left
+    // unchanged.
+    if (region == "EL_GAP") {
+      // First rotate, then shift to return the correct z coordinate
+      vertex.rotate(rot_angle_, G4ThreeVector(0., 1., 0.));
+      vertex = vertex + displ_;
+
+      // Change back x coordinate alone (y is not touched).
+      vertex.setX(-vertex.x());
+
+      return vertex;
+    }
+
     // First rotate, then shift
     vertex.rotate(rot_angle_, G4ThreeVector(0., 1., 0.));
     vertex = vertex + displ_;

--- a/source/geometries/NextNew.cc
+++ b/source/geometries/NextNew.cc
@@ -558,11 +558,9 @@ namespace nexus {
 
     // AD_HOC is not rotated and shifted because it is passed by the user
     // The LSC HallA vertices are already corrected so no need.
-    // The EL_GAP vertices are already corrected so no need.
     if ((region == "AD_HOC") ||
         (region == "HALLA_OUTER") ||
-        (region == "HALLA_INNER") ||
-        (region == "EL_GAP"))
+        (region == "HALLA_INNER"))
       return vertex;
 
     // First rotate, then shift

--- a/source/geometries/NextNewFieldCage.cc
+++ b/source/geometries/NextNewFieldCage.cc
@@ -494,9 +494,7 @@ void NextNewFieldCage::BuildBuffer()
     G4double el_gap_gen_disk_z = el_gap_z_pos_ - el_gap_length_/2.
       + el_gap_length_ * el_gap_gen_disk_zmin_ + el_gap_gen_disk_thickn/2.;
 
-    // (We change below the sign of x to correct the effect that a rotation
-    //  will introduce later.)
-    G4ThreeVector el_gap_gen_pos(-el_gap_gen_disk_x_,
+    G4ThreeVector el_gap_gen_pos(el_gap_gen_disk_x_,
                                  el_gap_gen_disk_y_,
                                  el_gap_gen_disk_z);
 

--- a/source/geometries/NextNewFieldCage.cc
+++ b/source/geometries/NextNewFieldCage.cc
@@ -494,7 +494,9 @@ void NextNewFieldCage::BuildBuffer()
     G4double el_gap_gen_disk_z = el_gap_z_pos_ - el_gap_length_/2.
       + el_gap_length_ * el_gap_gen_disk_zmin_ + el_gap_gen_disk_thickn/2.;
 
-    G4ThreeVector el_gap_gen_pos(el_gap_gen_disk_x_,
+    // (We change below the sign of x to correct the effect that a rotation
+    //  will introduce later.)
+    G4ThreeVector el_gap_gen_pos(-el_gap_gen_disk_x_,
                                  el_gap_gen_disk_y_,
                                  el_gap_gen_disk_z);
 


### PR DESCRIPTION
In the geometry of NEW, the event vertices in the EL gap were not being repositioned in the global frame of reference at the level of the main class (`NextNew`). This pull request fixes that bug.