### PR TITLE
New 3d vectors

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -304,7 +304,6 @@ for d in SRCDIR:
 env['CXXCOMSTR']  = "Compiling $SOURCE"
 env['LINKCOMSTR'] = "Linking $TARGET"
 
-
 LIBDIR = env['PREFIX'] + '/lib/nexus'
 libnexus = env.SharedLibrary(LIBDIR, src)
 
@@ -325,7 +324,7 @@ env.Execute(Chmod(w_prefix_dir+'/bin/nexus-config', 0o755))
 nexus = env.Program('bin/nexus', ['source/nexus.cc']+src)
 
 TSTDIR = ['utils',
-	  'example']
+	      'example']
 TSTDIR = ['source/tests/' + dir for dir in TSTDIR]
 
 tst = []

--- a/SConstruct
+++ b/SConstruct
@@ -324,7 +324,7 @@ env.Execute(Chmod(w_prefix_dir+'/bin/nexus-config', 0o755))
 nexus = env.Program('bin/nexus', ['source/nexus.cc']+src)
 
 TSTDIR = ['utils',
-	      'example']
+          'example']
 TSTDIR = ['source/tests/' + dir for dir in TSTDIR]
 
 tst = []

--- a/macros/NEW_geantino.config.mac
+++ b/macros/NEW_geantino.config.mac
@@ -15,7 +15,7 @@
 /Generator/SingleParticle/min_energy 1  eV
 /Generator/SingleParticle/max_energy 1 keV
 /Generator/SingleParticle/region AD_HOC
-/Geometry/NextNew/specific_vertex   0 0 100 mm
+/Geometry/NextNew/specific_vertex  0 0 100 mm
 
 # ACTIONS
 #/Actions/SaveAllSteppingAction/select_particle geantino

--- a/macros/NEW_geantino.config.mac
+++ b/macros/NEW_geantino.config.mac
@@ -15,9 +15,7 @@
 /Generator/SingleParticle/min_energy 1  eV
 /Generator/SingleParticle/max_energy 1 keV
 /Generator/SingleParticle/region AD_HOC
-/Geometry/NextNew/specific_vertex_X   0 mm
-/Geometry/NextNew/specific_vertex_Y   0 mm
-/Geometry/NextNew/specific_vertex_Z 100 mm
+/Geometry/NextNew/specific_vertex   0 0 100 mm
 
 # ACTIONS
 #/Actions/SaveAllSteppingAction/select_particle geantino

--- a/macros/NEXT100.singleMuon_200GeV.config.mac
+++ b/macros/NEXT100.singleMuon_200GeV.config.mac
@@ -24,9 +24,7 @@
 /Geometry/Next100/max_step_size 1. mm
 /Geometry/Next100/elfield false
 /Geometry/Next100/gas enrichedXe
-/Geometry/Next100/specific_vertex_X 0. mm
-/Geometry/Next100/specific_vertex_Y 2400. mm
-/Geometry/Next100/specific_vertex_Z 0. mm
+/Geometry/Next100/specific_vertex 0. 2400. 0. mm
 
 /control/execute macros/geometries/NEXT100DefaultVisibility.mac
 

--- a/macros/NEXT100.singleNeutron_2MeV.config.mac
+++ b/macros/NEXT100.singleNeutron_2MeV.config.mac
@@ -24,9 +24,7 @@
 /Geometry/Next100/max_step_size 1. mm
 /Geometry/Next100/elfield false
 /Geometry/Next100/gas enrichedXe
-/Geometry/Next100/specific_vertex_X 0. mm
-/Geometry/Next100/specific_vertex_Y 2400. mm
-/Geometry/Next100/specific_vertex_Z 0. mm
+/Geometry/Next100/specific_vertex 0. 2400. 0. mm
 
 /control/execute macros/geometries/NEXT100DefaultVisibility.mac
 

--- a/macros/NEXT100_S2_table.config.mac
+++ b/macros/NEXT100_S2_table.config.mac
@@ -20,9 +20,7 @@
 ##### GEOMETRY #####
 /Geometry/Next100/pressure 15. bar
 /Geometry/Next100/max_step_size 1. mm
-/Geometry/Next100/specific_vertex_X 0. mm
-/Geometry/Next100/specific_vertex_Y 0. mm
-/Geometry/Next100/specific_vertex_Z 0. mm
+/Geometry/Next100/specific_vertex 0. 0. 0. mm
 
 #### GENERATOR ####
 /Generator/ScintGenerator/nphotons 100000

--- a/macros/NEXT_options.config.mac
+++ b/macros/NEXT_options.config.mac
@@ -11,7 +11,7 @@
 ##### VERBOSITIES #####
 /run/verbose 0
 /event/verbose 0
-/tracking/verbose 0
+/tracking/verbose 1
 
 /process/em/verbose 0
 
@@ -22,6 +22,8 @@
 /Geometry/Next100/elfield false
 /Geometry/Next100/pressure 15. bar
 /Geometry/Next100/max_step_size 1. mm
+
+#/Geometry/Next100/specific_vertex 35 40 60 cm
 
 /Geometry/Next100/shielding_vis      false
 /Geometry/Next100/vessel_vis         false
@@ -61,6 +63,7 @@
 /Generator/IonGenerator/atomic_number 83
 /Generator/IonGenerator/mass_number 214
 /Generator/IonGenerator/region SAPPHIRE_WINDOW
+
 
 # Single Particle
 #/Generator/SingleParticle/particle e-

--- a/macros/NEXT_options.config.mac
+++ b/macros/NEXT_options.config.mac
@@ -11,7 +11,7 @@
 ##### VERBOSITIES #####
 /run/verbose 0
 /event/verbose 0
-/tracking/verbose 1
+/tracking/verbose 0
 
 /process/em/verbose 0
 

--- a/macros/NextFlex_fullKr.config.mac
+++ b/macros/NextFlex_fullKr.config.mac
@@ -89,9 +89,7 @@
 ### GENERATOR
 # Kripton
 /Generator/Kr83mGenerator/region  AD_HOC
-/Geometry/NextFlex/specific_vertex_X  0. mm
-/Geometry/NextFlex/specific_vertex_Y  0. mm
-/Geometry/NextFlex/specific_vertex_Z  580. mm
+/Geometry/NextFlex/specific_vertex  0. 0. 580. mm
 
 
 ### PHYSICS

--- a/macros/NextTonScale.config.mac
+++ b/macros/NextTonScale.config.mac
@@ -40,9 +40,7 @@
 ### GENERATOR
 # Single Particle
 /Generator/SingleParticle/region AD_HOC
-/Geometry/NextTonScale/specific_vertex_X 0. mm
-/Geometry/NextTonScale/specific_vertex_Y 0. mm
-/Geometry/NextTonScale/specific_vertex_Z 0. mm
+/Geometry/NextTonScale/specific_vertex 0. 0. 0. mm
 /Generator/SingleParticle/particle geantino
 /Generator/SingleParticle/min_energy 1. GeV
 /Generator/SingleParticle/max_energy 1. GeV

--- a/source/generators/MuonGenerator.h
+++ b/source/generators/MuonGenerator.h
@@ -55,10 +55,7 @@ namespace nexus {
 
     const GeometryBase* geom_; ///< Pointer to the detector geometry
 
-    G4double momentum_X_;
-    G4double momentum_Y_;
-    G4double momentum_Z_;
-
+    G4ThreeVector momentum_;
   };
 
 } // end namespace nexus

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -45,27 +45,15 @@ namespace nexus {
     central_nozzle_ypos_ (0. * cm),
     down_nozzle_ypos_ (-20. * cm),
     bottom_nozzle_ypos_(-53. * cm),
+    specific_vertex_{},
     lab_walls_(false)
   {
 
     msg_ = new G4GenericMessenger(this, "/Geometry/Next100/",
 				  "Control commands of geometry Next100.");
 
-    G4GenericMessenger::Command&  specific_vertex_X_cmd =
-      msg_->DeclareProperty("specific_vertex_X", specific_vertex_X_,
-                            "If region is AD_HOC, x coord of primary particles");
-    specific_vertex_X_cmd.SetParameterName("specific_vertex_X", true);
-    specific_vertex_X_cmd.SetUnitCategory("Length");
-    G4GenericMessenger::Command&  specific_vertex_Y_cmd =
-      msg_->DeclareProperty("specific_vertex_Y", specific_vertex_Y_,
-                            "If region is AD_HOC, y coord of primary particles");
-    specific_vertex_Y_cmd.SetParameterName("specific_vertex_Y", true);
-    specific_vertex_Y_cmd.SetUnitCategory("Length");
-    G4GenericMessenger::Command&  specific_vertex_Z_cmd =
-      msg_->DeclareProperty("specific_vertex_Z", specific_vertex_Z_,
-                            "If region is AD_HOC, z coord of primary particles");
-    specific_vertex_Z_cmd.SetParameterName("specific_vertex_Z", true);
-    specific_vertex_Z_cmd.SetUnitCategory("Length");
+    msg_->DeclarePropertyWithUnit("specific_vertex", "mm",  specific_vertex_,
+      "Set generation vertex.");
 
     msg_->DeclareProperty("lab_walls", lab_walls_, "Placement of Hall A walls");
 
@@ -236,8 +224,7 @@ namespace nexus {
     }
     else if (region == "AD_HOC") {
       // AD_HOC does not need to be shifted because it is passed by the user
-      vertex =
-	G4ThreeVector(specific_vertex_X_, specific_vertex_Y_, specific_vertex_Z_);
+      vertex = specific_vertex_;
       return vertex;
     }
     // Lab walls

--- a/source/geometries/Next100.h
+++ b/source/geometries/Next100.h
@@ -70,9 +70,7 @@ namespace nexus {
     G4GenericMessenger* msg_;
 
     /// Specific vertex for AD_HOC region
-    G4double specific_vertex_X_;
-    G4double specific_vertex_Y_;
-    G4double specific_vertex_Z_;
+    G4ThreeVector specific_vertex_;
 
     /// Position of gate in its mother volume
     G4double gate_zpos_in_vessel_;

--- a/source/geometries/Next100OpticalGeometry.cc
+++ b/source/geometries/Next100OpticalGeometry.cc
@@ -36,7 +36,8 @@ namespace nexus {
 						    pressure_(15. * bar),
 						    temperature_ (300 * kelvin),
 						    sc_yield_(25510. * 1/MeV),
-                                                    e_lifetime_(1000. * ms),
+                e_lifetime_(1000. * ms),
+                specific_vertex_{},
 						    gas_("naturalXe")
   {
     /// Messenger
@@ -64,21 +65,8 @@ namespace nexus {
     e_lifetime_cmd.SetUnitCategory("Time");
     e_lifetime_cmd.SetRange("e_lifetime>0.");
 
-    G4GenericMessenger::Command&  specific_vertex_X_cmd =
-      msg_->DeclareProperty("specific_vertex_X", specific_vertex_X_,
-                            "If region is AD_HOC, x coord of primary particles");
-    specific_vertex_X_cmd.SetParameterName("specific_vertex_X", true);
-    specific_vertex_X_cmd.SetUnitCategory("Length");
-    G4GenericMessenger::Command&  specific_vertex_Y_cmd =
-      msg_->DeclareProperty("specific_vertex_Y", specific_vertex_Y_,
-                            "If region is AD_HOC, y coord of primary particles");
-    specific_vertex_Y_cmd.SetParameterName("specific_vertex_Y", true);
-    specific_vertex_Y_cmd.SetUnitCategory("Length");
-    G4GenericMessenger::Command&  specific_vertex_Z_cmd =
-      msg_->DeclareProperty("specific_vertex_Z", specific_vertex_Z_,
-                            "If region is AD_HOC, z coord of primary particles");
-    specific_vertex_Z_cmd.SetParameterName("specific_vertex_Z", true);
-    specific_vertex_Z_cmd.SetUnitCategory("Length");
+    msg_->DeclarePropertyWithUnit("specific_vertex", "mm",  specific_vertex_,
+      "Set generation vertex.");
 
     msg_->DeclareProperty("gas", gas_, "Gas being used");
 
@@ -168,8 +156,7 @@ namespace nexus {
     G4ThreeVector vertex(0.,0.,0.);
     if (region == "AD_HOC") {
       // AD_HOC does not need to be shifted because it is passed by the user
-      vertex =
-	G4ThreeVector(specific_vertex_X_, specific_vertex_Y_, specific_vertex_Z_);
+      vertex = specific_vertex_;
       return vertex;
     }
     else {

--- a/source/geometries/Next100OpticalGeometry.h
+++ b/source/geometries/Next100OpticalGeometry.h
@@ -48,9 +48,7 @@ namespace nexus {
     G4double e_lifetime_;
 
     // Vertex decided by user
-    G4double specific_vertex_X_;
-    G4double specific_vertex_Y_;
-    G4double specific_vertex_Z_;
+    G4ThreeVector specific_vertex_;
 
     G4String gas_;
 

--- a/source/geometries/Next1EL.cc
+++ b/source/geometries/Next1EL.cc
@@ -124,7 +124,8 @@ Next1EL::Next1EL():
   // DEFAULT VALUES FOR SOME PARAMETERS///////////
   max_step_size_(1.*mm),
   sc_yield_(13889/MeV),
-  e_lifetime_(1000.*ms)
+  e_lifetime_(1000.*ms),
+  specific_vertex_{}
 {
 
   msg_ = new G4GenericMessenger(this, "/Geometry/Next1EL/",
@@ -158,22 +159,8 @@ Next1EL::Next1EL():
   e_lifetime_cmd.SetUnitCategory("Time");
   e_lifetime_cmd.SetRange("e_lifetime>0.");
 
-  /// Temporary
-  G4GenericMessenger::Command&  specific_vertex_X_cmd =
-    msg_->DeclareProperty("specific_vertex_X", specific_vertex_X_,
-   			  "If region is AD_HOC, x coord where particles are generated");
-  specific_vertex_X_cmd.SetParameterName("specific_vertex_X", true);
-  specific_vertex_X_cmd.SetUnitCategory("Length");
-  G4GenericMessenger::Command&  specific_vertex_Y_cmd =
-    msg_->DeclareProperty("specific_vertex_Y", specific_vertex_Y_,
-   			  "If region is AD_HOC, y coord where particles are generated");
-  specific_vertex_Y_cmd.SetParameterName("specific_vertex_Y", true);
-  specific_vertex_Y_cmd.SetUnitCategory("Length");
-  G4GenericMessenger::Command&  specific_vertex_Z_cmd =
-    msg_->DeclareProperty("specific_vertex_Z", specific_vertex_Z_,
-   			  "If region is AD_HOC, z coord where particles are generated");
-  specific_vertex_Z_cmd.SetParameterName("specific_vertex_Z", true);
-  specific_vertex_Z_cmd.SetUnitCategory("Length");
+  msg_->DeclarePropertyWithUnit("specific_vertex", "mm",  specific_vertex_,
+      "Set generation vertex.");
 
    // Other properties (dimension and dimensionless)
   G4GenericMessenger::Command& pressure_cmd =
@@ -249,9 +236,6 @@ void Next1EL::Construct()
     BuildSiPMTrackingPlane();
   else
     BuildPMTTrackingPlane();
-
-  G4ThreeVector v(specific_vertex_X_, specific_vertex_Y_, specific_vertex_Z_);
-  specific_vertex_ = v;
 
    // For EL Table generation
   idx_table_ = 0;

--- a/source/geometries/Next1EL.h
+++ b/source/geometries/Next1EL.h
@@ -163,7 +163,6 @@ namespace nexus {
     G4double elgrid_transparency_;
     G4double gate_transparency_;
     G4ThreeVector specific_vertex_;
-    G4double specific_vertex_X_, specific_vertex_Y_, specific_vertex_Z_;
     G4bool muonsGenerator_;
 
     // Positions in the detector geometry relevant for event vertex generation

--- a/source/geometries/NextDemo.cc
+++ b/source/geometries/NextDemo.cc
@@ -26,7 +26,7 @@ REGISTER_CLASS(NextDemo, GeometryBase)
 NextDemo::NextDemo():
   GeometryBase(),
   lab_size_(10.*m),
-  specific_vertex_X_(0.), specific_vertex_Y_(0.), specific_vertex_Z_(0.),
+  specific_vertex_{},
   vessel_geom_(new NextDemoVessel),
   inner_geom_(new NextDemoInnerElements),
   msg_(nullptr)
@@ -34,23 +34,8 @@ NextDemo::NextDemo():
   msg_ = new G4GenericMessenger(this, "/Geometry/NextDemo/",
                                 "Control commands of geometry NextDemo.");
 
-  G4GenericMessenger::Command&  specific_vertex_X_cmd =
-    msg_->DeclareProperty("specific_vertex_X", specific_vertex_X_,
-                          "If region is AD_HOC, x coord where particles are generated");
-  specific_vertex_X_cmd.SetParameterName("specific_vertex_X", true);
-  specific_vertex_X_cmd.SetUnitCategory("Length");
-
-  G4GenericMessenger::Command&  specific_vertex_Y_cmd =
-    msg_->DeclareProperty("specific_vertex_Y", specific_vertex_Y_,
-                          "If region is AD_HOC, y coord where particles are generated");
-  specific_vertex_Y_cmd.SetParameterName("specific_vertex_Y", true);
-  specific_vertex_Y_cmd.SetUnitCategory("Length");
-
-  G4GenericMessenger::Command&  specific_vertex_Z_cmd =
-    msg_->DeclareProperty("specific_vertex_Z", specific_vertex_Z_,
-                            "If region is AD_HOC, z coord where particles are generated");
-  specific_vertex_Z_cmd.SetParameterName("specific_vertex_Z", true);
-  specific_vertex_Z_cmd.SetUnitCategory("Length");
+  msg_->DeclarePropertyWithUnit("specific_vertex", "mm",  specific_vertex_,
+      "Set generation vertex.");
 
 }
 
@@ -109,7 +94,7 @@ G4ThreeVector NextDemo::GenerateVertex(const G4String& region) const
   G4ThreeVector vtx;
 
   if (region == "AD_HOC") {
-    vtx = G4ThreeVector(specific_vertex_X_, specific_vertex_Y_, specific_vertex_Z_);
+    vtx = specific_vertex_;
   }
   else if (region == "CALIBRATION_SOURCE") {
     vtx = vessel_geom_->GenerateVertex("CALIBRATION_SOURCE");

--- a/source/geometries/NextDemo.h
+++ b/source/geometries/NextDemo.h
@@ -32,7 +32,7 @@ namespace nexus {
 
   private:
     const G4double lab_size_;
-    G4double specific_vertex_X_, specific_vertex_Y_, specific_vertex_Z_;
+    G4ThreeVector specific_vertex_;
     NextDemoVessel* vessel_geom_;
     NextDemoInnerElements* inner_geom_;
     G4GenericMessenger* msg_;

--- a/source/geometries/NextFlex.cc
+++ b/source/geometries/NextFlex.cc
@@ -50,9 +50,7 @@ NextFlex::NextFlex():
   sc_yield_          (25510. * 1 / MeV),
   e_lifetime_        (1000. * ms),
   ics_thickness_     (12. * cm),
-  adhoc_x_           (0.),              // Vertex-X in case of AD_HOC region
-  adhoc_y_           (0.),              // Vertex-Y in case of AD_HOC region
-  adhoc_z_           (0.)               // Vertex-Z in case of AD_HOC region
+  specific_vertex_{}
 {
 
   // Messenger
@@ -124,23 +122,8 @@ void NextFlex::DefineConfigurationParameters()
   e_lifetime_cmd.SetRange("e_lifetime>0.");
 
   // Specific vertex in case region to shoot from is AD_HOC
-  G4GenericMessenger::Command& adhoc_x_cmd =
-    msg_->DeclareProperty("specific_vertex_X", adhoc_x_,
-      "If region is AD_HOC, x coord where particles are generated");
-  adhoc_x_cmd.SetParameterName("specific_vertex_X", false);
-  adhoc_x_cmd.SetUnitCategory("Length");
-
-  G4GenericMessenger::Command& adhoc_y_cmd =
-    msg_->DeclareProperty("specific_vertex_Y", adhoc_y_,
-      "If region is AD_HOC, y coord where particles are generated");
-  adhoc_y_cmd.SetParameterName("specific_vertex_Y", false);
-  adhoc_y_cmd.SetUnitCategory("Length");
-
-  G4GenericMessenger::Command& adhoc_z_cmd =
-    msg_->DeclareProperty("specific_vertex_Z", adhoc_z_,
-      "If region is AD_HOC, z coord where particles are generated");
-  adhoc_z_cmd.SetParameterName("specific_vertex_Z", false);
-  adhoc_z_cmd.SetUnitCategory("Length");
+  msg_->DeclarePropertyWithUnit("specific_vertex", "mm",  specific_vertex_,
+      "Set generation vertex.");
 
   // ICS
   G4GenericMessenger::Command& ics_thickness_cmd =
@@ -309,7 +292,7 @@ G4ThreeVector NextFlex::GenerateVertex(const G4String& region) const
   G4ThreeVector vertex;
 
   if (region == "AD_HOC") {
-    vertex = G4ThreeVector(adhoc_x_, adhoc_y_, adhoc_z_);
+    vertex = specific_vertex_;
   }
 
   // ICS region

--- a/source/geometries/NextFlex.h
+++ b/source/geometries/NextFlex.h
@@ -95,7 +95,7 @@ namespace nexus {
     CylinderPointSampler2020* copper_gen_;
 
     // AD-HOC vertex
-    G4double adhoc_x_, adhoc_y_, adhoc_z_;
+    G4ThreeVector specific_vertex_;
   };
 
 } // end namespace nexus

--- a/source/geometries/NextNew.cc
+++ b/source/geometries/NextNew.cc
@@ -67,7 +67,8 @@ namespace nexus {
     disk_source_(false),
     source_mat_(""),
     source_dist_from_anode_(15.*cm),
-    pedestal_pos_(-568.*mm)
+    pedestal_pos_(-568.*mm),
+    specific_vertex_{}
     //   ext_source_distance_(0.*mm)
     // Buffer gas dimensions
   {
@@ -118,6 +119,9 @@ namespace nexus {
     source_dist_cmd.SetUnitCategory("Length");
     source_dist_cmd.SetParameterName("distance_from_anode", false);
     source_dist_cmd.SetRange("distance_from_anode>=0.");
+
+    msg_->DeclarePropertyWithUnit("specific_vertex", "mm",  specific_vertex_,
+      "Set generation vertex.");
 
     cal_ = new CalibrationSource();
 
@@ -546,7 +550,6 @@ namespace nexus {
              (region == "BUFFER") ||
              (region == "EL_GAP") ||
              (region == "EL_TABLE") ||
-             (region == "AD_HOC") ||
              (region == "CATHODE")||
              (region == "TRACKING_FRAMES") ||
              (region == "SUPPORT_PLATE") ||
@@ -554,15 +557,17 @@ namespace nexus {
              (region == "DB_PLUG")) {
       vertex = inner_elements_->GenerateVertex(region);
     }
+    // AD_HOC is not rotated and shifted because it is passed by the user
+    else if (region == "AD_HOC") {
+      return specific_vertex_;
+    }
     else {
       G4Exception("[NextNew]", "GenerateVertex()", FatalException,
 		  "Unknown vertex generation region!");
     }
 
-    // AD_HOC is not rotated and shifted because it is passed by the user
     // The LSC HallA vertices are already corrected so no need.
-    if ((region == "AD_HOC") ||
-        (region == "HALLA_OUTER") ||
+    if ((region == "HALLA_OUTER") ||
         (region == "HALLA_INNER"))
       return vertex;
 

--- a/source/geometries/NextNew.h
+++ b/source/geometries/NextNew.h
@@ -114,6 +114,8 @@ namespace nexus {
     G4ThreeVector extra_pos_; ///< position of the external elements outside the vessel, behind the tracking plane
 
     G4double pedestal_pos_;
+
+    G4ThreeVector specific_vertex_;
   };
 
 } // end namespace nexus

--- a/source/geometries/NextNewFieldCage.cc
+++ b/source/geometries/NextNewFieldCage.cc
@@ -130,22 +130,6 @@ namespace nexus {
     step_cmd.SetParameterName("max_step_size", false);
     step_cmd.SetRange("max_step_size>0.");
 
-    G4GenericMessenger::Command&  specific_vertex_X_cmd =
-      msg_->DeclareProperty("specific_vertex_X", specific_vertex_X_,
-			    "If region is AD_HOC, x coord where particles are generated");
-    specific_vertex_X_cmd.SetParameterName("specific_vertex_X", true);
-    specific_vertex_X_cmd.SetUnitCategory("Length");
-    G4GenericMessenger::Command&  specific_vertex_Y_cmd =
-      msg_->DeclareProperty("specific_vertex_Y", specific_vertex_Y_,
-			    "If region is AD_HOC, y coord where particles are generated");
-    specific_vertex_Y_cmd.SetParameterName("specific_vertex_Y", true);
-    specific_vertex_Y_cmd.SetUnitCategory("Length");
-    G4GenericMessenger::Command&  specific_vertex_Z_cmd =
-      msg_->DeclareProperty("specific_vertex_Z", specific_vertex_Z_,
-			    "If region is AD_HOC, z coord where particles are generated");
-    specific_vertex_Z_cmd.SetParameterName("specific_vertex_Z", true);
-    specific_vertex_Z_cmd.SetUnitCategory("Length");
-
     G4GenericMessenger::Command&  ELtransv_diff_cmd =
       msg_->DeclareProperty("ELtransv_diff", ELtransv_diff_,
 			    "Tranvsersal diffusion in the EL region");
@@ -806,9 +790,6 @@ void NextNewFieldCage::BuildBuffer()
     }
     else if (region == "TRACKING_FRAMES") {
       vertex = tracking_frames_gen_->GenerateVertex("BODY_VOL");
-    }
-    else if (region == "AD_HOC") {
-      vertex = G4ThreeVector(specific_vertex_X_, specific_vertex_Y_, specific_vertex_Z_);
     }
     else if (region == "EL_TABLE") {
       unsigned int i = el_table_point_id_ + el_table_index_;

--- a/source/geometries/NextNewFieldCage.h
+++ b/source/geometries/NextNewFieldCage.h
@@ -124,10 +124,6 @@ namespace nexus {
     CylinderPointSampler* cathode_gen_;
     CylinderPointSampler* tracking_frames_gen_;
 
-    G4double specific_vertex_X_;
-    G4double specific_vertex_Y_;
-    G4double specific_vertex_Z_;
-
     // Messenger for the definition of control commands
     G4GenericMessenger* msg_;
 

--- a/source/geometries/NextTonScale.cc
+++ b/source/geometries/NextTonScale.cc
@@ -44,7 +44,7 @@ NextTonScale::NextTonScale():
   xe_perc_(100.), helium_mass_num_(4),
   tank_vis_(true), vessel_vis_(true), ics_vis_(true),
   fcage_vis_(true), cathode_vis_(true), anode_vis_(true), readout_vis_(true),
-  specific_vertex_X_(0.), specific_vertex_Y_(0.), specific_vertex_Z_(0.),
+  specific_vertex_{},
   active_gen_(nullptr), field_cage_gen_(nullptr), cathode_gen_(nullptr),
   ics_gen_(nullptr), vessel_gen_(nullptr), readout_plane_gen_(nullptr),
   outer_plane_gen_(nullptr), external_gen_(nullptr), muon_gen_(nullptr)
@@ -409,7 +409,7 @@ G4ThreeVector NextTonScale::GenerateVertex(const G4String& region) const
   G4ThreeVector vertex;
 
   if (region == "AD_HOC") {
-    vertex = G4ThreeVector(specific_vertex_X_, specific_vertex_Y_, specific_vertex_Z_);
+    vertex = specific_vertex_;
   }
   else if (region == "ACTIVE") {
     vertex = active_gen_->GenerateVertex("BODY_VOL");
@@ -528,23 +528,8 @@ void NextTonScale::DefineConfigurationParameters()
   water_thickn_cmd.SetRange("water_thickn>=0.");
 
   // Specific vertex in case region to shoot from is AD_HOC
-  G4GenericMessenger::Command& specific_vertex_X_cmd =
-    msg_->DeclareProperty("specific_vertex_X", specific_vertex_X_,
-      "If region is AD_HOC, x coord where particles are generated");
-  specific_vertex_X_cmd.SetParameterName("specific_vertex_X", true);
-  specific_vertex_X_cmd.SetUnitCategory("Length");
-
-  G4GenericMessenger::Command& specific_vertex_Y_cmd =
-    msg_->DeclareProperty("specific_vertex_Y", specific_vertex_Y_,
-      "If region is AD_HOC, y coord where particles are generated");
-  specific_vertex_Y_cmd.SetParameterName("specific_vertex_Y", true);
-  specific_vertex_Y_cmd.SetUnitCategory("Length");
-
-  G4GenericMessenger::Command& specific_vertex_Z_cmd =
-    msg_->DeclareProperty("specific_vertex_Z", specific_vertex_Z_,
-      "If region is AD_HOC, z coord where particles are generated");
-  specific_vertex_Z_cmd.SetParameterName("specific_vertex_Z", true);
-  specific_vertex_Z_cmd.SetUnitCategory("Length");
+  msg_->DeclarePropertyWithUnit("specific_vertex", "mm",  specific_vertex_,
+    "Set generation vertex.");
 
   // Percentage xenon for mixtures /////////////////////////
   G4GenericMessenger::Command& Xe_percent_cmd =

--- a/source/geometries/NextTonScale.h
+++ b/source/geometries/NextTonScale.h
@@ -59,7 +59,7 @@ namespace nexus {
     G4bool tank_vis_, vessel_vis_, ics_vis_,
            fcage_vis_, cathode_vis_, anode_vis_, readout_vis_;
 
-    G4double specific_vertex_X_, specific_vertex_Y_, specific_vertex_Z_;
+    G4ThreeVector specific_vertex_;
 
     CylinderPointSampler* active_gen_;
     CylinderPointSampler* field_cage_gen_;

--- a/tests/pytest/produce_output_test.py
+++ b/tests/pytest/produce_output_test.py
@@ -220,11 +220,8 @@ def test_create_nexus_output_file_flex100(config_tmpdir, output_tmpdir, NEXUSDIR
 /Generator/SingleParticle/particle       e-
 /Generator/SingleParticle/min_energy     100. keV
 /Generator/SingleParticle/max_energy     100. keV
-/Generator/SingleParticle/region         CENTER
 /Generator/SingleParticle/region         AD_HOC
-/Geometry/NextFlex/specific_vertex_X     0. mm
-/Geometry/NextFlex/specific_vertex_Y     0. mm
-/Geometry/NextFlex/specific_vertex_Z     500. mm
+/Geometry/NextFlex/specific_vertex       0. 0. 500. mm
 
 /nexus/persistency/outputFile {output_tmpdir}/{full_base_name_flex100}
 /nexus/random_seed 21051817
@@ -285,9 +282,7 @@ def test_create_nexus_output_file_demopp(config_tmpdir, output_tmpdir, NEXUSDIR,
 /Geometry/NextDemo/pressure 10. bar
 /Geometry/NextDemo/sc_yield 10000 1/MeV
 
-/Geometry/NextDemo/specific_vertex_X 0. mm
-/Geometry/NextDemo/specific_vertex_Y 0. mm
-/Geometry/NextDemo/specific_vertex_Z 10. cm
+/Geometry/NextDemo/specific_vertex 0. 0. 10. cm
 
 /Generator/SingleParticle/particle e-
 /Generator/SingleParticle/min_energy 100. keV


### PR DESCRIPTION
This PR adapts the code to using a 3-D vector instead of three different coordinates, when a specific vertex or momentum is passed by the user via configuration parameter.

It also changes the way the `AD_HOC` vertex is implemented in the `NEW` geometry, to make it similar to the rest of the geometries.