### PR TITLE
Fix order in the tile definition

### DIFF
--- a/source/geometries/PetBox.cc
+++ b/source/geometries/PetBox.cc
@@ -240,15 +240,12 @@ namespace nexus {
     // TILE TYPE
     if (tile_type_ == "HamamatsuVUV") {
       tile_ = new TileHamamatsuVUV();
-      tile_->SetBoxGeom(1);
       dist_dice_flange_ = 20.*mm;
     } else if (tile_type_ == "HamamatsuBlue") {
       tile_ = new TileHamamatsuBlue();
-      tile_->SetBoxGeom(1);
       dist_dice_flange_ = 19.35*mm;
     } else if (tile_type_ == "FBK") {
       tile_ = new TileFBK();
-      tile_->SetBoxGeom(2);
       tile_->SetPDE(sipm_pde_);
       dist_dice_flange_ = 21.05*mm;
     } else {
@@ -256,6 +253,7 @@ namespace nexus {
                   "Unknown tile type!");
     }
 
+    tile_->SetBoxGeom(1);
     // Construct the tile for the distances in the active
     tile_->SetTileVisibility(tile_vis_);
     tile_->SetTileReflectivity(tile_refl_);

--- a/source/geometries/PetBox.cc
+++ b/source/geometries/PetBox.cc
@@ -476,10 +476,10 @@ namespace nexus {
     G4int copy_no = 0;
 
     G4double z_pos = -box_size_/2. + box_thickness_ + dist_dice_flange_ + tile_thickn_/2.;
-    for (G4int i=0; i<n_tile_columns_; i++) {
-      G4double x_pos = -full_row_size_/2. + tile_size_x/2. + i*tile_size_x;
-      for (G4int j=0; j<n_tile_rows_; j++) {
-        G4double y_pos = full_col_size_/2. - tile_size_y/2. - j*tile_size_y;
+    for (G4int j=0; j<n_tile_rows_; j++) {
+      G4double y_pos = full_col_size_/2. - tile_size_y/2. - j*tile_size_y;
+      for (G4int i=0; i<n_tile_columns_; i++) {
+        G4double x_pos = -full_row_size_/2. + tile_size_x/2. + i*tile_size_x;
         vol_name = "TILE_" + std::to_string(copy_no);
         new G4PVPlacement(0, G4ThreeVector(x_pos, y_pos, z_pos), tile_logic,
                           vol_name, LXe_logic_, false, copy_no, false);
@@ -492,16 +492,16 @@ namespace nexus {
 
     /// ASYMMETRIC GEOMETRY
     vol_name = "TILE_" + std::to_string(copy_no);
-    G4double x_pos = -full_row_size_/2. + tile_size_x/2.;
+    G4double x_pos = full_row_size_/2. - tile_size_x/2.;
     G4double y_pos = full_col_size_/2. - tile_size_y/2.;
     new G4PVPlacement(G4Transform3D(rot, G4ThreeVector(x_pos, y_pos, -z_pos)), tile_logic,
                           vol_name, LXe_logic_, false, copy_no, false);
 
     /// SYMMETRIC GEOMETRY
-    // for (G4int i=0; i<n_tile_columns_; i++) {
-    //   G4double x_pos = -full_row_size_/2. + tile_size_x/2. + i*tile_size_x;
-    //   for (G4int j=0; j<n_tile_columns_; j++) {
-    //     G4double y_pos = full_col_size_/2. - tile_size_y/2. - j*tile_size_y;
+    // for (G4int j=0; j<n_tile_rows_; j++) {
+    //   G4double y_pos = full_col_size_/2. - tile_size_y/2. - j*tile_size_y;
+    //   for (G4int i=0; i<n_tile_columns_; i++) {
+    //     G4double x_pos = full_row_size_/2. - tile_size_x/2. - i*tile_size_x;
     //     vol_name = "TILE_" + std::to_string(copy_no);
     //     new G4PVPlacement(G4Transform3D(rot, G4ThreeVector(x_pos, y_pos, -z_pos)), tile_logic,
     //                       vol_name, LXe_logic_, false, copy_no, false);

--- a/source/geometries/TileFBK.cc
+++ b/source/geometries/TileFBK.cc
@@ -85,9 +85,18 @@ namespace nexus {
     // SiPMs
     G4LogicalVolume* sipm_logic = sipm_->GetLogicalVolume();
 
+    G4int copy_no;
+    G4int init_val = 10;
+    G4int k = 0;
     for (int i=0; i<n_rows_; i++){
+      if ((i != 0) && (i % 2 == 0)){
+        k +=1;
+      }
+      copy_no = init_val + 10*k;
       for (int j=0; j<n_columns_; j++){
-        G4int copy_no = i*2*n_columns_ + j + 1;
+        if (j % 2 == 0){
+          copy_no += 1;
+        }
         G4double x_pos = -tile_x_/2. + offset_x + sipm_dim.x()/2. + j * sipm_pitch_;
         G4double y_pos = tile_y_/2. - offset_y - sipm_dim.y()/2. - i * sipm_pitch_;
         G4double z_pos = tile_z_/2. - sipm_dim.z()/2.;

--- a/source/geometries/TileHamamatsuBlue.cc
+++ b/source/geometries/TileHamamatsuBlue.cc
@@ -111,7 +111,7 @@ namespace nexus {
          G4int copy_no = (j+1)*10 + i + 1;
          G4double x_pos = -tile_x_/2. + offset_x + sipm_dim.x()/2. + i * sipm_pitch_;
          G4double y_pos =  tile_y_/2. - offset_y - sipm_dim.y()/2. - j * sipm_pitch_;
-         G4double z_pos =  tile_z_/2. - quartz_thick_ - lxe_thick_ - sipm_dim.z()/2.;
+         G4double z_pos = (tile_z_+epoxy_depth_)/2. - epoxy_depth - sipm_dim.z()/2.;
          G4String vol_name = "SiPMHmtsuBlue_" + std::to_string(copy_no);
          new G4PVPlacement(0, G4ThreeVector(x_pos, y_pos, z_pos),
                            sipm_logic, vol_name, tile_logic, false, copy_no, false);

--- a/source/geometries/TileHamamatsuBlue.cc
+++ b/source/geometries/TileHamamatsuBlue.cc
@@ -106,15 +106,15 @@ namespace nexus {
     // SiPMs
     G4LogicalVolume* sipm_logic = sipm_->GetLogicalVolume();
 
-    for (int i=0; i<n_rows_; i++){
-      for (int j=0; j<n_columns_; j++){
-	       G4int copy_no = i*2*n_columns_ + j + 1;
-         G4double x_pos = -tile_x_/2. + offset_x + sipm_dim.x()/2. + j * sipm_pitch_;
-         G4double y_pos = tile_y_/2. - offset_y - sipm_dim.y()/2. - i * sipm_pitch_;
-         G4double z_pos = (tile_z_+epoxy_depth_)/2. - epoxy_depth - sipm_dim.z()/2.;
+     for (int j=0; j<n_rows_; j++){
+       for (int i=0; i<n_columns_; i++){
+         G4int copy_no = (j+1)*10 + i + 1;
+         G4double x_pos = -tile_x_/2. + offset_x + sipm_dim.x()/2. + i * sipm_pitch_;
+         G4double y_pos =  tile_y_/2. - offset_y - sipm_dim.y()/2. - j * sipm_pitch_;
+         G4double z_pos =  tile_z_/2. - quartz_thick_ - lxe_thick_ - sipm_dim.z()/2.;
          G4String vol_name = "SiPMHmtsuBlue_" + std::to_string(copy_no);
-	       new G4PVPlacement(0, G4ThreeVector(x_pos, y_pos, z_pos),
-			       sipm_logic, vol_name, tile_logic, false, copy_no, false);
+         new G4PVPlacement(0, G4ThreeVector(x_pos, y_pos, z_pos),
+                           sipm_logic, vol_name, tile_logic, false, copy_no, false);
 	}
       }
 

--- a/source/geometries/TileHamamatsuVUV.cc
+++ b/source/geometries/TileHamamatsuVUV.cc
@@ -133,12 +133,12 @@ namespace nexus {
     // SiPMs
     G4LogicalVolume* sipm_logic = sipm_->GetLogicalVolume();
 
-    for (int i=0; i<n_rows_; i++){
-      for (int j=0; j<n_columns_; j++){
-        G4int copy_no = i*2*n_columns_ + j + 1;
-        G4double x_pos = -tile_x_/2. + offset_x + sipm_dim.x()/2. + j * sipm_pitch_;
-        G4double y_pos =  tile_y_/2. - offset_y - sipm_dim.y()/2. - i * sipm_pitch_;
-        G4double z_pos = tile_z_/2. - quartz_thick_ - lxe_thick_ - sipm_dim.z()/2.;
+    for (int j=0; j<n_rows_; j++){
+      for (int i=0; i<n_columns_; i++){
+        G4int copy_no = (j+1)*10 + i + 1;
+        G4double x_pos = -tile_x_/2. + offset_x + sipm_dim.x()/2. + i * sipm_pitch_;
+        G4double y_pos =  tile_y_/2. - offset_y - sipm_dim.y()/2. - j * sipm_pitch_;
+        G4double z_pos =  tile_z_/2. - quartz_thick_ - lxe_thick_ - sipm_dim.z()/2.;
         G4String vol_name = "SiPMHmtsuVUV_" + std::to_string(copy_no);
         new G4PVPlacement(0, G4ThreeVector(x_pos, y_pos, z_pos),
                           sipm_logic, vol_name, tile_logic, false, copy_no, false);

--- a/source/sensdet/ToFSD.cc
+++ b/source/sensdet/ToFSD.cc
@@ -141,7 +141,7 @@ namespace nexus {
       pmtid = naming_order_*motherid + pmtid;
     }
     if (box_geom_==1) { // Hamamatsu
-      std::vector<G4int> init_ids ({ 0, 4, 32, 36, 64, 68, 96, 100 });
+      std::vector<G4int> init_ids ({ 0, 4, 40, 44, 100, 104, 140, 144 });
       G4int motherid = touchable->GetCopyNumber(mother_depth_);
       G4int first_id = (init_ids)[motherid];
       pmtid = first_id + pmtid;

--- a/source/sensdet/ToFSD.cc
+++ b/source/sensdet/ToFSD.cc
@@ -140,18 +140,12 @@ namespace nexus {
       G4int motherid = touchable->GetCopyNumber(mother_depth_);
       pmtid = naming_order_*motherid + pmtid;
     }
-    if (box_geom_==1) { // Hamamatsu
+    if (box_geom_==1) { // Hamamatsu & FBK
       std::vector<G4int> init_ids ({ 0, 4, 40, 44, 100, 104, 140, 144 });
       G4int motherid = touchable->GetCopyNumber(mother_depth_);
       G4int first_id = (init_ids)[motherid];
       pmtid = first_id + pmtid;
-    } else if (box_geom_==2) { // FBK
-      std::vector<G4int> init_ids ({ 0, 8, 128, 136, 256, 264, 384, 392 });
-      G4int motherid = touchable->GetCopyNumber(mother_depth_);
-      G4int first_id = (init_ids)[motherid];
-      pmtid = first_id + pmtid;
     }
-
     return pmtid;
   }
 

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -62,7 +62,7 @@ def base_name_pet_box_FBK():
 def nexus_params_pet_box_HamamatsuVUV(output_tmpdir, base_name_pet_box_HamamatsuVUV):
     n_sipm         = 128
     sipms_per_tile = 16
-    init_sns_id    = 1
+    init_sns_id    = 11
     sensor_name    = 'SiPMHmtsuVUV'
     return os.path.join(output_tmpdir, base_name_pet_box_HamamatsuVUV+'.h5'), n_sipm, sipms_per_tile, init_sns_id, sensor_name
 
@@ -70,7 +70,7 @@ def nexus_params_pet_box_HamamatsuVUV(output_tmpdir, base_name_pet_box_Hamamatsu
 def nexus_params_pet_box_HamamatsuBlue(output_tmpdir, base_name_pet_box_HamamatsuBlue):
     n_sipm         = 128
     sipms_per_tile = 16
-    init_sns_id    = 1
+    init_sns_id    = 11
     sensor_name    = 'SiPMHmtsuBlue'
     return os.path.join(output_tmpdir, base_name_pet_box_HamamatsuBlue+'.h5'), n_sipm, sipms_per_tile, init_sns_id, sensor_name
 
@@ -78,7 +78,7 @@ def nexus_params_pet_box_HamamatsuBlue(output_tmpdir, base_name_pet_box_Hamamats
 def nexus_params_pet_box_FBK(output_tmpdir, base_name_pet_box_FBK):
     n_sipm         = 512
     sipms_per_tile = 64
-    init_sns_id    = 1
+    init_sns_id    = 11
     sensor_name    = 'SiPMFBKVUV'
     return os.path.join(output_tmpdir, base_name_pet_box_FBK+'.h5'), n_sipm, sipms_per_tile, init_sns_id, sensor_name
 

--- a/tests/pytest/sensitive_detectors_test.py
+++ b/tests/pytest/sensitive_detectors_test.py
@@ -44,8 +44,9 @@ def test_sensor_ids_pet_box(nexus_pet_box_params):
      assert min(sipm_ids) >= init_sns_id
      assert sns_positions.sensor_name.unique() == sensor_name
 
-     sns_z_pos_left  = sns_positions[ sns_positions.sensor_id<nsipms/2].z.values
-     sns_z_pos_right = sns_positions[~sns_positions.sensor_id<nsipms/2].z.values
+     first_id_second_plane = 111
+     sns_z_pos_left  = sns_positions[ sns_positions.sensor_id<first_id_second_plane].z.values
+     sns_z_pos_right = sns_positions[~sns_positions.sensor_id<first_id_second_plane].z.values
      if len(sns_z_pos_left) > 0:
          assert len(np.unique(sns_z_pos_left)) == 1
          assert     np.unique(sns_z_pos_left)  < 0


### PR DESCRIPTION
A bug was introduced when the coordinates in the PetBox geometry were changed. This bug is related to the order in which the tiles are defined in the geometry, affecting the sensor identification. This PR fixes the problem changing the order in which the tiles are defined, both in the case of the asymmetric box and the symmetric one.