### PR TITLE
New generic VUV-sensitive SiPMs.

### DIFF
--- a/source/geometries/FullRingInfinity.cc
+++ b/source/geometries/FullRingInfinity.cc
@@ -8,7 +8,7 @@
 // ----------------------------------------------------------------------------
 
 #include "FullRingInfinity.h"
-#include "SiPMpetFBK.h"
+#include "SiPMpetVUV.h"
 #include "SpherePointSampler.h"
 #include "MaterialsList.h"
 #include "IonizationSD.h"
@@ -161,8 +161,7 @@ namespace nexus {
     sns_z_max_cmd.SetUnitCategory("Length");
     sns_z_max_cmd.SetParameterName("sens_z_max", false);
 
-
-    sipm_ = new SiPMpetFBK();
+    sipm_ = new SiPMpetVUV();
   }
 
   FullRingInfinity::~FullRingInfinity()

--- a/source/geometries/FullRingInfinity.h
+++ b/source/geometries/FullRingInfinity.h
@@ -16,7 +16,7 @@
 class G4GenericMessenger;
 class G4LogicalVolume;
 namespace nexus {
-  class SiPMpetFBK;
+  class SiPMpetVUV;
   class SpherePointSampler;
 }
 
@@ -43,7 +43,7 @@ namespace nexus {
     G4ThreeVector RandomPointVertex() const;
     void CalculateSensitivityVertices(G4double binning);
 
-    SiPMpetFBK* sipm_;
+    SiPMpetVUV* sipm_;
 
     G4LogicalVolume* lab_logic_;
     G4LogicalVolume* LXe_logic_;

--- a/source/geometries/SiPMpetVUV.cc
+++ b/source/geometries/SiPMpetVUV.cc
@@ -32,7 +32,7 @@ namespace nexus {
 
   SiPMpetVUV::SiPMpetVUV(): BaseGeometry(),
 			    visibility_(0),
-			    refr_index_(1),
+			    refr_index_(1.6),
 			    eff_(1.),
                             time_binning_(1.*microsecond),
                             sensor_depth_(-1),

--- a/source/geometries/SiPMpetVUV.h
+++ b/source/geometries/SiPMpetVUV.h
@@ -1,7 +1,8 @@
 // ----------------------------------------------------------------------------
 // nexus | SiPMpetVUV.h
 //
-// Basic 3x3 mm2 SiPM geometry without TPB coating.
+// Variable size SiPM geometry with no wavelength shifter
+// and a window with perfect transparency and configurable refractive index.
 //
 // The NEXT Collaboration
 // ----------------------------------------------------------------------------
@@ -30,6 +31,10 @@ namespace nexus {
     /// Invoke this method to build the volumes of the geometry
     void Construct();
 
+    void SetSensorDepth (G4int sensor_depth);
+    void SetMotherDepth (G4int mother_depth);
+    void SetNamingOrder (G4int naming_order);
+
   private:
 
     // Visibility of the tracking plane
@@ -45,9 +50,19 @@ namespace nexus {
     G4GenericMessenger* msg_;
 
     G4double time_binning_;
+    G4double sipm_size_;
+    G4int sensor_depth_, mother_depth_, naming_order_;
 
   };
 
+  inline void SiPMpetVUV::SetSensorDepth(G4int sensor_depth)
+  { sensor_depth_ = sensor_depth; }
+
+  inline void SiPMpetVUV::SetMotherDepth(G4int mother_depth)
+  { mother_depth_ = mother_depth; }
+
+  inline void SiPMpetVUV::SetNamingOrder(G4int naming_order)
+  { naming_order_ = naming_order; }
 
 } // end namespace nexus
 


### PR DESCRIPTION
In this PR, the old `SiPMpetVUV` class is being modified to make it configurable in size and with a protective window with a configurable refractive index. Moreover, the size of the active area has been made slightly smaller than the SiPM size, so that no photons can be detected coming from the sides.
It is used now as a default in the full-body PET geometry, instead of `SiPMpetFBK`, which is kept for now, but could be removed in the next future.