### PR TITLE
Add DEMOPP psf generator

### DIFF
--- a/macros/DEMOPP_psf.config.mac
+++ b/macros/DEMOPP_psf.config.mac
@@ -1,0 +1,42 @@
+## ----------------------------------------------------------------------------
+## nexus | DEMOPP_psf.config.mac
+##
+## Configuration macro for psf generator.
+##
+##
+## The NEXT Collaboration
+## ----------------------------------------------------------------------------
+
+# VERBOSITY
+/run/verbose 1
+/event/verbose 0
+/tracking/verbose 0
+
+
+# GEOMETRY
+/Geometry/NextDemo/config run8
+/Geometry/NextDemo/elfield true
+/Geometry/NextDemo/pressure 8.5 bar
+/Geometry/NextDemo/max_step_size 1. mm
+/Geometry/NextDemo/EL_field_intensity 14 kV/cm
+/Geometry/NextDemo/max_step_size 1. mm
+/Geometry/PmtR11410/time_binning 100. nanosecond
+/Geometry/SiPMSensl/time_binning 1. microsecond
+
+/process/optical/processActivation Cerenkov false
+
+# GENERATION
+/Generator/ScintGenerator/region EL_GAP
+/Generator/ScintGenerator/nphotons 1
+
+/Geometry/NextDemo/el_gap_gen_disk_diam  10.0 mm
+/Geometry/NextDemo/el_gap_gen_disk_x      0.0 mm
+/Geometry/NextDemo/el_gap_gen_disk_y      0.0 mm
+/Geometry/NextDemo/el_gap_gen_disk_zmin   0.0
+/Geometry/NextDemo/el_gap_gen_disk_zmax   1.0
+
+# PERSISTENCY
+/nexus/persistency/outputFile demopp_psf_generation
+
+/nexus/random_seed 12345
+

--- a/macros/DEMOPP_psf.init.mac
+++ b/macros/DEMOPP_psf.init.mac
@@ -1,0 +1,24 @@
+## ----------------------------------------------------------------------------
+## nexus | DEMOPP_psf.init.mac
+##
+## Initialization macro to simulate scintillation photons from the 
+## el region inside a seteable cilinder.
+##
+## The NEXT Collaboration
+## ----------------------------------------------------------------------------
+
+
+/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
+/PhysicsList/RegisterPhysics G4DecayPhysics
+/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
+/PhysicsList/RegisterPhysics G4OpticalPhysics
+/PhysicsList/RegisterPhysics NexusPhysics
+/PhysicsList/RegisterPhysics G4StepLimiterPhysics
+
+/Geometry/RegisterGeometry NEXT_DEMO
+
+/Generator/RegisterGenerator SCINTILLATION
+
+/Actions/RegisterTrackingAction LIGHT_TABLE
+
+/nexus/RegisterMacro macros/DEMOPP_psf.config.mac

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -168,10 +168,6 @@ Next100FieldCage::Next100FieldCage():
                           "Maximum Z range of the EL gap vertex generation disk.");
   el_gap_gen_disk_zmax_cmd.SetParameterName("el_gap_gen_disk_zmax", false);
   el_gap_gen_disk_zmax_cmd.SetRange("el_gap_gen_disk_zmax>=0.0 && el_gap_gen_disk_zmax<=1.0");
-
-  if (el_gap_gen_disk_zmin_ > el_gap_gen_disk_zmax_)
-    G4Exception("[Next100FieldCage]", "Next100FieldCage()", FatalErrorInArgument,
-                "Error in configuration of EL gap generator: zmax < zmin");
 }
 
 
@@ -454,6 +450,10 @@ void Next100FieldCage::BuildELRegion()
                     "EL_GRID_ANODE", el_gap_logic, false, 1, false);
 
   // Vertex generator
+  if (el_gap_gen_disk_zmin_ > el_gap_gen_disk_zmax_)
+    G4Exception("[Next100FieldCage]", "Next100FieldCage()", FatalErrorInArgument,
+                "Error in configuration of EL gap generator: zmax < zmin");
+
   G4double el_gap_gen_disk_thickn =
     el_gap_length_ * (el_gap_gen_disk_zmax_ - el_gap_gen_disk_zmin_);
 

--- a/source/geometries/NextDemo.cc
+++ b/source/geometries/NextDemo.cc
@@ -7,7 +7,6 @@
 // -----------------------------------------------------------------------------
 
 #include "NextDemo.h"
-
 #include "NextDemoVessel.h"
 #include "NextDemoInnerElements.h"
 
@@ -114,9 +113,10 @@ G4ThreeVector NextDemo::GenerateVertex(const G4String& region) const
     G4ThreeVector displacement = G4ThreeVector(0., 0., -vessel_geom_->GetGateEndcapDistance());
     vtx = vtx + displacement;
   }
-  else if ( (region == "ACTIVE")  ||
-            (region == "TP_PLATE") ||
-            (region == "SIPM_BOARD") ) {
+  else if ((region == "ACTIVE")  ||
+           (region == "TP_PLATE") ||
+           (region == "SIPM_BOARD") ||
+           (region == "EL_GAP")) {
     vtx = inner_geom_->GenerateVertex(region);
     G4ThreeVector displacement = G4ThreeVector(0., 0., -vessel_geom_->GetGateEndcapDistance());
     vtx = vtx + displacement;

--- a/source/geometries/NextDemoFieldCage.h
+++ b/source/geometries/NextDemoFieldCage.h
@@ -115,9 +115,15 @@ namespace nexus {
 
     // Vertex generators
     CylinderPointSampler2020* active_gen_;
+    CylinderPointSampler2020* el_gap_gen_;
 
     // Messenger for the definition of control commands
     G4GenericMessenger* msg_;
+
+    // el generator params
+    G4double el_gap_gen_disk_diam_;
+    G4double el_gap_gen_disk_x_, el_gap_gen_disk_y_;
+    G4double el_gap_gen_disk_zmin_, el_gap_gen_disk_zmax_;
 
   };
 

--- a/source/geometries/NextDemoInnerElements.cc
+++ b/source/geometries/NextDemoInnerElements.cc
@@ -102,7 +102,8 @@ G4ThreeVector NextDemoInnerElements::GenerateVertex(const G4String& region) cons
   G4ThreeVector vertex(0.,0.,0.);
 
   // Field Cage
-  if (region == "ACTIVE") {
+  if ((region == "ACTIVE") ||
+      (region == "EL_GAP")) {
     vertex = field_cage_->GenerateVertex(region);
   }
 


### PR DESCRIPTION
This PR adds a PSF generator, consisting of a vertex generator from random points inside a cilinder in the EL_GAP region. The PR also solves the bug in the exception raised when zmin>zmax.

The generator is tested by comparing the DEMOPP-Run8 psf generated from AD_HOC emission points with this new generator. The results shows a matching between PSFs, but effects can be seen at low distances probably because the AD_HOC method is affected by border effects.

<img width="429" alt="Captura de pantalla 2021-04-19 a las 9 22 34" src="https://user-images.githubusercontent.com/35993868/115197008-d751f580-a0f0-11eb-9af7-699dadacd7a9.png">


