### PR TITLE
Remove noise when running automatic tests

### DIFF
--- a/macros/NextFlex_fullKr.config.mac
+++ b/macros/NextFlex_fullKr.config.mac
@@ -68,11 +68,11 @@
 /Geometry/NextFlex/ics_thickness  12. cm
 
 # VERBOSITY
-/Geometry/NextFlex/verbosity          true
-/Geometry/NextFlex/fc_verbosity       true
-/Geometry/NextFlex/ep_verbosity       true
-/Geometry/NextFlex/tp_verbosity       true
-/Geometry/NextFlex/tp_sipm_verbosity  true
+/Geometry/NextFlex/verbosity          false
+/Geometry/NextFlex/fc_verbosity       false
+/Geometry/NextFlex/ep_verbosity       false
+/Geometry/NextFlex/tp_verbosity       false
+/Geometry/NextFlex/tp_sipm_verbosity  false
 
 # VISIBILITIES
 /Geometry/NextFlex/fc_visibility           true


### PR DESCRIPTION
This PR sets to false the parameters that control verbosity in NextFlex, so that less noise is produced when automatic tests run. The parameters are kept in the macro to show their usage.