### PR TITLE
Clean up colour definitions

### DIFF
--- a/source/utils/Visibilities.h
+++ b/source/utils/Visibilities.h
@@ -13,54 +13,22 @@
 
 namespace nexus {
 
-  inline G4VisAttributes Yellow()
-  { G4Colour myColour; G4Colour::GetColour("yellow", myColour);
-    G4VisAttributes myAttr(myColour);
-    return myAttr;}
-  inline G4VisAttributes White()
-  { G4Colour myColour; G4Colour::GetColour("white", myColour);
-    G4VisAttributes myAttr(myColour);
-    return myAttr;}
-  inline G4VisAttributes Red()
-  { G4Colour myColour(1., 0., 0.); G4VisAttributes myAttr(myColour);
-    return myAttr;}
-  inline G4VisAttributes BloodRed()
-  { G4Colour myColour(.55, .09, .09); G4VisAttributes myAttr(myColour);
-    return myAttr;}
-  inline G4VisAttributes DarkGreen()
-  { G4Colour myColour(0., .6, 0.); G4VisAttributes myAttr(myColour);
-    return myAttr;}
-  inline G4VisAttributes LightGreen()
-  { G4Colour myColour(.6,.9,.2); G4VisAttributes myAttr(myColour);
-    return myAttr;}
-  inline G4VisAttributes DirtyWhite()
-  { G4Colour myColour(1., 1., .8); G4VisAttributes myAttr(myColour);
-    return myAttr;}
-  inline G4VisAttributes CopperBrown()
-  { G4Colour myColour(.72, .45, .20); G4VisAttributes myAttr(myColour);
-    return myAttr;}
-  inline G4VisAttributes Brown()
-  { G4Colour myColour(.93, .87, .80); G4VisAttributes myAttr(myColour);
-    return myAttr;}
-  inline G4VisAttributes Blue()
-  { G4Colour myColour(0., 0., 1.); G4VisAttributes myAttr(myColour);
-    return myAttr;}
-  inline G4VisAttributes LightBlue()
-  { G4Colour myColour(.6, .8, .79); G4VisAttributes myAttr(myColour);
-    return myAttr;}
-  inline G4VisAttributes Lilla()
-  { G4Colour myColour(.5,.5,.7); G4VisAttributes myAttr(myColour);
-    return myAttr;}
-  inline G4VisAttributes DarkGrey()
-  { G4Colour myColour(.3, .3, .3); G4VisAttributes myAttr(myColour);
-    return myAttr;}
-  inline G4VisAttributes LightGrey()
-  { G4Colour myColour(.7,.7,.7); G4VisAttributes myAttr(myColour);
-    return myAttr;}
-  inline G4VisAttributes TitaniumGrey()
-  { G4Colour myColour(.71, .69, .66); G4VisAttributes myAttr(myColour);
-    return myAttr;}
-
+  inline G4VisAttributes Yellow()       { return { G4Colour::Yellow() }; }
+  inline G4VisAttributes White()        { return { G4Colour::White () }; }
+  inline G4VisAttributes Red()          { return { {1   ,  .0 ,  .0 } }; }
+  inline G4VisAttributes DarkRed()      { return { { .88,  .87,  .86} }; }
+  inline G4VisAttributes BloodRed()     { return { { .55,  .09,  .09} }; }
+  inline G4VisAttributes DarkGreen()    { return { { .0 ,  .6 ,  .0 } }; }
+  inline G4VisAttributes LightGreen()   { return { { .6 ,  .9 ,  .2 } }; }
+  inline G4VisAttributes DirtyWhite()   { return { {1   , 1   ,  .8 } }; }
+  inline G4VisAttributes CopperBrown()  { return { { .72,  .45,  .20} }; }
+  inline G4VisAttributes Brown()        { return { { .93,  .87,  .80} }; }
+  inline G4VisAttributes Blue()         { return { { .0 ,  .0 , 1   } }; }
+  inline G4VisAttributes LightBlue()    { return { { .6 ,  .8 ,  .79} }; }
+  inline G4VisAttributes Lilla()        { return { { .5 ,  .5 ,  .7 } }; }
+  inline G4VisAttributes DarkGrey()     { return { { .3 ,  .3 ,  .3 } }; }
+  inline G4VisAttributes LightGrey()    { return { { .7 ,  .7 ,  .7 } }; }
+  inline G4VisAttributes TitaniumGrey() { return { { .71,  .69,  .66} }; }
 
 }  // end namespace nexus
 


### PR DESCRIPTION
The colour definitions in `Visibilities.h` were unnecessarily convoluted.