### PR TITLE
Change nexus interactive mode

### DIFF
--- a/macros/vis.mac
+++ b/macros/vis.mac
@@ -11,8 +11,8 @@
 
 ### Create an empty scene and a scene handles (OpenGL)
 /vis/scene/create
-/vis/open OGLIX
-/vis/viewer/create ! ! 900
+/vis/open OGL
+#/vis/viewer/create ! ! 900
 
 ### Setting drawing style to "wireframe" / "surface"
 /vis/viewer/set/style wireframe

--- a/source/nexus.cc
+++ b/source/nexus.cc
@@ -109,7 +109,7 @@ G4int main(int argc, char** argv)
 
   // visual mode
   if (!batch) {
-    std::unique_ptr<G4UIExecutive> ui{new G4UIExecutive{argc, argv}};
+    std::unique_ptr<G4UIExecutive> ui{new G4UIExecutive{1, argv}};
     std::unique_ptr<G4VisManager> visManager{new G4VisExecutive};
     visManager->Initialize();
     UI->ApplyCommand("/control/execute macros/vis.mac");

--- a/source/nexus.cc
+++ b/source/nexus.cc
@@ -8,17 +8,13 @@
 
 #include "NexusApp.h"
 
-#include <G4UImanager.hh>   
-#include <G4UIterminal.hh>  
-#include <G4UItcsh.hh> 
+#include <G4UImanager.hh>
+#include <G4UIExecutive.hh>
 #include <G4VisExecutive.hh>
 
 #include <getopt.h>
 
 using namespace nexus;
-
-
-
 
 
 void PrintUsage()
@@ -33,15 +29,14 @@ void PrintUsage()
 }
 
 
-
-G4int main(int argc, char** argv) 
+G4int main(int argc, char** argv)
 {
   ////////////////////////////////////////////////////////////////////
   // PARSE COMMAND-LINE OPTIONS
 
   // Abort if no command-line argument is provided. The user must
   // specify at least the name of a configuration macro.
-  if (argc < 2) PrintUsage(); 
+  if (argc < 2) PrintUsage();
 
   G4bool batch = true;
   G4int nevents = 0;
@@ -61,7 +56,7 @@ G4int main(int argc, char** argv)
     //  int option_index = 0;
     opterr = 0;
     c = getopt_long(argc, argv, "bin:", long_options, 0);
-    
+
     if (c==-1) break; // Exit if we are done reading options
 
     switch (c) {
@@ -89,8 +84,8 @@ G4int main(int argc, char** argv)
   // If there is no other command-line argument to be processed, abort
   // because the user has not provided a configuration macro.
   // (The variable optind is set by getopt_long to the index of the next
-  // element of the argv array to be processed. Once getopt has found all 
-  // of the option arguments, this variable can be used to determine where 
+  // element of the argv array to be processed. Once getopt has found all
+  // of the option arguments, this variable can be used to determine where
   // the remaining non-option arguments begin.)
   if (optind == argc) PrintUsage();
 
@@ -98,13 +93,10 @@ G4int main(int argc, char** argv)
   // command-line parameters that is not a GNU option.
   G4String macro_filename = argv[optind];
 
-  if (macro_filename == "") PrintUsage(); 
-    
-
+  if (macro_filename == "") PrintUsage();
 
   ////////////////////////////////////////////////////////////////////
 
-  
   NexusApp* app = new NexusApp(macro_filename);
   app->Initialize();
 
@@ -112,20 +104,18 @@ G4int main(int argc, char** argv)
 
   // if (seed < 0) CLHEP::HepRandom::setTheSeed(time(0));
   // else CLHEP::HepRandom::setTheSeed(seed);
-  
+
   // CLHEP::HepRandom::showEngineStatus();
 
   // visual mode
   if (!batch) {
-    G4VisManager* vismgr = new G4VisExecutive();
-    vismgr->Initialize();
-
-    G4UIsession* session = new G4UIterminal(new G4UItcsh);
+    G4UIExecutive* ui = new G4UIExecutive(argc, argv);
+    G4VisManager* visManager = new G4VisExecutive;
+    visManager->Initialize();
     UI->ApplyCommand("/control/execute macros/vis.mac");
-    session->SessionStart();
-
-    delete session;
-    delete vismgr;
+    ui->SessionStart();
+    delete ui;
+    delete visManager;
   }
   else {
     app->BeamOn(nevents);
@@ -133,4 +123,4 @@ G4int main(int argc, char** argv)
 
   delete app;
   return EXIT_SUCCESS;
-} 
+}

--- a/source/nexus.cc
+++ b/source/nexus.cc
@@ -109,13 +109,11 @@ G4int main(int argc, char** argv)
 
   // visual mode
   if (!batch) {
-    G4UIExecutive* ui = new G4UIExecutive(argc, argv);
-    G4VisManager* visManager = new G4VisExecutive;
+    std::unique_ptr<G4UIExecutive> ui{new G4UIExecutive{argc, argv}};
+    std::unique_ptr<G4VisManager> visManager{new G4VisExecutive};
     visManager->Initialize();
     UI->ApplyCommand("/control/execute macros/vis.mac");
     ui->SessionStart();
-    delete ui;
-    delete visManager;
   }
   else {
     app->BeamOn(nevents);


### PR DESCRIPTION
This change allows a more user-friendly interactive nexus visualization. In particular, it enables a Qt-based GUI (see Figure). The GUI is composed by a 3D mouse-interactive OGL viewer (up panel), a listing with the possible input commands (left panel) and a terminal where commands are launched (down panel).
To activate this GUI, Geant4 must be compiler with Qt (see G4 installation guide). The Figure shows an example of 100 photons generated in the EL_GAP for DEMOPP using the generator implemented in PR #96.

<img width="1437" alt="Captura de pantalla 2021-04-19 a las 9 43 24" src="https://user-images.githubusercontent.com/35993868/115200575-a7a4ec80-a0f4-11eb-8dcd-9d7c30739bed.png">

