### PR TITLE
Turn cherenkov off

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+tag v6_02_00 - 17 Feb 2021
+	- Add a new generator in the EL gap for light table production.
+	- Fix the composition of ITO to the best of our knowledge.
+	- Fix the position of the holes in the ICS of NEW.
+	- Add nix to nexus.
+	- Add the possibility of generating a single particle in a limited range of directions.
+	- Add the LSC rock geometry.
+	- Add photoelectric process.
+	- Simulate DEMO++ geometry.
+	- Fix GenericPhotosensor geometry to prevent photons from entering through the sides of the active area.
+
 tag v6_01_01 - 6 Oct 2020
 	- Fix a bug in the position of SiPMs in the NEXT100 boards.
 

--- a/macros/DEMOPP_fullKr.config.mac
+++ b/macros/DEMOPP_fullKr.config.mac
@@ -23,6 +23,8 @@
 /Geometry/PmtR11410/time_binning 100. nanosecond
 /Geometry/SiPMSensl/time_binning 1. microsecond
 
+/process/optical/processActivation Cerenkov false
+
 
 # GENERATION
 /Generator/Kr83mGenerator/region  ACTIVE

--- a/macros/NEW_fullKr.config.mac
+++ b/macros/NEW_fullKr.config.mac
@@ -22,6 +22,7 @@
 /Geometry/SiPMSensl/time_binning 1. microsecond
 
 /PhysicsList/Nexus/photoelectric false
+/process/optical/processActivation Cerenkov false
 
 # GENERATOR
 /Generator/Kr83mGenerator/region ACTIVE

--- a/macros/NEXT100_full.config.mac
+++ b/macros/NEXT100_full.config.mac
@@ -18,6 +18,8 @@
 /Geometry/Next100/pressure 10. bar
 /Geometry/Next100/max_step_size 5. mm
 
+/process/optical/processActivation Cerenkov false
+
 ##### GENERATOR #####
 /Generator/Kr83mGenerator/region ACTIVE
 

--- a/macros/NextFlex_fullKr.config.mac
+++ b/macros/NextFlex_fullKr.config.mac
@@ -84,6 +84,8 @@
 /Geometry/NextFlex/ics_visibility          false
 
 
+/process/optical/processActivation Cerenkov false
+
 ### GENERATOR
 # Kripton
 /Generator/Kr83mGenerator/region  AD_HOC


### PR DESCRIPTION
This PR adds a line to the examples using full simulation, to turn off the Cherenkov effect.
This is just a temporary fix, to deal with materials that don't have their optical properties defined in the whole range of wavelengths of the Cherenkov photons. It will be removed once we revisit the optical properties of the whole set of materials used in nexus.
The ChangeLog has also been updated for the next tag.