### PR TITLE
Refactor Back2backGammas::GeneratePrimaryVertex

### DIFF
--- a/source/generators/Back2backGammas.cc
+++ b/source/generators/Back2backGammas.cc
@@ -81,7 +81,7 @@ namespace nexus {
     G4PrimaryVertex* vertex =
         new G4PrimaryVertex(position, time);
 
-    G4ParticleDefinition* particle_definition =
+    G4ParticleDefinition* gamma =
       G4ParticleTable::GetParticleTable()->FindParticle("gamma");
 
     if (costheta_min_ != -1. || costheta_max_ != 1. || phi_min_ != 0. || phi_max_ != 2.*pi) {

--- a/source/generators/Back2backGammas.cc
+++ b/source/generators/Back2backGammas.cc
@@ -83,16 +83,13 @@ namespace nexus {
 
     G4ParticleDefinition* particle_definition =
       G4ParticleTable::GetParticleTable()->FindParticle("gamma");
-    // Set masses to PDG values
-    G4double mass = particle_definition->GetPDGMass();
     // Set charges to PDG value
     G4double charge = particle_definition->GetPDGCharge();
 
     G4ThreeVector momentum_direction = G4RandomDirection();
 
     // Calculate cartesian components of momentum
-    G4double energy = 510.999*keV + mass;
-    G4double pmod = std::sqrt(energy*energy - mass*mass);
+    G4double pmod = 510.999*keV;
     G4double px = pmod * momentum_direction.x();
     G4double py = pmod * momentum_direction.y();
     G4double pz = pmod * momentum_direction.z();

--- a/source/generators/Back2backGammas.cc
+++ b/source/generators/Back2backGammas.cc
@@ -121,16 +121,10 @@ namespace nexus {
 
      G4PrimaryParticle* particle1 =
        new G4PrimaryParticle(particle_definition, px, py, pz);
-    particle1->SetMass(mass);
-    particle1->SetCharge(charge);
-    particle1->SetPolarization(0.,0.,0.);
     vertex->SetPrimary(particle1);
 
     G4PrimaryParticle* particle2 =
       new G4PrimaryParticle(particle_definition, -px, -py, -pz);
-    particle2->SetMass(mass);
-    particle2->SetCharge(charge);
-    particle2->SetPolarization(0.,0.,0.);
     vertex->SetPrimary(particle2);
 
     evt->AddPrimaryVertex(vertex);

--- a/source/generators/Back2backGammas.cc
+++ b/source/generators/Back2backGammas.cc
@@ -100,22 +100,22 @@ namespace nexus {
     if (costheta_min_ != -1. || costheta_max_ != 1. || phi_min_ != 0. || phi_max_ != 2.*pi) {
       G4bool mom_dir = false;
       while (mom_dir == false) {
-	G4double cosTheta  = 2.*G4UniformRand()-1.;
-	if (cosTheta > costheta_min_ && cosTheta < costheta_max_){
-	  G4double sinTheta2 = 1. - cosTheta*cosTheta;
-	  if( sinTheta2 < 0.)  sinTheta2 = 0.;
-	  G4double sinTheta  = std::sqrt(sinTheta2);
-	  G4double phi = twopi*G4UniformRand();
-	  if (phi > phi_min_ && phi < phi_max_){
-	    mom_dir = true;
-	    momentum_direction = G4ThreeVector(sinTheta*std::cos(phi),
-					       sinTheta*std::sin(phi),
+        G4double cosTheta  = 2.*G4UniformRand()-1.;
+        if (cosTheta > costheta_min_ && cosTheta < costheta_max_){
+          G4double sinTheta2 = 1. - cosTheta*cosTheta;
+          if( sinTheta2 < 0.)  sinTheta2 = 0.;
+          G4double sinTheta  = std::sqrt(sinTheta2);
+          G4double phi = twopi*G4UniformRand();
+          if (phi > phi_min_ && phi < phi_max_){
+            mom_dir = true;
+            momentum_direction = G4ThreeVector(sinTheta*std::cos(phi),
+                                               sinTheta*std::sin(phi),
                                                cosTheta).unit();
-	    px = pmod * momentum_direction.x();
-	    py = pmod * momentum_direction.y();
-	    pz = pmod * momentum_direction.z();
-	  }
-	}
+            px = pmod * momentum_direction.x();
+            py = pmod * momentum_direction.y();
+            pz = pmod * momentum_direction.z();
+          }
+        }
       }
     }
 

--- a/source/generators/Back2backGammas.cc
+++ b/source/generators/Back2backGammas.cc
@@ -74,7 +74,6 @@ namespace nexus {
 
   void Back2backGammas::GeneratePrimaryVertex(G4Event* evt)
   {
-
     // Ask the geometry to generate a position for the particle
 
     if (costheta_min_ != -1. || costheta_max_ != 1. || phi_min_ != 0. || phi_max_ != 2.*pi) {
@@ -96,13 +95,10 @@ namespace nexus {
       }
     }
 
-
     auto position = geom_->GenerateVertex(region_);
     auto time = 0 * sec;
     auto vertex = new G4PrimaryVertex(position, time);
-
     auto gamma = G4ParticleTable::GetParticleTable()->FindParticle("gamma");
-
     auto p = 510.999*keV * G4RandomDirection();
 
     vertex->SetPrimary(new G4PrimaryParticle(gamma,  p.x(),  p.y(),  p.z()));

--- a/source/generators/Back2backGammas.cc
+++ b/source/generators/Back2backGammas.cc
@@ -84,14 +84,6 @@ namespace nexus {
     G4ParticleDefinition* particle_definition =
       G4ParticleTable::GetParticleTable()->FindParticle("gamma");
 
-    G4ThreeVector momentum_direction = G4RandomDirection();
-
-    // Calculate cartesian components of momentum
-    G4double pmod = 510.999*keV;
-    G4double px = pmod * momentum_direction.x();
-    G4double py = pmod * momentum_direction.y();
-    G4double pz = pmod * momentum_direction.z();
-
     if (costheta_min_ != -1. || costheta_max_ != 1. || phi_min_ != 0. || phi_max_ != 2.*pi) {
       G4bool mom_dir = false;
       while (mom_dir == false) {
@@ -106,13 +98,18 @@ namespace nexus {
             momentum_direction = G4ThreeVector(sinTheta*std::cos(phi),
                                                sinTheta*std::sin(phi),
                                                cosTheta).unit();
-            px = pmod * momentum_direction.x();
-            py = pmod * momentum_direction.y();
-            pz = pmod * momentum_direction.z();
           }
         }
       }
     }
+
+    G4ThreeVector momentum_direction = G4RandomDirection();
+
+    // Calculate cartesian components of momentum
+    G4double pmod = 510.999*keV;
+    G4double px = pmod * momentum_direction.x();
+    G4double py = pmod * momentum_direction.y();
+    G4double pz = pmod * momentum_direction.z();
 
     vertex->SetPrimary(new G4PrimaryParticle(particle_definition,  px,  py,  pz));
     vertex->SetPrimary(new G4PrimaryParticle(particle_definition, -px, -py, -pz));

--- a/source/generators/Back2backGammas.cc
+++ b/source/generators/Back2backGammas.cc
@@ -114,13 +114,8 @@ namespace nexus {
       }
     }
 
-     G4PrimaryParticle* particle1 =
-       new G4PrimaryParticle(particle_definition, px, py, pz);
-    vertex->SetPrimary(particle1);
-
-    G4PrimaryParticle* particle2 =
-      new G4PrimaryParticle(particle_definition, -px, -py, -pz);
-    vertex->SetPrimary(particle2);
+    vertex->SetPrimary(new G4PrimaryParticle(particle_definition,  px,  py,  pz));
+    vertex->SetPrimary(new G4PrimaryParticle(particle_definition, -px, -py, -pz));
 
     evt->AddPrimaryVertex(vertex);
 

--- a/source/generators/Back2backGammas.cc
+++ b/source/generators/Back2backGammas.cc
@@ -97,14 +97,13 @@ namespace nexus {
     }
 
 
-    G4ThreeVector position = geom_->GenerateVertex(region_);
-    G4double time = 0.;
-    G4PrimaryVertex* vertex = new G4PrimaryVertex(position, time);
+    auto position = geom_->GenerateVertex(region_);
+    auto time = 0 * sec;
+    auto vertex = new G4PrimaryVertex(position, time);
 
-    G4ParticleDefinition* gamma =
-      G4ParticleTable::GetParticleTable()->FindParticle("gamma");
+    auto gamma = G4ParticleTable::GetParticleTable()->FindParticle("gamma");
 
-    G4double p = 510.999*keV * G4RandomDirection();
+    auto p = 510.999*keV * G4RandomDirection();
 
     vertex->SetPrimary(new G4PrimaryParticle(gamma,  p.x(),  p.y(),  p.z()));
     vertex->SetPrimary(new G4PrimaryParticle(gamma, -p.x(), -p.y(), -p.z()));

--- a/source/generators/Back2backGammas.cc
+++ b/source/generators/Back2backGammas.cc
@@ -96,7 +96,7 @@ namespace nexus {
     }
 
     auto position = geom_->GenerateVertex(region_);
-    auto time = 0 * sec;
+    auto time = 0.;
     auto vertex = new G4PrimaryVertex(position, time);
     auto gamma = G4ParticleTable::GetParticleTable()->FindParticle("gamma");
     auto p = 510.999*keV * G4RandomDirection();

--- a/source/generators/Back2backGammas.cc
+++ b/source/generators/Back2backGammas.cc
@@ -74,15 +74,8 @@ namespace nexus {
 
   void Back2backGammas::GeneratePrimaryVertex(G4Event* evt)
   {
+
     // Ask the geometry to generate a position for the particle
-
-    G4ThreeVector position = geom_->GenerateVertex(region_);
-    G4double time = 0.;
-    G4PrimaryVertex* vertex =
-        new G4PrimaryVertex(position, time);
-
-    G4ParticleDefinition* gamma =
-      G4ParticleTable::GetParticleTable()->FindParticle("gamma");
 
     if (costheta_min_ != -1. || costheta_max_ != 1. || phi_min_ != 0. || phi_max_ != 2.*pi) {
       G4bool mom_dir = false;
@@ -103,10 +96,18 @@ namespace nexus {
       }
     }
 
+
+    G4ThreeVector position = geom_->GenerateVertex(region_);
+    G4double time = 0.;
+    G4PrimaryVertex* vertex = new G4PrimaryVertex(position, time);
+
+    G4ParticleDefinition* gamma =
+      G4ParticleTable::GetParticleTable()->FindParticle("gamma");
+
     G4double p = 510.999*keV * G4RandomDirection();
 
-    vertex->SetPrimary(new G4PrimaryParticle(particle_definition,  p.x(),  p.y(),  p.z()));
-    vertex->SetPrimary(new G4PrimaryParticle(particle_definition, -p.x(), -p.y(), -p.z()));
+    vertex->SetPrimary(new G4PrimaryParticle(gamma,  p.x(),  p.y(),  p.z()));
+    vertex->SetPrimary(new G4PrimaryParticle(gamma, -p.x(), -p.y(), -p.z()));
 
     evt->AddPrimaryVertex(vertex);
 

--- a/source/generators/Back2backGammas.cc
+++ b/source/generators/Back2backGammas.cc
@@ -103,16 +103,10 @@ namespace nexus {
       }
     }
 
-    G4ThreeVector momentum_direction = G4RandomDirection();
+    G4double p = 510.999*keV * G4RandomDirection();
 
-    // Calculate cartesian components of momentum
-    G4double pmod = 510.999*keV;
-    G4double px = pmod * momentum_direction.x();
-    G4double py = pmod * momentum_direction.y();
-    G4double pz = pmod * momentum_direction.z();
-
-    vertex->SetPrimary(new G4PrimaryParticle(particle_definition,  px,  py,  pz));
-    vertex->SetPrimary(new G4PrimaryParticle(particle_definition, -px, -py, -pz));
+    vertex->SetPrimary(new G4PrimaryParticle(particle_definition,  p.x(),  p.y(),  p.z()));
+    vertex->SetPrimary(new G4PrimaryParticle(particle_definition, -p.x(), -p.y(), -p.z()));
 
     evt->AddPrimaryVertex(vertex);
 

--- a/source/generators/Back2backGammas.cc
+++ b/source/generators/Back2backGammas.cc
@@ -76,6 +76,8 @@ namespace nexus {
   {
     // Ask the geometry to generate a position for the particle
 
+    G4ThreeVector momentum_direction = G4RandomDirection();
+
     if (costheta_min_ != -1. || costheta_max_ != 1. || phi_min_ != 0. || phi_max_ != 2.*pi) {
       G4bool mom_dir = false;
       while (mom_dir == false) {
@@ -99,7 +101,7 @@ namespace nexus {
     auto time = 0.;
     auto vertex = new G4PrimaryVertex(position, time);
     auto gamma = G4ParticleTable::GetParticleTable()->FindParticle("gamma");
-    auto p = 510.999*keV * G4RandomDirection();
+    auto p = 510.999*keV * momentum_direction;
 
     vertex->SetPrimary(new G4PrimaryParticle(gamma,  p.x(),  p.y(),  p.z()));
     vertex->SetPrimary(new G4PrimaryParticle(gamma, -p.x(), -p.y(), -p.z()));

--- a/source/generators/Back2backGammas.cc
+++ b/source/generators/Back2backGammas.cc
@@ -83,8 +83,6 @@ namespace nexus {
 
     G4ParticleDefinition* particle_definition =
       G4ParticleTable::GetParticleTable()->FindParticle("gamma");
-    // Set charges to PDG value
-    G4double charge = particle_definition->GetPDGCharge();
 
     G4ThreeVector momentum_direction = G4RandomDirection();
 


### PR DESCRIPTION
This PR thoroughly cleans up code generating back-to-back gammas.

Caveat: As the installation/development/testing environment I contributed to Nexus is not present on this branch, I have not had the time to actually compile, run and test this in its full glory and context (though I did verify the general principle in my own environment). Therefore someone else will have to compile, test, and fix any mistakes that might have crept in.

I have a suspicion that the original (pointlessly noisy) code has been copy-pasted in numerous places in Nexus (I have seen at least one with my own eyes). Moral of the story:

+ Don't copy-paste: abstract!
+ If you absolutely *must* copy-paste, then *think carefully* about the meaning of the code, and adapt it to your specific use-case, rather than bringing in truckloads of irrelevant junk.