### PR TITLE
Next100 shielding revision

### DIFF
--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -190,7 +190,8 @@ namespace nexus {
              (region == "INNER_AIR") ||
              (region == "SHIELDING_STRUCT") ||
              (region == "PEDESTAL") ||
-             (region == "BUBBLE_SEAL")) {
+             (region == "BUBBLE_SEAL") ||
+             (region == "EDPM_SEAL")) {
       vertex = shielding_->GenerateVertex(region);
     }
     // Vessel regions

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -189,7 +189,8 @@ namespace nexus {
              (region == "EXTERNAL") ||
              (region == "INNER_AIR") ||
              (region == "SHIELDING_STRUCT") ||
-             (region == "PEDESTAL")) {
+             (region == "PEDESTAL") ||
+             (region == "BUBBLE_SEAL")) {
       vertex = shielding_->GenerateVertex(region);
     }
     // Vessel regions

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -188,7 +188,8 @@ namespace nexus {
              (region == "SHIELDING_STEEL") ||
              (region == "EXTERNAL") ||
              (region == "INNER_AIR") ||
-             (region == "SHIELDING_STRUCT") ) {
+             (region == "SHIELDING_STRUCT") ||
+             (region == "PEDESTAL")) {
       vertex = shielding_->GenerateVertex(region);
     }
     // Vessel regions

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -185,7 +185,7 @@ namespace nexus {
     G4Box* air_box_solid = new G4Box("INNER_AIR", shield_x_/2., shield_y_/2., shield_z_/2.);
 
     air_box_logic_ = new G4LogicalVolume(air_box_solid,
-                                			   G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"),
+                                         G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"),
                                 			   "INNER_AIR");
 
     ////Limit the uStepMax=Maximum step length, uTrakMax=Maximum total track length,
@@ -222,36 +222,37 @@ namespace nexus {
     // Creating the vertex generators   //////////
     //lead_gen_  = new BoxPointSampler(steel_x, steel_y, steel_z, lead_thickness_, G4ThreeVector(0.,0.,0.), 0);
     // Only shooting from the innest 5 cm.
-    lead_gen_  = new BoxPointSampler(steel_x, steel_y, steel_z, 5.*cm, G4ThreeVector(0.,0.,0.), 0);
+    lead_gen_  = new BoxPointSampler(steel_x, steel_y, steel_z, 5.*cm,
+                                     G4ThreeVector(0.,0.,0.), 0);
 
     G4double ext_offset = 1. * cm;
-    external_gen_ = new BoxPointSampler(lead_x_ + ext_offset, lead_y_ + ext_offset, lead_z_ + ext_offset,
-                                        1. * mm, G4ThreeVector(0.,0.,0.), 0);
-
+    external_gen_ = new BoxPointSampler(lead_x_ + ext_offset, lead_y_ + ext_offset, lead_z_ + ext_offset, 1. * mm,
+                                        G4ThreeVector(0.,0.,0.), 0);
 
     steel_gen_ = new BoxPointSampler(shield_x_, shield_y_, shield_z_, steel_thickness_,
                                      G4ThreeVector(0.,0.,0.), 0);
 
     G4double inn_offset = .5 * cm;
-    inner_air_gen_ = new BoxPointSampler(shield_x_ - inn_offset, shield_y_ - inn_offset, shield_z_ - inn_offset,
-                                         1. * mm, G4ThreeVector(0.,0.,0.), 0);
+    inner_air_gen_ = new BoxPointSampler(shield_x_ - inn_offset, shield_y_ - inn_offset, shield_z_ - inn_offset, 1. * mm,
+                                         G4ThreeVector(0.,0.,0.), 0);
 
+    lat_roof_gen_ = new BoxPointSampler(lead_thickness_, beam_base_thickness_, shield_z_ + 2.*steel_thickness_, 0.,
+                                        G4ThreeVector(0., shield_y_/2. + steel_thickness_ + beam_base_thickness_/2., 0.), 0);
 
-    lat_roof_gen_ =
-      new BoxPointSampler(lead_thickness_,beam_base_thickness_,shield_z_,0.,
-			  G4ThreeVector(0.,shield_y_/2.+steel_thickness_/2.,0.),0);
-    front_roof_gen_ =
-      new BoxPointSampler(lead_x_,beam_base_thickness_,lead_thickness_,0.,
-			  G4ThreeVector(0.,shield_y_/2.+steel_thickness_/2.,0.),0);
-    // struct_gen_=;
-    struct_x_gen_ = new BoxPointSampler((shield_x_+2*lead_thickness_+2*steel_thickness_), lead_thickness_, beam_base_thickness_,0.,
-					G4ThreeVector(0.,top_beam_y,roof_z_separation_+lateral_z_separation_/2),0);
-    struct_z_gen_ = new BoxPointSampler( beam_base_thickness_, lead_thickness_ -1.*mm, shield_z_+2*lead_thickness_+2*steel_thickness_,0.,
-					 G4ThreeVector(-front_x_separation_/2.,top_beam_y, 0.), 0);
-    lat_beam_gen_ = new BoxPointSampler(lead_thickness_, shield_y_+steel_thickness_,beam_base_thickness_,0.,
-					G4ThreeVector(lat_beam_x,-beam_base_thickness_/2.,lateral_z_separation_/2.),0);
-    front_beam_gen_ = new BoxPointSampler(beam_base_thickness_, shield_y_+steel_thickness_,lead_thickness_,0.,
-					G4ThreeVector(-front_x_separation_/2.,-beam_base_thickness_/2.,front_beam_z),0);
+    front_roof_gen_ = new BoxPointSampler(lead_x_, beam_base_thickness_, lead_thickness_, 0.,
+                                          G4ThreeVector(0., shield_y_/2. + steel_thickness_ + beam_base_thickness_/2., 0.), 0);
+
+    struct_x_gen_ = new BoxPointSampler(shield_x_ + 2.*lead_thickness_ + 2.*steel_thickness_, lead_thickness_ - beam_base_thickness_, beam_base_thickness_, 0.,
+                                        G4ThreeVector(0., top_beam_y, roof_z_separation_+lateral_z_separation_/2.), 0);
+
+    struct_z_gen_ = new BoxPointSampler(beam_base_thickness_, lead_thickness_ - beam_base_thickness_, shield_z_ + 2.*lead_thickness_ + 2.*steel_thickness_, 0.,
+                                        G4ThreeVector(-front_x_separation_/2., top_beam_y, 0.), 0);
+
+    lat_beam_gen_ = new BoxPointSampler(lead_thickness_, shield_y_ + 2. * steel_thickness_+ lead_thickness_, beam_base_thickness_, 0.,
+                                        G4ThreeVector(lat_beam_x, -lead_thickness_/2., lateral_z_separation_/2.), 0);
+
+    front_beam_gen_ = new BoxPointSampler(beam_base_thickness_, shield_y_ + 2. * steel_thickness_+ lead_thickness_, lead_thickness_, 0.,
+                                          G4ThreeVector(-front_x_separation_/2., -lead_thickness_/2., front_beam_z), 0);
 
 
     // Calculating some probs
@@ -261,13 +262,15 @@ namespace nexus {
     //std::cout<<"TOP STRUCT VOLUME "<<struct_top_vol<<std::endl;
     G4double lateral_vol = lat_beam_solid->GetCubicVolume();
     //std::cout<<"LAT BEAM STRUCT VOLUME "<<lateral_vol<<"\t TOTAL LATERAL BEAMS VOL "<<8*lateral_vol<<std::endl;
-    G4double total_vol = roof_vol+struct_top_vol+(8*lateral_vol);
+    G4double total_vol = roof_vol + struct_top_vol + (8*lateral_vol);
     //std::cout<<"TOTAL STRUCTURE VOLUME "<<total_vol<<std::endl;
 
-    perc_roof_vol_ = roof_vol/total_vol;
-    perc_front_roof_vol_ = 2*(lead_x_*beam_base_thickness_*lead_thickness_) /roof_vol;
+    perc_roof_vol_       = roof_vol/total_vol;
+    perc_front_roof_vol_ = 2*(lead_x_*beam_base_thickness_*lead_thickness_)/roof_vol;
     perc_top_struct_vol_ = struct_top_vol /total_vol;
-    perc_struc_x_vol_ = 4*((shield_x_+2*lead_thickness_+2*steel_thickness_)*lead_thickness_*beam_base_thickness_)/struct_top_vol;
+
+    G4double lat_beam_x_vol = (shield_x_ + 2.*lead_thickness_ + 2.*steel_thickness_)*(lead_thickness_ - beam_base_thickness_)*beam_base_thickness_;
+    perc_struc_x_vol_    = 4*lat_beam_x_vol/struct_top_vol;
 
     // std::cout<<"SHIELDING LEAD VOLUME:\t"<<lead_box_solid->GetCubicVolume()<<std::endl;
     // std::cout<<"SHIELDING STEEL VOLUME:\t"<<steel_box_solid->GetCubicVolume()<<std::endl;
@@ -306,17 +309,17 @@ namespace nexus {
     G4ThreeVector vertex(0., 0., 0.);
 
     if (region == "SHIELDING_LEAD") {
-      G4VPhysicalVolume *VertexVolume;
-      do {
-	vertex = lead_gen_->GenerateVertex("WHOLE_VOL");
-	// To check its volume, one needs to rotate and shift the vertex
-	// because the check is done using global coordinates
-	G4ThreeVector glob_vtx(vertex);
-	// First rotate, then shift
-	glob_vtx.rotate(pi, G4ThreeVector(0., 1., 0.));
-	glob_vtx = glob_vtx + G4ThreeVector(0, 0, GetELzCoord());
-	VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
-      } while (VertexVolume->GetName() != "LEAD_BOX");
+        G4VPhysicalVolume *VertexVolume;
+        do {
+          	vertex = lead_gen_->GenerateVertex("WHOLE_VOL");
+          	// To check its volume, one needs to rotate and shift the vertex
+          	// because the check is done using global coordinates
+          	G4ThreeVector glob_vtx(vertex);
+          	// First rotate, then shift
+          	glob_vtx.rotate(pi, G4ThreeVector(0., 1., 0.));
+          	glob_vtx = glob_vtx + G4ThreeVector(0, 0, GetELzCoord());
+          	VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
+        } while (VertexVolume->GetName() != "LEAD_BOX");
     }
 
     else if (region == "SHIELDING_STEEL") {
@@ -331,116 +334,115 @@ namespace nexus {
       vertex = external_gen_->GenerateVertex("WHOLE_VOL");
     }
     else if(region=="SHIELDING_STRUCT"){
-      G4double rand = G4UniformRand();
+        G4double rand = G4UniformRand();
 
-      if (rand < perc_roof_vol_) { //ROOF BEAM STRUCTURE
-      	// G4VPhysicalVolume *VertexVolume;
-      	// do {
-      	if (G4UniformRand() <  perc_front_roof_vol_){
-      	  if (G4UniformRand() < 0.5) {
-      	    vertex = front_roof_gen_->GenerateVertex("INSIDE");
-      	    vertex.setZ(vertex.z() + (shield_z_/2.+steel_thickness_+lead_thickness_/2.));
-	    // std::cout<<"frontal +"<<std::endl;
-      	  }
-      	  else{
-      	    vertex = front_roof_gen_->GenerateVertex("INSIDE");
-      	    vertex.setZ(vertex.z() - (shield_z_/2.+steel_thickness_+lead_thickness_/2.));
-      	    // std::cout<<"frontal -"<<std::endl;
-      	  }
-      	}
-      	else{
-      	  if (G4UniformRand() < 0.5) {
-      	    vertex = lat_roof_gen_->GenerateVertex("INSIDE");
-      	    vertex.setX(vertex.x() + ( shield_x_/2.+ steel_thickness_ + lead_thickness_/2.));
-      	    // std::cout<<"lateral +"<<std::endl;
-      	  }
-      	  else{
-      	    vertex = lat_roof_gen_->GenerateVertex("INSIDE");
-      	    vertex.setX(vertex.x() - ( shield_x_/2.+ steel_thickness_ + lead_thickness_/2.));
-      	    // std::cout<<"lateral -"<<std::endl;
-      	  }
-      	}
-      	// VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(vertex, 0, false);
-      	// } while (VertexVolume->GetName() != "STEEL_BEAM_ROOF");
-      }
+        if (rand < perc_roof_vol_) { //ROOF BEAM STRUCTURE
+        	// G4VPhysicalVolume *VertexVolume;
+        	// do {
+        	if (G4UniformRand() <  perc_front_roof_vol_){
+          	  if (G4UniformRand() < 0.5) {
+          	    vertex = front_roof_gen_->GenerateVertex("INSIDE");
+          	    vertex.setZ(vertex.z() + (shield_z_/2.+steel_thickness_+lead_thickness_/2.));
+    	          // std::cout<<"frontal +"<<std::endl;
+          	  }
+          	  else{
+          	    vertex = front_roof_gen_->GenerateVertex("INSIDE");
+          	    vertex.setZ(vertex.z() - (shield_z_/2.+steel_thickness_+lead_thickness_/2.));
+          	    // std::cout<<"frontal -"<<std::endl;
+          	  }
+        	}
+        	else{
+          	  if (G4UniformRand() < 0.5) {
+          	    vertex = lat_roof_gen_->GenerateVertex("INSIDE");
+          	    vertex.setX(vertex.x() + (shield_x_/2.+ steel_thickness_ + lead_thickness_/2.));
+          	    // std::cout<<"lateral +"<<std::endl;
+          	  }
+          	  else{
+          	    vertex = lat_roof_gen_->GenerateVertex("INSIDE");
+          	    vertex.setX(vertex.x() - (shield_x_/2.+ steel_thickness_ + lead_thickness_/2.));
+          	    // std::cout<<"lateral -"<<std::endl;
+          	  }
+        	}
+        	// VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(vertex, 0, false);
+        	// } while (VertexVolume->GetName() != "STEEL_BEAM_ROOF");
+        }
 
-      else if (rand < perc_top_struct_vol_) { //TOP BEAM STRUCTURE
-	G4double random = G4UniformRand();
-	if (random <  perc_struc_x_vol_){
-	  G4double rand_beam = int (4* G4UniformRand());
-	  if (rand_beam == 0) {
-	    vertex = struct_x_gen_->GenerateVertex("INSIDE");
-	  }
-	  else if (rand_beam == 1) {
-	    vertex = struct_x_gen_->GenerateVertex("INSIDE");
-	    vertex.setZ(vertex.z()-roof_z_separation_);
-	  }
-	  else if (rand_beam == 2) {
-	    vertex = struct_x_gen_->GenerateVertex("INSIDE");
-	    vertex.setZ(vertex.z()-(roof_z_separation_+lateral_z_separation_));
-	  }
-	  else if (rand_beam == 3) {
-	    vertex = struct_x_gen_->GenerateVertex("INSIDE");
-	    vertex.setZ(vertex.z()-(2*roof_z_separation_+lateral_z_separation_));
-	  }
-	}
-	else {
-	  if (G4UniformRand() < 0.5) {
-	    vertex = struct_z_gen_->GenerateVertex("INSIDE");
-	  }
-	  else {
-	    vertex = struct_z_gen_->GenerateVertex("INSIDE");
-	    vertex.setX(vertex.x()+front_x_separation_);
-	  }
-	}
-      }
+        else if (rand < (perc_top_struct_vol_ + perc_roof_vol_)) { //TOP BEAM STRUCTURE
+            	G4double random = G4UniformRand();
+            	if (random <  perc_struc_x_vol_){
+            	  G4double rand_beam = int (4* G4UniformRand());
+            	  if (rand_beam == 0) {
+            	    vertex = struct_x_gen_->GenerateVertex("INSIDE");
+            	  }
+            	  else if (rand_beam == 1) {
+            	    vertex = struct_x_gen_->GenerateVertex("INSIDE");
+            	    vertex.setZ(vertex.z()-roof_z_separation_);
+            	  }
+            	  else if (rand_beam == 2) {
+            	    vertex = struct_x_gen_->GenerateVertex("INSIDE");
+            	    vertex.setZ(vertex.z()-(roof_z_separation_+lateral_z_separation_));
+            	  }
+            	  else if (rand_beam == 3) {
+            	    vertex = struct_x_gen_->GenerateVertex("INSIDE");
+            	    vertex.setZ(vertex.z()-(2*roof_z_separation_+lateral_z_separation_));
+            	  }
+            	}
+            	else {
+            	  if (G4UniformRand() < 0.5) {
+            	    vertex = struct_z_gen_->GenerateVertex("INSIDE");
+            	  }
+            	  else {
+            	    vertex = struct_z_gen_->GenerateVertex("INSIDE");
+            	    vertex.setX(vertex.x()+front_x_separation_);
+            	  }
+              }
+        }
 
-      else{    //LATERAL BEAM STRUCTURE
-	G4double rand_beam = int (8 * G4UniformRand());
-	// std::cout<< "viga numero "<<rand_beam<<std::endl; //0-7
-	if (rand_beam == 0) {
-	  //lat_1 (lat_beam_x,-beam_base_thickness_/2.,lateral_z_separation_/2.)
-	  vertex = lat_beam_gen_->GenerateVertex("INSIDE");
-	}
-	else if (rand_beam ==1){
-	  // //lat_2 (lat_beam_x,-beam_base_thickness_/2.,-lateral_z_separation_/2.)
-	  vertex = lat_beam_gen_->GenerateVertex("INSIDE");
-	  vertex.setZ(vertex.z() -lateral_z_separation_);
-	}
-	else if (rand_beam ==2){
-	  // //lat_3 	(-lat_beam_x,-beam_base_thickness_/2.,lateral_z_separation_/2.)
-	  vertex = lat_beam_gen_->GenerateVertex("INSIDE");
-	  vertex.setX(vertex.x() -(shield_x_ + 2*steel_thickness_ + lead_thickness_ ));
-	}
-	else if (rand_beam ==3){
-	  // //lat_4 (-lat_beam_x,-beam_base_thickness_/2.,-lateral_z_separation_/2.)
-	  vertex = lat_beam_gen_->GenerateVertex("INSIDE");
-	  vertex.setX(vertex.x() -(shield_x_ + 2*steel_thickness_ + lead_thickness_ ));
-	  vertex.setZ(vertex.z() -lateral_z_separation_);
-	}
-	else if (rand_beam ==4){
-	  // //lat_5 front_beam (-front_x_separation_/2.,-beam_base_thickness_/2.,front_beam_z)
-	  vertex = front_beam_gen_->GenerateVertex("INSIDE");
-	}
-	else if (rand_beam ==5){
-	  // //lat_6 front_beam (front_x_separation_/2.,-beam_base_thickness_/2.,front_beam_z)
-	  vertex = front_beam_gen_->GenerateVertex("INSIDE");
-	  vertex.setX(vertex.x() + front_x_separation_);
-	}
-	else if (rand_beam ==6){
-	  // //lat_7 front_beam (-front_x_separation_/2.,-beam_base_thickness_/2.,-front_beam_z)
-	  vertex = front_beam_gen_->GenerateVertex("INSIDE");
-	  vertex.setZ(vertex.z() -(shield_z_+2*steel_thickness_+lead_thickness_));
-	}
-	else if (rand_beam ==7){
-	  //lat_8 front_beam (front_x_separation_/2.,-beam_base_thickness_/2.,-front_beam_z)
-	  vertex = front_beam_gen_->GenerateVertex("INSIDE");
-	  vertex.setX(vertex.x() + front_x_separation_);
-	  vertex.setZ(vertex.z() -(shield_z_+2*steel_thickness_+lead_thickness_));
-	}
-      }
-
-    }
+        else{    //LATERAL BEAM STRUCTURE
+            	G4double rand_beam = int (8 * G4UniformRand());
+            	// std::cout<< "viga numero "<<rand_beam<<std::endl; //0-7
+            	if (rand_beam == 0) {
+            	  //lat_1 (lat_beam_x,-beam_base_thickness_/2.,lateral_z_separation_/2.)
+            	  vertex = lat_beam_gen_->GenerateVertex("INSIDE");
+            	}
+            	else if (rand_beam ==1){
+            	  // //lat_2 (lat_beam_x,-beam_base_thickness_/2.,-lateral_z_separation_/2.)
+            	  vertex = lat_beam_gen_->GenerateVertex("INSIDE");
+            	  vertex.setZ(vertex.z() - lateral_z_separation_);
+            	}
+            	else if (rand_beam ==2){
+            	  // //lat_3 	(-lat_beam_x,-beam_base_thickness_/2.,lateral_z_separation_/2.)
+            	  vertex = lat_beam_gen_->GenerateVertex("INSIDE");
+            	  vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ + lead_thickness_));
+            	}
+            	else if (rand_beam ==3){
+            	  // //lat_4 (-lat_beam_x,-beam_base_thickness_/2.,-lateral_z_separation_/2.)
+            	  vertex = lat_beam_gen_->GenerateVertex("INSIDE");
+            	  vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ + lead_thickness_));
+            	  vertex.setZ(vertex.z() - lateral_z_separation_);
+            	}
+            	else if (rand_beam ==4){
+            	  // //lat_5 front_beam (-front_x_separation_/2.,-beam_base_thickness_/2.,front_beam_z)
+            	  vertex = front_beam_gen_->GenerateVertex("INSIDE");
+            	}
+            	else if (rand_beam ==5){
+            	  // //lat_6 front_beam (front_x_separation_/2.,-beam_base_thickness_/2.,front_beam_z)
+            	  vertex = front_beam_gen_->GenerateVertex("INSIDE");
+            	  vertex.setX(vertex.x() + front_x_separation_);
+            	}
+            	else if (rand_beam ==6){
+            	  // //lat_7 front_beam (-front_x_separation_/2.,-beam_base_thickness_/2.,-front_beam_z)
+            	  vertex = front_beam_gen_->GenerateVertex("INSIDE");
+            	  vertex.setZ(vertex.z() - (shield_z_+2*steel_thickness_+lead_thickness_));
+            	}
+            	else if (rand_beam ==7){
+            	  //lat_8 front_beam (front_x_separation_/2.,-beam_base_thickness_/2.,-front_beam_z)
+            	  vertex = front_beam_gen_->GenerateVertex("INSIDE");
+            	  vertex.setX(vertex.x() + front_x_separation_);
+            	  vertex.setZ(vertex.z() - (shield_z_+2*steel_thickness_+lead_thickness_));
+            	}
+            }
+        }
     else {
       G4Exception("[Next100Shielding]", "GenerateVertex()", FatalException,
 		  "Unknown vertex generation region!");

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -36,26 +36,24 @@ namespace nexus {
     GeometryBase(),
 
     // Shielding internal dimensions
-    shield_x_ (155.  * cm),
-    shield_y_ (225.6 * cm),
-    shield_z_ (258.5 * cm), // 253.0 * cm before May 12, 2017
+    shield_x_ (158.  * cm),
+    shield_y_ (166.  * cm),
+    shield_z_ (259.4 * cm),
 
     //Steel Structure
-    beam_base_thickness_ (4. *mm),
-    lateral_z_separation_ (1006. *mm), //distance between the two lateral beams
-    roof_z_separation_ (755. *mm), //distance between 1st and 2nd roof beams
-    front_x_separation_ (154.*mm), //distance between the two front beams
+    beam_base_thickness_ (4.   * mm),
+    lateral_z_separation_(1010.* mm), //distance between the two lateral beams
+    roof_z_separation_   (760. * mm), //distance between x beams
+    front_x_separation_  (156. * mm), //distance between the two front beams
     // Box thickness
     lead_thickness_ (20. * cm),
-    steel_thickness_ (6. * mm),
+    steel_thickness_(2.0 * mm),
     visibility_ (0)
 
   {
-
     /// Shielding is compound by two boxes, the external made of lead,
     /// and the internal, made of a mix of Steel & Titanium
     /// The Steel beam structure is placed inside the lead
-
 
     /// Messenger
     msg_ = new G4GenericMessenger(this, "/Geometry/Next100/", "Control commands of geometry Next100.");
@@ -70,8 +68,6 @@ namespace nexus {
 
   void Next100Shielding::Construct()
   {
-    // Auxiliary solids
-    //   G4Box* shielding_box_solid = new G4Box("SHIELD_BOX", shield_x_/2., shield_y_/2., shield_z_/2.);
 
     // LEAD BOX   ///////////
     lead_x_ = shield_x_ + 2. * steel_thickness_ + 2. * lead_thickness_;
@@ -86,92 +82,90 @@ namespace nexus {
     this->SetLogicalVolume(lead_box_logic);
 
     //STEEL BEAM STRUCTURE
-    //auxiliar positions
-    G4double lat_beam_x = shield_x_/2.+ steel_thickness_ + lead_thickness_/2.;
-    G4double front_beam_z = shield_z_/2.+steel_thickness_+lead_thickness_/2.;
-    //   G4double frontz = front_beam_z - (roof_z_separation_+lateral_z_separation_/2.);
-    G4double top_beam_y = shield_y_/2.+ steel_thickness_ + lead_thickness_/2.;
+    // auxiliar positions used in translations
+    G4double lat_beam_x   = shield_x_/2. + steel_thickness_ + lead_thickness_/2.;
+    G4double front_beam_z = shield_z_/2. + steel_thickness_ + lead_thickness_/2.;
+    G4double top_beam_y   = shield_y_/2. + steel_thickness_ + (lead_thickness_ + beam_base_thickness_)/2.;
 
-    G4Box* roof_beam = new G4Box("STRUCT_BEAM",lead_x_/2.,beam_base_thickness_/2.,lead_z_/2.);
-    G4Box* aux_box = new G4Box("AUX_box",shield_x_/2.+ steel_thickness_,beam_base_thickness_,shield_z_/2.+ steel_thickness_);
-    G4SubtractionSolid* roof_beam_solid = new G4SubtractionSolid("STRUCT_BEAM",roof_beam,aux_box,0,G4ThreeVector(0.,0.,0.));
+    G4Box* roof_beam = new G4Box("STRUCT_BEAM", lead_x_/2.                     , beam_base_thickness_/2., lead_z_/2.);
+    G4Box* aux_box   = new G4Box("AUX_box"    , shield_x_/2. + steel_thickness_, beam_base_thickness_   , shield_z_/2.+ steel_thickness_);
+    G4SubtractionSolid* roof_beam_solid = new G4SubtractionSolid("STRUCT_BEAM", roof_beam, aux_box);
 
-    G4Box* lat_beam_solid = new G4Box("STRUCT_BEAM",
-				      lead_thickness_/2.,
-				      shield_y_/2.+steel_thickness_/2.,
-				      beam_base_thickness_/2.);
+    G4Box* lat_beam_solid  = new G4Box("STRUCT_BEAM",
+                                       lead_thickness_/2.,
+                                       (shield_y_ + 2. * steel_thickness_+ lead_thickness_)/2.,
+                                       beam_base_thickness_/2.);
+
     G4Box* top_xbeam_solid = new G4Box("STRUCT_BEAM",
-				      shield_x_/2.+lead_thickness_+steel_thickness_,
-				      lead_thickness_/2.,
-				      beam_base_thickness_/2.);
+                                       (shield_x_ + 2.*lead_thickness_ + 2.*steel_thickness_)/2.,
+                                       (lead_thickness_ - beam_base_thickness_)/2.,
+                                       beam_base_thickness_/2.);
+
     G4Box* top_zbeam_solid = new G4Box("STRUCT_BEAM",
-				       beam_base_thickness_/2.,
-				       lead_thickness_/2. -1.*mm,
-				       shield_z_/2.+lead_thickness_+steel_thickness_);
-    G4UnionSolid* struct_solid = new G4UnionSolid("STEEL_BEAM1_STRUCTURE",top_xbeam_solid,top_zbeam_solid,
-						  0,G4ThreeVector(-front_x_separation_/2.,0.,
-								  -(roof_z_separation_+lateral_z_separation_/2.)));
-    struct_solid = new G4UnionSolid("STEEL_BEAM2_STRUCTURE",struct_solid,top_xbeam_solid,
-      				    0,G4ThreeVector(0.,0., -roof_z_separation_));
-    struct_solid = new G4UnionSolid("STEEL_BEAM3_STRUCTURE",struct_solid,top_xbeam_solid,
-       				    0,G4ThreeVector(0.,0., -(roof_z_separation_+lateral_z_separation_)));
-    struct_solid = new G4UnionSolid("STEEL_BEAM4_STRUCTURE",struct_solid,top_xbeam_solid,
-       				    0, G4ThreeVector(0.,0., -(2*roof_z_separation_+lateral_z_separation_)));
-    struct_solid = new G4UnionSolid("STEEL_BEAM5_STRUCTURE",struct_solid,top_zbeam_solid,
-     				    0,G4ThreeVector(front_x_separation_/2.,0.,
-      						    -(roof_z_separation_+lateral_z_separation_/2.)));
+                                       beam_base_thickness_/2.,
+                                       (lead_thickness_ - beam_base_thickness_)/2.,
+                                       (shield_z_ + 2.*lead_thickness_ + 2.*steel_thickness_)/2.);
+
+    // top beams
+    // x beams
+    G4UnionSolid* struct_solid = new G4UnionSolid("STEEL_BEAM_STRUCTURE_top1", top_xbeam_solid, top_xbeam_solid, 0,
+                                                  G4ThreeVector(0., 0., -roof_z_separation_));
+
+    struct_solid = new G4UnionSolid("STEEL_BEAM_STRUCTURE_top2", struct_solid, top_xbeam_solid, 0,
+                                    G4ThreeVector(0., 0., -(roof_z_separation_ + lateral_z_separation_)));
+
+    struct_solid = new G4UnionSolid("STEEL_BEAM_STRUCTURE_top3", struct_solid, top_xbeam_solid, 0,
+                                    G4ThreeVector(0., 0., -(2*roof_z_separation_ + lateral_z_separation_)));
+    // z beams
+    struct_solid = new G4UnionSolid("STEEL_BEAM_STRUCTURE_top4", struct_solid, top_zbeam_solid, 0,
+                                    G4ThreeVector(-front_x_separation_/2., 0., -(roof_z_separation_+lateral_z_separation_/2.)));
+
+    struct_solid = new G4UnionSolid("STEEL_BEAM_STRUCTURE_top5", struct_solid, top_zbeam_solid, 0,
+                                    G4ThreeVector(front_x_separation_/2., 0., -(roof_z_separation_+lateral_z_separation_/2.)));
 
 
-    G4LogicalVolume* roof_logic = new G4LogicalVolume(roof_beam_solid,
-      						      MaterialsList::Steel(),
-  						      "STEEL_BEAM_ROOF");
-    G4LogicalVolume* lat_beam_logic = new G4LogicalVolume(lat_beam_solid,
-     							  MaterialsList::Steel(),
- 							  "STEEL_BEAM_STRUCTURE_LAT");
-    G4LogicalVolume* struct_logic = new G4LogicalVolume(struct_solid,
-							MaterialsList::Steel(),
-							"STEEL_BEAM_STRUCTURE_TOP");
+    G4LogicalVolume* roof_logic      = new G4LogicalVolume(roof_beam_solid,
+                                                           MaterialsList::Steel(), "STEEL_BEAM_ROOF");
 
-    new G4PVPlacement(0,G4ThreeVector(0.,shield_y_/2.+steel_thickness_/2.,0.),roof_logic,"STEEL_BEAM_STRUCTURE_roof",
-		      lead_box_logic,false,0,false);
-    new G4PVPlacement(0,G4ThreeVector
-		      (lat_beam_x,-beam_base_thickness_/2.,lateral_z_separation_/2.)
-		      ,lat_beam_logic,"STEEL_BEAM_STRUCTURE_lat1",
-		      lead_box_logic,false,0,false);
-    new G4PVPlacement(0,G4ThreeVector
-		      (lat_beam_x,-beam_base_thickness_/2.,-lateral_z_separation_/2.)
-		      ,lat_beam_logic,"STEEL_BEAM_STRUCTURE_lat2",
-		      lead_box_logic,false,0,false);
-    new G4PVPlacement(0,G4ThreeVector
-		      (-lat_beam_x,-beam_base_thickness_/2.,lateral_z_separation_/2.)
-		      ,lat_beam_logic,"STEEL_BEAM_STRUCTURE_lat3",
-		      lead_box_logic,false,0,false);
-    new G4PVPlacement(0,G4ThreeVector
-		      (-lat_beam_x,-beam_base_thickness_/2.,-lateral_z_separation_/2.)
-		      ,lat_beam_logic,"STEEL_BEAM_STRUCTURE_lat4",
-		      lead_box_logic,false,0,false);
-    // //Rotate the beams
+    G4LogicalVolume* lat_beam_logic  = new G4LogicalVolume(lat_beam_solid,
+                                                           MaterialsList::Steel(), "STEEL_BEAM_STRUCTURE_LAT");
+
+     G4LogicalVolume* struct_logic   = new G4LogicalVolume(struct_solid,
+                                                           MaterialsList::Steel(), "STEEL_BEAM_STRUCTURE_TOP");
+
+    new G4PVPlacement(0, G4ThreeVector(0., top_beam_y, roof_z_separation_ + lateral_z_separation_/2.),
+                      struct_logic, "STEEL_BEAM_STRUCTURE_top", lead_box_logic, false, 0, false);
+
+    new G4PVPlacement(0, G4ThreeVector(0., shield_y_/2. + steel_thickness_ + beam_base_thickness_/2., 0.),
+                      roof_logic, "STEEL_BEAM_STRUCTURE_roof", lead_box_logic, false, 0, false);
+
+    // lateral beams
+    new G4PVPlacement(0, G4ThreeVector(lat_beam_x, -lead_thickness_/2., lateral_z_separation_/2.),
+              		    lat_beam_logic, "STEEL_BEAM_STRUCTURE_lat1", lead_box_logic, false, 0, false);
+
+    new G4PVPlacement(0, G4ThreeVector(lat_beam_x, -lead_thickness_/2., -lateral_z_separation_/2.),
+                      lat_beam_logic, "STEEL_BEAM_STRUCTURE_lat2", lead_box_logic, false, 0, false);
+
+    new G4PVPlacement(0, G4ThreeVector(-lat_beam_x, -lead_thickness_/2., lateral_z_separation_/2.),
+                      lat_beam_logic, "STEEL_BEAM_STRUCTURE_lat3", lead_box_logic, false, 0, false);
+
+    new G4PVPlacement(0, G4ThreeVector(-lat_beam_x, -lead_thickness_/2., -lateral_z_separation_/2.),
+                      lat_beam_logic, "STEEL_BEAM_STRUCTURE_lat4", lead_box_logic, false, 0, false);
+
+    // front beams
     G4RotationMatrix* rot_beam = new G4RotationMatrix();
     rot_beam->rotateY(pi/2.);
-    new G4PVPlacement(rot_beam,G4ThreeVector
-		      (-front_x_separation_/2.,-beam_base_thickness_/2.,front_beam_z)
-		      ,lat_beam_logic,"STEEL_BEAM_STRUCTURE_lat5",
-		      lead_box_logic,false,0,false);
-    new G4PVPlacement(rot_beam,G4ThreeVector
-		      (front_x_separation_/2.,-beam_base_thickness_/2.,front_beam_z)
-		      ,lat_beam_logic,"STEEL_BEAM_STRUCTURE_lat6",
-		      lead_box_logic,false,0,false);
-    new G4PVPlacement(rot_beam,G4ThreeVector
-		      (-front_x_separation_/2.,-beam_base_thickness_/2.,-front_beam_z)
-		      ,lat_beam_logic,"STEEL_BEAM_STRUCTURE_lat7",
-		      lead_box_logic,false,0,false);
-    new G4PVPlacement(rot_beam,G4ThreeVector
-		      (front_x_separation_/2.,-beam_base_thickness_/2.,-front_beam_z)
-		      ,lat_beam_logic,"STEEL_BEAM_STRUCTURE_lat8",
-		      lead_box_logic,false,0,false);
+    new G4PVPlacement(rot_beam, G4ThreeVector(-front_x_separation_/2., -lead_thickness_/2., front_beam_z),
+                      lat_beam_logic, "STEEL_BEAM_STRUCTURE_lat5", lead_box_logic, false, 0, false);
 
-    new G4PVPlacement(0,G4ThreeVector(0.,top_beam_y,roof_z_separation_+lateral_z_separation_/2.)
-		      ,struct_logic,"STEEL_BEAM_STRUCTURE_top", lead_box_logic,false,0,false);
+    new G4PVPlacement(rot_beam, G4ThreeVector(front_x_separation_/2., -lead_thickness_/2., front_beam_z),
+                      lat_beam_logic, "STEEL_BEAM_STRUCTURE_lat6", lead_box_logic, false, 0, false);
+
+    new G4PVPlacement(rot_beam, G4ThreeVector(-front_x_separation_/2., -lead_thickness_/2., -front_beam_z),
+                      lat_beam_logic, "STEEL_BEAM_STRUCTURE_lat7", lead_box_logic, false, 0, false);
+
+    new G4PVPlacement(rot_beam, G4ThreeVector(front_x_separation_/2., -lead_thickness_/2., -front_beam_z),
+                      lat_beam_logic,"STEEL_BEAM_STRUCTURE_lat8", lead_box_logic, false, 0, false);
 
 
     // STEEL BOX   ///////////
@@ -179,24 +173,20 @@ namespace nexus {
     G4double steel_y = shield_y_ + 2. * steel_thickness_;
     G4double steel_z = shield_z_ + 2. * steel_thickness_;
 
-    G4Box* steel_box_solid =
-      new G4Box("STEEL_BOX", steel_x/2., steel_y/2., steel_z/2.);
+    G4Box* steel_box_solid = new G4Box("STEEL_BOX", steel_x/2., steel_y/2., steel_z/2.);
 
     G4LogicalVolume* steel_box_logic = new G4LogicalVolume(steel_box_solid,
-							   MaterialsList::Steel(),
-							   "STEEL_BOX");
+                                                           MaterialsList::Steel(), "STEEL_BOX");
 
-    new G4PVPlacement(0, G4ThreeVector(0.,0.,0.), steel_box_logic,
-		      "STEEL_BOX", lead_box_logic, false, 0);
+    new G4PVPlacement(0, G4ThreeVector(0.,0.,0.),
+                      steel_box_logic, "STEEL_BOX", lead_box_logic, false, 0);
 
     // AIR INSIDE
-    G4Box* air_box_solid =
-      new G4Box("INNER_AIR", shield_x_/2., shield_y_/2., shield_z_/2.);
+    G4Box* air_box_solid = new G4Box("INNER_AIR", shield_x_/2., shield_y_/2., shield_z_/2.);
 
-    air_box_logic_ =
-      new G4LogicalVolume(air_box_solid,
-			  G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"),
-			  "INNER_AIR");
+    air_box_logic_ = new G4LogicalVolume(air_box_solid,
+                                			   G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"),
+                                			   "INNER_AIR");
 
     ////Limit the uStepMax=Maximum step length, uTrakMax=Maximum total track length,
     //uTimeMax= Maximum global time for a track, uEkinMin= Minimum remaining kinetic energy for a track
@@ -204,9 +194,8 @@ namespace nexus {
     air_box_logic_->SetUserLimits(new G4UserLimits( DBL_MAX, DBL_MAX, DBL_MAX,100.*keV,0.));
     air_box_logic_->SetVisAttributes(G4VisAttributes::Invisible);
 
-    new G4PVPlacement(0, G4ThreeVector(0.,0.,0.), air_box_logic_,
-		      "INNER_AIR", steel_box_logic, false, 0);
-
+    new G4PVPlacement(0, G4ThreeVector(0.,0.,0.),
+                      air_box_logic_, "INNER_AIR", steel_box_logic, false, 0);
 
 
     // SETTING VISIBILITIES   //////////
@@ -217,16 +206,16 @@ namespace nexus {
       steel_box_logic->SetVisAttributes(grey_col);
       G4VisAttributes antiox_col = nexus::BloodRed();
       //  antiox.SetForceSolid(true);
-      roof_logic->SetVisAttributes(antiox_col);
+      roof_logic    ->SetVisAttributes(antiox_col);
       lat_beam_logic->SetVisAttributes(antiox_col);
-      struct_logic->SetVisAttributes(antiox_col);
+      struct_logic  ->SetVisAttributes(antiox_col);
     }
     else {
-      lead_box_logic->SetVisAttributes(G4VisAttributes::Invisible);
+      lead_box_logic ->SetVisAttributes(G4VisAttributes::Invisible);
       steel_box_logic->SetVisAttributes(G4VisAttributes::Invisible);
-      roof_logic->SetVisAttributes(G4VisAttributes::Invisible);
-      struct_logic->SetVisAttributes(G4VisAttributes::Invisible);
-      lat_beam_logic->SetVisAttributes(G4VisAttributes::Invisible);
+      roof_logic     ->SetVisAttributes(G4VisAttributes::Invisible);
+      struct_logic   ->SetVisAttributes(G4VisAttributes::Invisible);
+      lat_beam_logic ->SetVisAttributes(G4VisAttributes::Invisible);
     }
 
 
@@ -263,7 +252,6 @@ namespace nexus {
 					G4ThreeVector(lat_beam_x,-beam_base_thickness_/2.,lateral_z_separation_/2.),0);
     front_beam_gen_ = new BoxPointSampler(beam_base_thickness_, shield_y_+steel_thickness_,lead_thickness_,0.,
 					G4ThreeVector(-front_x_separation_/2.,-beam_base_thickness_/2.,front_beam_z),0);
-
 
 
     // Calculating some probs
@@ -460,6 +448,5 @@ namespace nexus {
 
     return vertex;
   }
-
 
 } //end namespace nexus

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -105,12 +105,14 @@ namespace nexus {
     // auxiliar positions used in translations
     G4double lat_beam_x   = shield_x_/2. + steel_thickness_ + lead_thickness_/2.;
     G4double front_beam_z = shield_z_/2. + steel_thickness_ + lead_thickness_/2.;
-    G4double top_beam_y   = (shield_y_-beam_thickness_2)/2. + steel_thickness_ + beam_thickness_2 + lead_thickness_/2.;
+    G4double top_beam_y   = (shield_y_-beam_thickness_2)/2. + steel_thickness_ + beam_thickness_2
+                            + lead_thickness_/2.;
     G4double lat_beam_y   = -(lead_thickness_ + beam_thickness_2)/2.;
     G4double roof_y       = (shield_y_-beam_thickness_2)/2. + steel_thickness_ + beam_thickness_2/2.;
 
-    G4Box* roof_beam = new G4Box("STRUCT_BEAM", lead_x_/2.                     , beam_thickness_2/2., lead_z_/2.);
-    G4Box* aux_box   = new G4Box("AUX_box"    , shield_x_/2. + steel_thickness_, beam_thickness_2   , shield_z_/2.+ steel_thickness_);
+    G4Box* roof_beam = new G4Box("STRUCT_BEAM", lead_x_/2., beam_thickness_2/2., lead_z_/2.);
+    G4Box* aux_box   = new G4Box("AUX_box", shield_x_/2. + steel_thickness_, beam_thickness_2,
+                                 shield_z_/2.+ steel_thickness_);
     G4SubtractionSolid* roof_beam_solid = new G4SubtractionSolid("STRUCT_BEAM", roof_beam, aux_box);
 
     // vertical bottom beams
@@ -137,33 +139,38 @@ namespace nexus {
 
     // top beams
     // x beams
-    G4UnionSolid* struct_solid = new G4UnionSolid("STEEL_BEAM_STRUCTURE_top1", top_xbeam_solid, top_xbeam_solid, 0,
-                                                  G4ThreeVector(0., 0., -roof_z_separation_));
+    G4UnionSolid* struct_solid =
+      new G4UnionSolid("STEEL_BEAM_STRUCTURE_top1", top_xbeam_solid, top_xbeam_solid, 0,
+                       G4ThreeVector(0., 0., -roof_z_separation_));
 
-    struct_solid = new G4UnionSolid("STEEL_BEAM_STRUCTURE_top2", struct_solid, top_xbeam_solid, 0,
-                                    G4ThreeVector(0., 0., -(roof_z_separation_ + lateral_z_separation_)));
+    struct_solid =
+      new G4UnionSolid("STEEL_BEAM_STRUCTURE_top2", struct_solid, top_xbeam_solid, 0,
+                       G4ThreeVector(0., 0., -(roof_z_separation_ + lateral_z_separation_)));
 
-    struct_solid = new G4UnionSolid("STEEL_BEAM_STRUCTURE_top3", struct_solid, top_xbeam_solid, 0,
-                                    G4ThreeVector(0., 0., -(2*roof_z_separation_ + lateral_z_separation_)));
+    struct_solid =
+      new G4UnionSolid("STEEL_BEAM_STRUCTURE_top3", struct_solid, top_xbeam_solid, 0,
+                       G4ThreeVector(0., 0., -(2*roof_z_separation_ + lateral_z_separation_)));
     // z beams
-    struct_solid = new G4UnionSolid("STEEL_BEAM_STRUCTURE_top4", struct_solid, top_zbeam_solid, 0,
-                                    G4ThreeVector(-front_x_separation_/2., 0., -(roof_z_separation_+lateral_z_separation_/2.)));
+    struct_solid =
+      new G4UnionSolid("STEEL_BEAM_STRUCTURE_top4", struct_solid, top_zbeam_solid, 0,
+      G4ThreeVector(-front_x_separation_/2., 0., -(roof_z_separation_+lateral_z_separation_/2.)));
 
-    struct_solid = new G4UnionSolid("STEEL_BEAM_STRUCTURE_top5", struct_solid, top_zbeam_solid, 0,
-                                    G4ThreeVector(front_x_separation_/2., 0., -(roof_z_separation_+lateral_z_separation_/2.)));
+    struct_solid =
+      new G4UnionSolid("STEEL_BEAM_STRUCTURE_top5", struct_solid, top_zbeam_solid, 0,
+      G4ThreeVector(front_x_separation_/2., 0., -(roof_z_separation_+lateral_z_separation_/2.)));
 
 
     G4LogicalVolume* roof_logic      = new G4LogicalVolume(roof_beam_solid,
-                                                           MaterialsList::Steel(), "STEEL_BEAM_ROOF");
+                                           MaterialsList::Steel(), "STEEL_BEAM_ROOF");
 
     G4LogicalVolume* lat_beam_logic  = new G4LogicalVolume(lat_beam_solid,
-                                                           MaterialsList::Steel(), "STEEL_BEAM_STRUCTURE_LAT");
+                                           MaterialsList::Steel(), "STEEL_BEAM_STRUCTURE_LAT");
 
     G4LogicalVolume* front_beam_logic = new G4LogicalVolume(front_beam_solid,
-                                                            MaterialsList::Steel(), "STEEL_BEAM_STRUCTURE_FRONT");
+                                            MaterialsList::Steel(), "STEEL_BEAM_STRUCTURE_FRONT");
 
      G4LogicalVolume* struct_logic   = new G4LogicalVolume(struct_solid,
-                                                           MaterialsList::Steel(), "STEEL_BEAM_STRUCTURE_TOP");
+                                           MaterialsList::Steel(), "STEEL_BEAM_STRUCTURE_TOP");
 
     new G4PVPlacement(0, G4ThreeVector(0., top_beam_y, roof_z_separation_ + lateral_z_separation_/2.),
                       struct_logic, "STEEL_BEAM_STRUCTURE_top", lead_box_logic, false, 0, false);
@@ -186,16 +193,16 @@ namespace nexus {
 
     // front beams
     new G4PVPlacement(0, G4ThreeVector(-front_x_separation_/2., lat_beam_y, front_beam_z),
-                      front_beam_logic, "STEEL_BEAM_STRUCTURE_front1", lead_box_logic, false, 0, false);
+                  front_beam_logic, "STEEL_BEAM_STRUCTURE_front1", lead_box_logic, false, 0, false);
 
     new G4PVPlacement(0, G4ThreeVector(front_x_separation_/2., lat_beam_y, front_beam_z),
-                      front_beam_logic, "STEEL_BEAM_STRUCTURE_front2", lead_box_logic, false, 0, false);
+                  front_beam_logic, "STEEL_BEAM_STRUCTURE_front2", lead_box_logic, false, 0, false);
 
     new G4PVPlacement(0, G4ThreeVector(-front_x_separation_/2., lat_beam_y, -front_beam_z),
-                      front_beam_logic, "STEEL_BEAM_STRUCTURE_front3", lead_box_logic, false, 0, false);
+                  front_beam_logic, "STEEL_BEAM_STRUCTURE_front3", lead_box_logic, false, 0, false);
 
     new G4PVPlacement(0, G4ThreeVector(front_x_separation_/2., lat_beam_y, -front_beam_z),
-                      front_beam_logic,"STEEL_BEAM_STRUCTURE_front4", lead_box_logic, false, 0, false);
+                  front_beam_logic,"STEEL_BEAM_STRUCTURE_front4", lead_box_logic, false, 0, false);
 
 
     // STEEL BOX   ///////////
@@ -212,10 +219,11 @@ namespace nexus {
                       steel_box_logic, "STEEL_BOX", lead_box_logic, false, 0);
 
     // AIR INSIDE
-    G4Box* air_box_solid = new G4Box("INNER_AIR", shield_x_/2., shield_y_/2. + steel_thickness_/2., shield_z_/2.);
+    G4Box* air_box_solid =
+    new G4Box("INNER_AIR", shield_x_/2., shield_y_/2. + steel_thickness_/2., shield_z_/2.);
 
     air_box_logic_ = new G4LogicalVolume(air_box_solid,
-                                         G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"), "INNER_AIR");
+                         G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"), "INNER_AIR");
 
     ////Limit the uStepMax=Maximum step length, uTrakMax=Maximum total track length,
     //uTimeMax= Maximum global time for a track, uEkinMin= Minimum remaining kinetic energy for a track
@@ -255,48 +263,69 @@ namespace nexus {
                                              lead_thickness_/2.,
                                              pedestal_lateral_length_/2.);
 
-    G4Box* pedestal_roof_ = new G4Box("PEDESTAL_ROOF", pedestal_x_/2. + pedestal_lateral_beam_thickness_,
-                                                       pedestal_lateral_beam_thickness_/2., pedestal_lateral_length_/2.);
-    G4Box* ped_aux_box    = new G4Box("AUX_box"      , pedestal_x_/2. + pedestal_lateral_beam_thickness_ - pedestal_roof_thickness_,
-                                                       pedestal_lateral_beam_thickness_, pedestal_lateral_length_/2.-pedestal_roof_thickness_);
-    G4SubtractionSolid* pedestal_roof = new G4SubtractionSolid("PEDESTAL_ROOF", pedestal_roof_, ped_aux_box);
+    G4Box* pedestal_roof_ =
+      new G4Box("PEDESTAL_ROOF", pedestal_x_/2. + pedestal_lateral_beam_thickness_,
+                                 pedestal_lateral_beam_thickness_/2., pedestal_lateral_length_/2.);
 
-    G4LogicalVolume* pedestal_support_beam_bottom_logic = new G4LogicalVolume(pedestal_support_beam_bottom,
-                                                                              MaterialsList::Steel316Ti(), "PEDESTAL_SUPPORT_BOTTOM");
+    G4Box* ped_aux_box    =
+      new G4Box("AUX_box", pedestal_x_/2. + pedestal_lateral_beam_thickness_ - pedestal_roof_thickness_,
+                           pedestal_lateral_beam_thickness_,
+                           pedestal_lateral_length_/2.-pedestal_roof_thickness_);
 
-    G4LogicalVolume* pedestal_support_beam_top_logic = new G4LogicalVolume(pedestal_support_beam_top,
-                                                                           MaterialsList::Steel316Ti(), "PEDESTAL_SUPPORT_TOP");
+    G4SubtractionSolid* pedestal_roof =
+      new G4SubtractionSolid("PEDESTAL_ROOF", pedestal_roof_, ped_aux_box);
 
-    G4LogicalVolume* pedestal_beam_front_logic = new G4LogicalVolume(pedestal_beam_front,
-                                                                     MaterialsList::Steel316Ti(), "PEDESTAL_BEAM_FRONT");
+    G4LogicalVolume* pedestal_support_beam_bottom_logic =
+      new G4LogicalVolume(pedestal_support_beam_bottom,
+                          MaterialsList::Steel316Ti(), "PEDESTAL_SUPPORT_BOTTOM");
 
-    G4LogicalVolume* pedestal_beam_lateral_logic = new G4LogicalVolume(pedestal_beam_lateral,
-                                                                       MaterialsList::Steel316Ti(), "PEDESTAL_BEAM_LATERAL");
+    G4LogicalVolume* pedestal_support_beam_top_logic =
+      new G4LogicalVolume(pedestal_support_beam_top,
+                          MaterialsList::Steel316Ti(), "PEDESTAL_SUPPORT_TOP");
 
-    G4LogicalVolume* pedestal_roof_logic = new G4LogicalVolume(pedestal_roof,
-                                                               MaterialsList::Steel316Ti(), "PEDESTAL_ROOF");
+    G4LogicalVolume* pedestal_beam_front_logic =
+      new G4LogicalVolume(pedestal_beam_front,
+                          MaterialsList::Steel316Ti(), "PEDESTAL_BEAM_FRONT");
+
+    G4LogicalVolume* pedestal_beam_lateral_logic =
+      new G4LogicalVolume(pedestal_beam_lateral,
+                          MaterialsList::Steel316Ti(), "PEDESTAL_BEAM_LATERAL");
+
+    G4LogicalVolume* pedestal_roof_logic =
+      new G4LogicalVolume(pedestal_roof,
+                          MaterialsList::Steel316Ti(), "PEDESTAL_ROOF");
 
     G4double pedestal_x_pos = pedestal_x_/2. + pedestal_lateral_beam_thickness_/2.;
     G4double pedestal_y_pos = -lead_y_/2. + lead_thickness_/2.;
-    G4double pedestal_top_y_pos  = -(shield_y_/2. + steel_thickness_/2.) + pedestal_support_top_thickness/2.;  //caution: it is refered to air-box
-    G4double pedestal_roof_y_pos = -(shield_y_/2. + steel_thickness_/2.) + pedestal_lateral_beam_thickness_/2.; //caution: it is refered to air-box
+    G4double pedestal_top_y_pos  = -(shield_y_/2. + steel_thickness_/2.)
+                                   + pedestal_support_top_thickness/2.;  //caution: it is refered to air-box
+    G4double pedestal_roof_y_pos = -(shield_y_/2. + steel_thickness_/2.)
+                                   + pedestal_lateral_beam_thickness_/2.; //caution: it is refered to air-box
+
+
     new G4PVPlacement(0, G4ThreeVector(0., pedestal_y_pos, support_beam_dist_/2.),
-                      pedestal_support_beam_bottom_logic, "PEDESTAL_SUPPORT_BEAM_BOTTOM_1", lead_box_logic, false, 0);
+                      pedestal_support_beam_bottom_logic,
+                      "PEDESTAL_SUPPORT_BEAM_BOTTOM_1", lead_box_logic, false, 0);
 
     new G4PVPlacement(0, G4ThreeVector(0., pedestal_y_pos, -support_beam_dist_/2.),
-                      pedestal_support_beam_bottom_logic, "PEDESTAL_SUPPORT_BEAM_BOTTOM_2", lead_box_logic, false, 0);
+                      pedestal_support_beam_bottom_logic,
+                      "PEDESTAL_SUPPORT_BEAM_BOTTOM_2", lead_box_logic, false, 0);
 
     new G4PVPlacement(0, G4ThreeVector(0., pedestal_top_y_pos, support_beam_dist_/2.),
-                      pedestal_support_beam_top_logic, "PEDESTAL_SUPPORT_BEAM_TOP_1", air_box_logic_, false, 0);
+                      pedestal_support_beam_top_logic,
+                      "PEDESTAL_SUPPORT_BEAM_TOP_1", air_box_logic_, false, 0);
 
     new G4PVPlacement(0, G4ThreeVector(0., pedestal_top_y_pos, -support_beam_dist_/2.),
-                      pedestal_support_beam_top_logic, "PEDESTAL_SUPPORT_BEAM_TOP_2", air_box_logic_, false, 0);
+                      pedestal_support_beam_top_logic,
+                      "PEDESTAL_SUPPORT_BEAM_TOP_2", air_box_logic_, false, 0);
 
     new G4PVPlacement(0, G4ThreeVector(0., pedestal_y_pos, support_beam_dist_/2. + support_front_dist_),
-                      pedestal_beam_front_logic, "PEDESTAL_BEAM_FRONT_1", lead_box_logic, false, 0);
+                      pedestal_beam_front_logic,
+                      "PEDESTAL_BEAM_FRONT_1", lead_box_logic, false, 0);
 
     new G4PVPlacement(0, G4ThreeVector(0., pedestal_y_pos, -support_beam_dist_/2. - support_front_dist_),
-                      pedestal_beam_front_logic, "PEDESTAL_BEAM_FRONT_2", lead_box_logic, false, 0);
+                      pedestal_beam_front_logic,
+                      "PEDESTAL_BEAM_FRONT_2", lead_box_logic, false, 0);
 
     new G4PVPlacement(0, G4ThreeVector(pedestal_x_pos, pedestal_y_pos, 0.),
                       pedestal_beam_lateral_logic, "PEDESTAL_BEAM_LAT_1", lead_box_logic, false, 0);
@@ -343,34 +372,46 @@ namespace nexus {
                                      G4ThreeVector(0., 0., 0.), 0);
 
     G4double ext_offset = 1. * cm;
-    external_gen_ = new BoxPointSampler(lead_x_ + ext_offset, lead_y_ + ext_offset, lead_z_ + ext_offset, 1. * mm,
-                                        G4ThreeVector(0., 0., 0.), 0);
+    external_gen_ =
+      new BoxPointSampler(lead_x_ + ext_offset, lead_y_ + ext_offset, lead_z_ + ext_offset, 1. * mm,
+                          G4ThreeVector(0., 0., 0.), 0);
 
     steel_gen_ = new BoxPointSampler(shield_x_, shield_y_, shield_z_, steel_thickness_,
                                      G4ThreeVector(0., -beam_thickness_1/2., 0.), 0);
 
     G4double inn_offset = .5 * cm;
-    inner_air_gen_ = new BoxPointSampler(shield_x_ - inn_offset, shield_y_ - inn_offset, shield_z_ - inn_offset, 1. * mm,
-                                         G4ThreeVector(0., -beam_thickness_1/2., 0.), 0);
+    inner_air_gen_ =
+      new BoxPointSampler(shield_x_ - inn_offset, shield_y_ - inn_offset, shield_z_ - inn_offset, 1. * mm,
+                          G4ThreeVector(0., -beam_thickness_1/2., 0.), 0);
 
     // STEEL STRUCTURE GENERATORS
-    lat_roof_gen_ = new BoxPointSampler(lead_thickness_, beam_thickness_2, shield_z_ + 2.*steel_thickness_, 0.,
-                                        G4ThreeVector(0., roof_y, 0.), 0);
+    lat_roof_gen_ =
+      new BoxPointSampler(lead_thickness_, beam_thickness_2, shield_z_ + 2.*steel_thickness_, 0.,
+                          G4ThreeVector(0., roof_y, 0.), 0);
 
-    front_roof_gen_ = new BoxPointSampler(lead_x_, beam_thickness_2, lead_thickness_, 0.,
-                                          G4ThreeVector(0., roof_y, 0.), 0);
+    front_roof_gen_ =
+      new BoxPointSampler(lead_x_, beam_thickness_2, lead_thickness_, 0.,
+                          G4ThreeVector(0., roof_y, 0.), 0);
 
-    struct_x_gen_ = new BoxPointSampler(shield_x_ + 2.*lead_thickness_ + 2.*steel_thickness_, lead_thickness_, beam_thickness_1, 0.,
-                                        G4ThreeVector(0., top_beam_y, roof_z_separation_+lateral_z_separation_/2.), 0);
+    struct_x_gen_ =
+      new BoxPointSampler(shield_x_ + 2.*lead_thickness_ + 2.*steel_thickness_, lead_thickness_,
+                          beam_thickness_1, 0.,
+                          G4ThreeVector(0., top_beam_y, roof_z_separation_+lateral_z_separation_/2.), 0);
 
-    struct_z_gen_ = new BoxPointSampler(beam_thickness_2, lead_thickness_, shield_z_ + 2.*lead_thickness_ + 2.*steel_thickness_, 0.,
-                                        G4ThreeVector(-front_x_separation_/2., top_beam_y, 0.), 0);
+    struct_z_gen_ =
+      new BoxPointSampler(beam_thickness_2, lead_thickness_,
+                          shield_z_ + 2.*lead_thickness_ + 2.*steel_thickness_, 0.,
+                          G4ThreeVector(-front_x_separation_/2., top_beam_y, 0.), 0);
 
-    lat_beam_gen_ = new BoxPointSampler(lead_thickness_, shield_y_ + 2. * steel_thickness_+ lead_thickness_, beam_thickness_1, 0.,
-                                        G4ThreeVector(lat_beam_x, -lead_thickness_/2., lateral_z_separation_/2.), 0);
+    lat_beam_gen_ =
+      new BoxPointSampler(lead_thickness_, shield_y_ + 2. * steel_thickness_+ lead_thickness_,
+                          beam_thickness_1, 0.,
+                          G4ThreeVector(lat_beam_x, -lead_thickness_/2., lateral_z_separation_/2.), 0);
 
-    front_beam_gen_ = new BoxPointSampler(beam_thickness_2, shield_y_ + 2. * steel_thickness_+ lead_thickness_, lead_thickness_, 0.,
-                                          G4ThreeVector(-front_x_separation_/2., -lead_thickness_/2., front_beam_z), 0);
+    front_beam_gen_ =
+      new BoxPointSampler(beam_thickness_2, shield_y_ + 2. * steel_thickness_+ lead_thickness_,
+                          lead_thickness_, 0.,
+                          G4ThreeVector(-front_x_separation_/2., -lead_thickness_/2., front_beam_z), 0);
 
     // Compute relative volumes
     G4double roof_vol       = roof_beam_solid->GetCubicVolume();
@@ -382,33 +423,42 @@ namespace nexus {
     perc_front_roof_vol_ = 2*(lead_x_*beam_thickness_2*lead_thickness_)/roof_vol;
     perc_top_struct_vol_ = struct_top_vol /total_vol;
 
-    G4double struc_beam_x_vol = (shield_x_ + 2.*lead_thickness_ + 2.*steel_thickness_)*lead_thickness_*beam_thickness_1;
+    G4double struc_beam_x_vol = (shield_x_ + 2.*lead_thickness_
+                                + 2.*steel_thickness_)*lead_thickness_*beam_thickness_1;
     perc_struc_x_vol_    = 4*struc_beam_x_vol/struct_top_vol;
 
 
     // PEDESTAL GENERATORS
-    ped_support_bottom_gen_ = new BoxPointSampler(pedestal_x_, lead_thickness_, pedestal_support_bottom_thickness, 0.,
-                                                  G4ThreeVector(0., pedestal_y_pos, support_beam_dist_/2.), 0);
+    ped_support_bottom_gen_ =
+      new BoxPointSampler(pedestal_x_, lead_thickness_, pedestal_support_bottom_thickness, 0.,
+                          G4ThreeVector(0., pedestal_y_pos, support_beam_dist_/2.), 0);
 
     G4double ped_gen_y_ = -lead_y_/2. + lead_thickness_ + pedestal_support_top_thickness/2.;
-    ped_support_top_gen_ = new BoxPointSampler(pedestal_top_x_, pedestal_support_top_thickness, pedestal_support_top_length, 0.,
-                                               G4ThreeVector(0., ped_gen_y_, support_beam_dist_/2.), 0);
+    ped_support_top_gen_ =
+      new BoxPointSampler(pedestal_top_x_, pedestal_support_top_thickness, pedestal_support_top_length, 0.,
+                          G4ThreeVector(0., ped_gen_y_, support_beam_dist_/2.), 0);
 
-    ped_front_gen_ = new BoxPointSampler(pedestal_x_, lead_thickness_, pedestal_front_beam_thickness_, 0.,
-                                       G4ThreeVector(0., pedestal_y_pos, support_beam_dist_/2. + support_front_dist_), 0);
+    ped_front_gen_ =
+      new BoxPointSampler(pedestal_x_, lead_thickness_, pedestal_front_beam_thickness_, 0.,
+                          G4ThreeVector(0., pedestal_y_pos, support_beam_dist_/2. + support_front_dist_), 0);
 
-    ped_lateral_gen_ = new BoxPointSampler(pedestal_lateral_beam_thickness_, lead_thickness_, pedestal_lateral_length_, 0.,
-                                           G4ThreeVector(pedestal_x_pos, pedestal_y_pos, 0.), 0);
+    ped_lateral_gen_ =
+      new BoxPointSampler(pedestal_lateral_beam_thickness_, lead_thickness_, pedestal_lateral_length_, 0.,
+                          G4ThreeVector(pedestal_x_pos, pedestal_y_pos, 0.), 0);
 
     // pedestal roof
     G4double ped_roof_gen_x = pedestal_top_x_/2. + pedestal_roof_thickness_/2.;
     G4double ped_roof_gen_y = -lead_y_/2. + lead_thickness_ + pedestal_lateral_beam_thickness_/2.;
     G4double ped_roof_gen_z = pedestal_lateral_length_/2. - pedestal_roof_thickness_/2.;
-    ped_roof_lat_gen_ = new BoxPointSampler(pedestal_roof_thickness_, pedestal_lateral_beam_thickness_, pedestal_lateral_length_, 0.,
-                                            G4ThreeVector(ped_roof_gen_x, ped_roof_gen_y, 0.), 0);
+    ped_roof_lat_gen_ =
+      new BoxPointSampler(pedestal_roof_thickness_, pedestal_lateral_beam_thickness_,
+                          pedestal_lateral_length_, 0.,
+                          G4ThreeVector(ped_roof_gen_x, ped_roof_gen_y, 0.), 0);
 
-    ped_roof_front_gen_ = new BoxPointSampler(pedestal_top_x_, pedestal_lateral_beam_thickness_, pedestal_roof_thickness_, 0.,
-                                              G4ThreeVector(0., ped_roof_gen_y, ped_roof_gen_z), 0);
+    ped_roof_front_gen_ =
+      new BoxPointSampler(pedestal_top_x_, pedestal_lateral_beam_thickness_,
+                          pedestal_roof_thickness_, 0.,
+                          G4ThreeVector(0., ped_roof_gen_y, ped_roof_gen_z), 0);
     // Compute relative volumes
     G4double ped_support_bottom_vol = pedestal_support_beam_bottom->GetCubicVolume();
     G4double ped_support_top_vol    = pedestal_support_beam_top   ->GetCubicVolume();
@@ -416,7 +466,8 @@ namespace nexus {
     G4double ped_lateral_vol        = pedestal_beam_lateral       ->GetCubicVolume();
     G4double ped_roof_vol           = pedestal_roof               ->GetCubicVolume();
 
-    G4double ped_total_vol = ped_roof_vol + 2*(ped_support_bottom_vol + ped_support_top_vol + ped_front_vol + ped_lateral_vol);
+    G4double ped_total_vol = ped_roof_vol + 2*(ped_support_bottom_vol + ped_support_top_vol
+                           + ped_front_vol + ped_lateral_vol);
 
     perc_ped_bottom_vol_ = 2*ped_support_bottom_vol/ped_total_vol;
     perc_ped_top_vol_    = 2*ped_support_top_vol   /ped_total_vol;
@@ -426,27 +477,35 @@ namespace nexus {
 
 
     // BUBBLE SEAL
-    bubble_seal_front_gen_ = new BoxPointSampler(pedestal_x_ + 2*pedestal_lateral_beam_thickness_, bubble_seal_thickness_, bubble_seal_thickness_, 0.,
-                                                 G4ThreeVector(0., ped_gen_y_, 0.), 0);
+    bubble_seal_front_gen_ =
+      new BoxPointSampler(pedestal_x_ + 2*pedestal_lateral_beam_thickness_, bubble_seal_thickness_,
+                          bubble_seal_thickness_, 0.,
+                          G4ThreeVector(0., ped_gen_y_, 0.), 0);
 
-    bubble_seal_lateral_gen_ = new BoxPointSampler(bubble_seal_thickness_, bubble_seal_thickness_, pedestal_lateral_length_, 0.,
-                                                   G4ThreeVector(0., ped_gen_y_, 0.), 0);
+    bubble_seal_lateral_gen_ =
+      new BoxPointSampler(bubble_seal_thickness_, bubble_seal_thickness_, pedestal_lateral_length_, 0.,
+                          G4ThreeVector(0., ped_gen_y_, 0.), 0);
 
-    G4double bubble_front_vol   = 2*(pedestal_x_ + 2*pedestal_lateral_beam_thickness_)*(bubble_seal_thickness_)*(bubble_seal_thickness_);
-    G4double bubble_lateral_vol = 2*(bubble_seal_thickness_)*(bubble_seal_thickness_)*(pedestal_lateral_length_);
+    G4double bubble_front_vol   = 2*(pedestal_x_ + 2*pedestal_lateral_beam_thickness_)
+                                   *(bubble_seal_thickness_)*(bubble_seal_thickness_);
+    G4double bubble_lateral_vol = 2*(bubble_seal_thickness_)
+                                   *(bubble_seal_thickness_)*(pedestal_lateral_length_);
 
     perc_bubble_front_vol_  = bubble_front_vol  /(bubble_front_vol + bubble_lateral_vol);
     perc_buble_lateral_vol_ = bubble_lateral_vol/(bubble_front_vol + bubble_lateral_vol);
 
     // EDPM SEAL
-    edpm_seal_front_gen_ = new BoxPointSampler(edpm_seal_thickness_, steel_y, edpm_seal_thickness_, 0.,
-                                               G4ThreeVector(0., -beam_thickness_2/2., 0.), 0);
+    edpm_seal_front_gen_ =
+      new BoxPointSampler(edpm_seal_thickness_, steel_y, edpm_seal_thickness_, 0.,
+                          G4ThreeVector(0., -beam_thickness_2/2., 0.), 0);
 
-    edpm_seal_lateral_gen_ = new BoxPointSampler(edpm_seal_thickness_, edpm_seal_thickness_, steel_z, 0.,
-                                                G4ThreeVector(0., -beam_thickness_2/2., 0.), 0);
+    edpm_seal_lateral_gen_ =
+      new BoxPointSampler(edpm_seal_thickness_, edpm_seal_thickness_, steel_z, 0.,
+                          G4ThreeVector(0., -beam_thickness_2/2., 0.), 0);
 
     G4double edpm_front_vol   = 2*edpm_seal_thickness_ * steel_y * edpm_seal_thickness_;
-    G4double edpm_lateral_vol =   edpm_seal_thickness_ * edpm_seal_thickness_ * (steel_z + 2*steel_thickness_);
+    G4double edpm_lateral_vol =   edpm_seal_thickness_ * edpm_seal_thickness_
+                                 * (steel_z + 2*steel_thickness_);
 
     perc_edpm_front_vol_   = edpm_front_vol  /(edpm_front_vol + edpm_lateral_vol);
     perc_edpm_lateral_vol_ = edpm_lateral_vol/(edpm_front_vol + edpm_lateral_vol);
@@ -655,7 +714,8 @@ namespace nexus {
       	    vertex.setZ(vertex.z() - (2.*support_front_dist_ + support_beam_dist_));
       	  }
         }
-        else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_ + perc_ped_front_vol_ + perc_ped_lateral_vol_)){ // LATERAL BEAM
+        else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_ + perc_ped_front_vol_
+                                                                  + perc_ped_lateral_vol_)){ // LATERAL BEAM
           vertex = ped_lateral_gen_->GenerateVertex("INSIDE");
           if (G4UniformRand() < 0.5) {
             vertex.setX(vertex.x() - (pedestal_x_ + pedestal_lateral_beam_thickness_));
@@ -682,19 +742,23 @@ namespace nexus {
       if (rand<perc_bubble_front_vol_){ // front
         vertex = bubble_seal_front_gen_->GenerateVertex("INSIDE");
         if (G4UniformRand() < 0.5){
-          vertex.setZ(vertex.z() + (support_beam_dist_/2. + support_front_dist_ + pedestal_front_beam_thickness_/2. + bubble_seal_thickness_/2.));
+          vertex.setZ(vertex.z() + (support_beam_dist_/2. + support_front_dist_
+                                 + pedestal_front_beam_thickness_/2. + bubble_seal_thickness_/2.));
         }
         else{
-          vertex.setZ(vertex.z() - (support_beam_dist_/2. + support_front_dist_ + pedestal_front_beam_thickness_/2. + bubble_seal_thickness_/2.));
+          vertex.setZ(vertex.z() - (support_beam_dist_/2. + support_front_dist_
+                                 + pedestal_front_beam_thickness_/2. + bubble_seal_thickness_/2.));
         }
       }
       else{ // lateral
         vertex = bubble_seal_lateral_gen_->GenerateVertex("INSIDE");
         if (G4UniformRand() < 0.5){
-          vertex.setX(vertex.x() + (pedestal_x_/2. + pedestal_lateral_beam_thickness_ + bubble_seal_thickness_/2.));
+          vertex.setX(vertex.x() + (pedestal_x_/2. + pedestal_lateral_beam_thickness_
+                                 + bubble_seal_thickness_/2.));
         }
         else{
-          vertex.setX(vertex.x() - (pedestal_x_/2. + pedestal_lateral_beam_thickness_ + bubble_seal_thickness_/2.));
+          vertex.setX(vertex.x() - (pedestal_x_/2. + pedestal_lateral_beam_thickness_
+                                 + bubble_seal_thickness_/2.));
         }
       }
       }

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -56,14 +56,14 @@ namespace nexus {
     pedestal_top_x_    {1384. * mm},
     support_beam_dist_ {1027. * mm},
     support_front_dist_{732.  * mm},
-    pedestal_lateral_beam_thickness {8. * mm},
-    pedestal_front_beam_thickness   {20.* mm},
-    pedestal_roof_thickness {75. * mm},
-    pedestal_lateral_length {2511. * mm},
+    pedestal_lateral_beam_thickness_ {8. * mm},
+    pedestal_front_beam_thickness_   {20.* mm},
+    pedestal_roof_thickness_ {75. * mm},
+    pedestal_lateral_length_ {2511. * mm},
 
     // Seals
-    bubble_seal_thickness {1. * mm},
-    edpm_seal_thickness   {1. * mm},
+    bubble_seal_thickness_ {1. * mm},
+    edpm_seal_thickness_   {1. * mm},
 
     visibility_ {0},
     verbosity_{false}
@@ -248,17 +248,17 @@ namespace nexus {
     G4Box* pedestal_beam_front = new G4Box("PEDESTAL_BEAM_FRONT",
                                            pedestal_x_/2.,
                                            lead_thickness_/2.,
-                                           pedestal_front_beam_thickness/2.);
+                                           pedestal_front_beam_thickness_/2.);
 
     G4Box* pedestal_beam_lateral = new G4Box("PEDESTAL_BEAM_LATERAL",
-                                             pedestal_lateral_beam_thickness/2.,
+                                             pedestal_lateral_beam_thickness_/2.,
                                              lead_thickness_/2.,
-                                             pedestal_lateral_length/2.);
+                                             pedestal_lateral_length_/2.);
 
-    G4Box* pedestal_roof_ = new G4Box("PEDESTAL_ROOF", pedestal_x_/2. + pedestal_lateral_beam_thickness,
-                                                       pedestal_lateral_beam_thickness/2., pedestal_lateral_length/2.);
-    G4Box* ped_aux_box    = new G4Box("AUX_box"      , pedestal_x_/2. + pedestal_lateral_beam_thickness - pedestal_roof_thickness,
-                                                       pedestal_lateral_beam_thickness, pedestal_lateral_length/2.-pedestal_roof_thickness);
+    G4Box* pedestal_roof_ = new G4Box("PEDESTAL_ROOF", pedestal_x_/2. + pedestal_lateral_beam_thickness_,
+                                                       pedestal_lateral_beam_thickness_/2., pedestal_lateral_length_/2.);
+    G4Box* ped_aux_box    = new G4Box("AUX_box"      , pedestal_x_/2. + pedestal_lateral_beam_thickness_ - pedestal_roof_thickness_,
+                                                       pedestal_lateral_beam_thickness_, pedestal_lateral_length_/2.-pedestal_roof_thickness_);
     G4SubtractionSolid* pedestal_roof = new G4SubtractionSolid("PEDESTAL_ROOF", pedestal_roof_, ped_aux_box);
 
     G4LogicalVolume* pedestal_support_beam_bottom_logic = new G4LogicalVolume(pedestal_support_beam_bottom,
@@ -276,10 +276,10 @@ namespace nexus {
     G4LogicalVolume* pedestal_roof_logic = new G4LogicalVolume(pedestal_roof,
                                                                MaterialsList::Steel316Ti(), "PEDESTAL_ROOF");
 
-    G4double pedestal_x_pos = pedestal_x_/2. + pedestal_lateral_beam_thickness/2.;
+    G4double pedestal_x_pos = pedestal_x_/2. + pedestal_lateral_beam_thickness_/2.;
     G4double pedestal_y_pos = -lead_y_/2. + lead_thickness_/2.;
     G4double pedestal_top_y_pos  = -(shield_y_/2. + steel_thickness_/2.) + pedestal_support_top_thickness/2.;  //caution: it is refered to air-box
-    G4double pedestal_roof_y_pos = -(shield_y_/2. + steel_thickness_/2.) + pedestal_lateral_beam_thickness/2.; //caution: it is refered to air-box
+    G4double pedestal_roof_y_pos = -(shield_y_/2. + steel_thickness_/2.) + pedestal_lateral_beam_thickness_/2.; //caution: it is refered to air-box
     new G4PVPlacement(0, G4ThreeVector(0., pedestal_y_pos, support_beam_dist_/2.),
                       pedestal_support_beam_bottom_logic, "PEDESTAL_SUPPORT_BEAM_BOTTOM_1", lead_box_logic, false, 0);
 
@@ -394,21 +394,21 @@ namespace nexus {
     ped_support_top_gen_ = new BoxPointSampler(pedestal_top_x_, pedestal_support_top_thickness, pedestal_support_top_length, 0.,
                                                G4ThreeVector(0., ped_gen_y_, support_beam_dist_/2.), 0);
 
-    ped_front_gen_ = new BoxPointSampler(pedestal_x_, lead_thickness_, pedestal_front_beam_thickness, 0.,
+    ped_front_gen_ = new BoxPointSampler(pedestal_x_, lead_thickness_, pedestal_front_beam_thickness_, 0.,
                                        G4ThreeVector(0., pedestal_y_pos, support_beam_dist_/2. + support_front_dist_), 0);
 
-    ped_lateral_gen_ = new BoxPointSampler(pedestal_lateral_beam_thickness, lead_thickness_, pedestal_lateral_length, 0.,
+    ped_lateral_gen_ = new BoxPointSampler(pedestal_lateral_beam_thickness_, lead_thickness_, pedestal_lateral_length_, 0.,
                                            G4ThreeVector(pedestal_x_pos, pedestal_y_pos, 0.), 0);
 
     // pedestal roof
-    G4double ped_roof_gen_x_ = pedestal_top_x_/2. + pedestal_roof_thickness/2.;
-    G4double ped_roof_gen_y_ = -lead_y_/2. + lead_thickness_ + pedestal_lateral_beam_thickness/2.;
-    G4double ped_roof_gen_z_ = pedestal_lateral_length/2. - pedestal_roof_thickness/2.;
-    ped_roof_lat_gen_ = new BoxPointSampler(pedestal_roof_thickness, pedestal_lateral_beam_thickness, pedestal_lateral_length, 0.,
-                                            G4ThreeVector(ped_roof_gen_x_, ped_roof_gen_y_, 0.), 0);
+    G4double ped_roof_gen_x = pedestal_top_x_/2. + pedestal_roof_thickness_/2.;
+    G4double ped_roof_gen_y = -lead_y_/2. + lead_thickness_ + pedestal_lateral_beam_thickness_/2.;
+    G4double ped_roof_gen_z = pedestal_lateral_length_/2. - pedestal_roof_thickness_/2.;
+    ped_roof_lat_gen_ = new BoxPointSampler(pedestal_roof_thickness_, pedestal_lateral_beam_thickness_, pedestal_lateral_length_, 0.,
+                                            G4ThreeVector(ped_roof_gen_x, ped_roof_gen_y, 0.), 0);
 
-    ped_roof_front_gen_ = new BoxPointSampler(pedestal_top_x_, pedestal_lateral_beam_thickness, pedestal_roof_thickness, 0.,
-                                              G4ThreeVector(0., ped_roof_gen_y_, ped_roof_gen_z_), 0);
+    ped_roof_front_gen_ = new BoxPointSampler(pedestal_top_x_, pedestal_lateral_beam_thickness_, pedestal_roof_thickness_, 0.,
+                                              G4ThreeVector(0., ped_roof_gen_y, ped_roof_gen_z), 0);
     // Compute relative volumes
     G4double ped_support_bottom_vol = pedestal_support_beam_bottom->GetCubicVolume();
     G4double ped_support_top_vol    = pedestal_support_beam_top   ->GetCubicVolume();
@@ -426,30 +426,30 @@ namespace nexus {
 
 
     // BUBBLE SEAL
-    bubble_seal_front_gen_ = new BoxPointSampler(pedestal_x_ + 2*pedestal_lateral_beam_thickness, bubble_seal_thickness, bubble_seal_thickness, 0.,
+    bubble_seal_front_gen_ = new BoxPointSampler(pedestal_x_ + 2*pedestal_lateral_beam_thickness_, bubble_seal_thickness_, bubble_seal_thickness_, 0.,
                                                  G4ThreeVector(0., ped_gen_y_, 0.), 0);
 
-    bubble_seal_lateral_gen_ = new BoxPointSampler(bubble_seal_thickness, bubble_seal_thickness, pedestal_lateral_length, 0.,
+    bubble_seal_lateral_gen_ = new BoxPointSampler(bubble_seal_thickness_, bubble_seal_thickness_, pedestal_lateral_length_, 0.,
                                                    G4ThreeVector(0., ped_gen_y_, 0.), 0);
 
-    G4double bubble_front_vol_   = 2*(pedestal_x_ + 2*pedestal_lateral_beam_thickness)*(bubble_seal_thickness)*(bubble_seal_thickness);
-    G4double bubble_lateral_vol_ = 2*(bubble_seal_thickness)*(bubble_seal_thickness)*(pedestal_lateral_length);
+    G4double bubble_front_vol   = 2*(pedestal_x_ + 2*pedestal_lateral_beam_thickness_)*(bubble_seal_thickness_)*(bubble_seal_thickness_);
+    G4double bubble_lateral_vol = 2*(bubble_seal_thickness_)*(bubble_seal_thickness_)*(pedestal_lateral_length_);
 
-    perc_bubble_front_vol_  = bubble_front_vol_  /(bubble_front_vol_ + bubble_lateral_vol_);
-    perc_buble_lateral_vol_ = bubble_lateral_vol_/(bubble_front_vol_ + bubble_lateral_vol_);
+    perc_bubble_front_vol_  = bubble_front_vol  /(bubble_front_vol + bubble_lateral_vol);
+    perc_buble_lateral_vol_ = bubble_lateral_vol/(bubble_front_vol + bubble_lateral_vol);
 
     // EDPM SEAL
-    edpm_seal_front_gen_ = new BoxPointSampler(edpm_seal_thickness, steel_y, edpm_seal_thickness, 0.,
+    edpm_seal_front_gen_ = new BoxPointSampler(edpm_seal_thickness_, steel_y, edpm_seal_thickness_, 0.,
                                                G4ThreeVector(0., -beam_thickness_2/2., 0.), 0);
 
-    edpm_seal_lateral_gen_ = new BoxPointSampler(edpm_seal_thickness, edpm_seal_thickness, steel_z, 0.,
+    edpm_seal_lateral_gen_ = new BoxPointSampler(edpm_seal_thickness_, edpm_seal_thickness_, steel_z, 0.,
                                                 G4ThreeVector(0., -beam_thickness_2/2., 0.), 0);
 
-    G4double edpm_front_vol_   = 2*edpm_seal_thickness * steel_y * edpm_seal_thickness;
-    G4double edpm_lateral_vol_ =   edpm_seal_thickness * edpm_seal_thickness * (steel_z + 2*steel_thickness_);
+    G4double edpm_front_vol   = 2*edpm_seal_thickness_ * steel_y * edpm_seal_thickness_;
+    G4double edpm_lateral_vol =   edpm_seal_thickness_ * edpm_seal_thickness_ * (steel_z + 2*steel_thickness_);
 
-    perc_edpm_front_vol_   = edpm_front_vol_  /(edpm_front_vol_ + edpm_lateral_vol_);
-    perc_edpm_lateral_vol_ = edpm_lateral_vol_/(edpm_front_vol_ + edpm_lateral_vol_);
+    perc_edpm_front_vol_   = edpm_front_vol  /(edpm_front_vol + edpm_lateral_vol);
+    perc_edpm_lateral_vol_ = edpm_lateral_vol/(edpm_front_vol + edpm_lateral_vol);
 
 
     if (verbosity_){
@@ -696,7 +696,7 @@ namespace nexus {
           }
           else{
             vertex = ped_lateral_gen_->GenerateVertex("INSIDE");
-            vertex.setX(vertex.x() - (pedestal_x_ + pedestal_lateral_beam_thickness));
+            vertex.setX(vertex.x() - (pedestal_x_ + pedestal_lateral_beam_thickness_));
           }
          }
         else { // ROOF
@@ -706,7 +706,7 @@ namespace nexus {
             }
             else{
               vertex = ped_roof_lat_gen_->GenerateVertex("INSIDE");
-              vertex.setX(vertex.x() - pedestal_top_x_ - pedestal_roof_thickness);
+              vertex.setX(vertex.x() - pedestal_top_x_ - pedestal_roof_thickness_);
             }
           }
           else{
@@ -715,7 +715,7 @@ namespace nexus {
             }
             else{
               vertex = ped_roof_front_gen_->GenerateVertex("INSIDE");
-              vertex.setZ(vertex.z() - pedestal_lateral_length + pedestal_roof_thickness);
+              vertex.setZ(vertex.z() - pedestal_lateral_length_ + pedestal_roof_thickness_);
             }
           }
          }
@@ -726,21 +726,21 @@ namespace nexus {
       if (rand<perc_bubble_front_vol_){ // front
         if (G4UniformRand() < 0.5){
           vertex = bubble_seal_front_gen_->GenerateVertex("INSIDE");
-          vertex.setZ(vertex.z() + (support_beam_dist_/2. + support_front_dist_ + pedestal_front_beam_thickness/2. + bubble_seal_thickness/2.));
+          vertex.setZ(vertex.z() + (support_beam_dist_/2. + support_front_dist_ + pedestal_front_beam_thickness_/2. + bubble_seal_thickness_/2.));
         }
         else{
           vertex = bubble_seal_front_gen_->GenerateVertex("INSIDE");
-          vertex.setZ(vertex.z() - (support_beam_dist_/2. + support_front_dist_ + pedestal_front_beam_thickness/2. + bubble_seal_thickness/2.));
+          vertex.setZ(vertex.z() - (support_beam_dist_/2. + support_front_dist_ + pedestal_front_beam_thickness_/2. + bubble_seal_thickness_/2.));
         }
       }
       else{ // lateral
         if (G4UniformRand() < 0.5){
           vertex = bubble_seal_lateral_gen_->GenerateVertex("INSIDE");
-          vertex.setX(vertex.x() + (pedestal_x_/2. + pedestal_lateral_beam_thickness + bubble_seal_thickness/2.));
+          vertex.setX(vertex.x() + (pedestal_x_/2. + pedestal_lateral_beam_thickness_ + bubble_seal_thickness_/2.));
         }
         else{
           vertex = bubble_seal_lateral_gen_->GenerateVertex("INSIDE");
-          vertex.setX(vertex.x() - (pedestal_x_/2. + pedestal_lateral_beam_thickness + bubble_seal_thickness/2.));
+          vertex.setX(vertex.x() - (pedestal_x_/2. + pedestal_lateral_beam_thickness_ + bubble_seal_thickness_/2.));
         }
       }
       }
@@ -750,16 +750,16 @@ namespace nexus {
       if (rand<perc_edpm_front_vol_){ // front
         if (G4UniformRand() < 0.5){
           vertex = edpm_seal_front_gen_->GenerateVertex("INSIDE");
-          vertex.setZ(vertex.z() + (shield_z_/2. + steel_thickness_ + edpm_seal_thickness/2.));
+          vertex.setZ(vertex.z() + (shield_z_/2. + steel_thickness_ + edpm_seal_thickness_/2.));
         }
         else{
           vertex = edpm_seal_front_gen_->GenerateVertex("INSIDE");
-          vertex.setZ(vertex.z() - (shield_z_/2. + steel_thickness_ + edpm_seal_thickness/2.));
+          vertex.setZ(vertex.z() - (shield_z_/2. + steel_thickness_ + edpm_seal_thickness_/2.));
         }
       }
       else{ // lateral
         vertex = edpm_seal_lateral_gen_->GenerateVertex("INSIDE");
-        vertex.setY(vertex.y() + (shield_y_/2. + steel_thickness_ + edpm_seal_thickness/2.));
+        vertex.setY(vertex.y() + (shield_y_/2. + steel_thickness_ + edpm_seal_thickness_/2.));
       }
     }
 

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -52,9 +52,13 @@ namespace nexus {
     steel_thickness_{2. * mm},
 
     // Pedestal
-    pedestal_x_        {1384. * mm},
+    pedestal_x_        {1518. * mm},
+    pedestal_top_x_    {1384. * mm},
     support_beam_dist_ {1027. * mm},
     support_front_dist_{732.  * mm},
+    pedestal_lateral_beam_thickness {8. * mm},
+    pedestal_roof_thickness {75. * mm},
+    pedestal_lateral_length {2511. * mm},
 
     visibility_ {0},
     verbosity_{false}
@@ -219,8 +223,9 @@ namespace nexus {
 
 
     // PEDESTAL BEAMS
-    // there are two kind of beams: the support T-shaped beams (support), plain "front" beams (x-direction) and plain
-    // "lateral" beams (z-direction). The T-shaped beams are composed by two parts: the vertical part called "support-bottom"
+    // there are two kind of beams: the support T-shaped beams (support), plain "front" beams (x-direction), plain
+    // "lateral" beams (z-direction) and the roof. The roof completes the semi-T shaped "front" and "lateral" beams.
+    // The T-shaped beams are composed by two parts: the vertical part called "support-bottom"
     // and the horizantal top part called "support-top".
     G4double pedestal_support_bottom_thickness = 10.  * mm;
     G4double pedestal_support_top_thickness    = 15.  * mm;
@@ -232,7 +237,7 @@ namespace nexus {
                                                     pedestal_support_bottom_thickness/2.);
 
     G4Box* pedestal_support_beam_top = new G4Box("PEDESTAL_SUPPORT_BEAM_TOP",
-                                                 pedestal_x_/2.,
+                                                 pedestal_top_x_/2.,
                                                  pedestal_support_top_thickness/2.,
                                                  pedestal_support_top_length/2.);
 
@@ -240,6 +245,17 @@ namespace nexus {
                                            pedestal_x_/2.,
                                            lead_thickness_/2.,
                                            pedestal_front_beam_thickness/2.);
+
+    G4Box* pedestal_beam_lateral = new G4Box("PEDESTAL_BEAM_LATERAL",
+                                             pedestal_lateral_beam_thickness/2.,
+                                             lead_thickness_/2.,
+                                             pedestal_lateral_length/2.);
+
+    G4Box* pedestal_roof_ = new G4Box("PEDESTAL_ROOF", pedestal_x_/2. + pedestal_lateral_beam_thickness,
+                                                       pedestal_lateral_beam_thickness/2., pedestal_lateral_length/2.);
+    G4Box* ped_aux_box    = new G4Box("AUX_box"      , pedestal_x_/2. + pedestal_lateral_beam_thickness - pedestal_roof_thickness,
+                                                       pedestal_lateral_beam_thickness, pedestal_lateral_length/2.-pedestal_roof_thickness);
+    G4SubtractionSolid* pedestal_roof = new G4SubtractionSolid("PEDESTAL_ROOF", pedestal_roof_, ped_aux_box);
 
     G4LogicalVolume* pedestal_support_beam_bottom_logic = new G4LogicalVolume(pedestal_support_beam_bottom,
                                                                               MaterialsList::Steel316Ti(), "PEDESTAL_SUPPORT_BOTTOM");
@@ -250,8 +266,16 @@ namespace nexus {
     G4LogicalVolume* pedestal_beam_front_logic = new G4LogicalVolume(pedestal_beam_front,
                                                                      MaterialsList::Steel316Ti(), "PEDESTAL_SUPPORT_FRONT");
 
+    G4LogicalVolume* pedestal_beam_lateral_logic = new G4LogicalVolume(pedestal_beam_lateral,
+                                                                       MaterialsList::Steel316Ti(), "PEDESTAL_SUPPORT_FRONT");
+
+    G4LogicalVolume* pedestal_roof_logic = new G4LogicalVolume(pedestal_roof,
+                                                               MaterialsList::Steel316Ti(), "PEDESTAL_ROOF");
+
+    G4double pedestal_x_pos = pedestal_x_/2. + pedestal_lateral_beam_thickness/2.;
     G4double pedestal_y_pos = -lead_y_/2. + lead_thickness_/2.;
-    G4double pedestal_top_y_pos = -(shield_y_/2. + steel_thickness_/2.) + pedestal_support_top_thickness/2.; //caution: it is refered to air-box
+    G4double pedestal_top_y_pos  = -(shield_y_/2. + steel_thickness_/2.) + pedestal_support_top_thickness/2.;  //caution: it is refered to air-box
+    G4double pedestal_roof_y_pos = -(shield_y_/2. + steel_thickness_/2.) + pedestal_lateral_beam_thickness/2.; //caution: it is refered to air-box
     new G4PVPlacement(0, G4ThreeVector(0., pedestal_y_pos, support_beam_dist_/2.),
                       pedestal_support_beam_bottom_logic, "PEDESTAL_SUPPORT_BEAM_BOTTOM_1", lead_box_logic, false, 0);
 
@@ -269,6 +293,15 @@ namespace nexus {
 
     new G4PVPlacement(0, G4ThreeVector(0., pedestal_y_pos, -support_beam_dist_/2. - support_front_dist_),
                       pedestal_beam_front_logic, "PEDESTAL_BEAM_FRONT_2", lead_box_logic, false, 0);
+
+    new G4PVPlacement(0, G4ThreeVector(pedestal_x_pos, pedestal_y_pos, 0.),
+                      pedestal_beam_lateral_logic, "PEDESTAL_BEAM_LAT_1", lead_box_logic, false, 0);
+
+    new G4PVPlacement(0, G4ThreeVector(-pedestal_x_pos, pedestal_y_pos, 0.),
+                      pedestal_beam_lateral_logic, "PEDESTAL_BEAM_LAT_2", lead_box_logic, false, 0);
+
+    new G4PVPlacement(0, G4ThreeVector(0., pedestal_roof_y_pos, 0.),
+                      pedestal_roof_logic, "PEDESTAL_ROOF", air_box_logic_, false, 0);
 
     // SETTING VISIBILITIES   //////////
     if (visibility_) {
@@ -346,22 +379,38 @@ namespace nexus {
                                                   G4ThreeVector(0., pedestal_y_pos, support_beam_dist_/2.), 0);
 
     G4double ped_gen_y_ = -lead_y_/2. + lead_thickness_ + pedestal_support_top_thickness/2.;
-    ped_support_top_gen_ = new BoxPointSampler(pedestal_x_, pedestal_support_top_thickness, pedestal_support_top_length, 0.,
+    ped_support_top_gen_ = new BoxPointSampler(pedestal_top_x_, pedestal_support_top_thickness, pedestal_support_top_length, 0.,
                                                G4ThreeVector(0., ped_gen_y_, support_beam_dist_/2.), 0);
 
     ped_front_gen_ = new BoxPointSampler(pedestal_x_, lead_thickness_, pedestal_front_beam_thickness, 0.,
                                        G4ThreeVector(0., pedestal_y_pos, support_beam_dist_/2. + support_front_dist_), 0);
 
+    ped_lateral_gen_ = new BoxPointSampler(pedestal_lateral_beam_thickness, lead_thickness_, pedestal_lateral_length, 0.,
+                                           G4ThreeVector(pedestal_x_pos, pedestal_y_pos, 0.), 0);
+
+    // pedestal roof
+    G4double ped_roof_gen_x_ = pedestal_top_x_/2. + pedestal_roof_thickness/2.;
+    G4double ped_roof_gen_y_ = -lead_y_/2. + lead_thickness_ + pedestal_lateral_beam_thickness/2.;
+    G4double ped_roof_gen_z_ = pedestal_lateral_length/2. - pedestal_roof_thickness/2.;
+    ped_roof_lat_gen_ = new BoxPointSampler(pedestal_roof_thickness, pedestal_lateral_beam_thickness, pedestal_lateral_length, 0.,
+                                            G4ThreeVector(ped_roof_gen_x_, ped_roof_gen_y_, 0.), 0);
+
+    ped_roof_front_gen_ = new BoxPointSampler(pedestal_top_x_, pedestal_lateral_beam_thickness, pedestal_roof_thickness, 0.,
+                                              G4ThreeVector(0., ped_roof_gen_y_, ped_roof_gen_z_), 0);
     // Compute relative volumes
     G4double ped_support_bottom_vol = pedestal_support_beam_bottom->GetCubicVolume();
     G4double ped_support_top_vol    = pedestal_support_beam_top   ->GetCubicVolume();
-    G4double ped_front_vol          = pedestal_beam_front          ->GetCubicVolume();
-    G4double ped_total_vol = 2*(ped_support_bottom_vol + ped_support_top_vol + ped_front_vol);
+    G4double ped_front_vol          = pedestal_beam_front         ->GetCubicVolume();
+    G4double ped_lateral_vol        = pedestal_beam_lateral       ->GetCubicVolume();
+    G4double ped_roof_vol           = pedestal_roof               ->GetCubicVolume();
+
+    G4double ped_total_vol = ped_roof_vol + 2*(ped_support_bottom_vol + ped_support_top_vol + ped_front_vol + ped_lateral_vol);
 
     perc_ped_bottom_vol_ = 2*ped_support_bottom_vol/ped_total_vol;
     perc_ped_top_vol_    = 2*ped_support_top_vol   /ped_total_vol;
-    perc_ped_front_vol_    = 2*ped_front_vol       /ped_total_vol;
-
+    perc_ped_front_vol_  = 2*ped_front_vol         /ped_total_vol;
+    perc_ped_lateral_vol_= 2*ped_lateral_vol       /ped_total_vol;
+    perc_ped_roof_vol_   = ped_roof_vol            /ped_total_vol;
 
     if (verbosity_){
       std::cout<<"STEEL STRUCTURE VOLUME (m3)" <<std::endl;
@@ -382,6 +431,8 @@ namespace nexus {
       std::cout << "BOTTOM " << perc_ped_bottom_vol_ * 100 << std::endl;
       std::cout << "TOP "    << perc_ped_top_vol_    * 100 << std::endl;
       std::cout << "FRONT "  << perc_ped_front_vol_  * 100 << std::endl;
+      std::cout << "LATERAL "<< perc_ped_lateral_vol_* 100 << std::endl;
+      std::cout << "ROOF "   << perc_ped_roof_vol_   * 100 << std::endl;
     }
   }
 
@@ -402,6 +453,9 @@ namespace nexus {
     delete ped_support_bottom_gen_;
     delete ped_support_top_gen_;
     delete ped_front_gen_;
+    delete ped_lateral_gen_;
+    delete ped_roof_lat_gen_;
+    delete ped_roof_front_gen_;
   }
 
   G4LogicalVolume* Next100Shielding::GetAirLogicalVolume() const
@@ -575,7 +629,7 @@ namespace nexus {
       	    vertex.setZ(vertex.z() - support_beam_dist_);
       	  }
         }
-        else{//FRONT BEAM
+        else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_ + perc_ped_front_vol_)){ //FRONT BEAM
           if (G4UniformRand() < 0.5) {
       	    vertex = ped_front_gen_->GenerateVertex("INSIDE");
       	  }
@@ -584,6 +638,35 @@ namespace nexus {
       	    vertex.setZ(vertex.z() - (2.*support_front_dist_ + support_beam_dist_));
       	  }
         }
+        else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_ + perc_ped_front_vol_ + perc_ped_lateral_vol_)){ // LATERAL BEAM
+          if (G4UniformRand() < 0.5) {
+            vertex = ped_lateral_gen_->GenerateVertex("INSIDE");
+          }
+          else{
+            vertex = ped_lateral_gen_->GenerateVertex("INSIDE");
+            vertex.setX(vertex.x() - (pedestal_x_ + pedestal_lateral_beam_thickness));
+          }
+         }
+        else { // ROOF
+          if (G4UniformRand() < 0.5) {
+            if (G4UniformRand() < 0.5){
+              vertex = ped_roof_lat_gen_->GenerateVertex("INSIDE");
+            }
+            else{
+              vertex = ped_roof_lat_gen_->GenerateVertex("INSIDE");
+              vertex.setX(vertex.x() - pedestal_top_x_ - pedestal_roof_thickness);
+            }
+          }
+          else{
+            if (G4UniformRand() < 0.5){
+              vertex = ped_roof_front_gen_->GenerateVertex("INSIDE");
+            }
+            else{
+              vertex = ped_roof_front_gen_->GenerateVertex("INSIDE");
+              vertex.setZ(vertex.z() - pedestal_lateral_length + pedestal_roof_thickness);
+            }
+          }
+         }
       }
     else {
       G4Exception("[Next100Shielding]", "GenerateVertex()", FatalException,
@@ -592,5 +675,4 @@ namespace nexus {
 
     return vertex;
   }
-
 } //end namespace nexus

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -52,9 +52,9 @@ namespace nexus {
     steel_thickness_{2. * mm},
 
     // Pedestal
-    pedestal_x_        {1534. * mm},
+    pedestal_x_        {1384. * mm},
     support_beam_dist_ {1027. * mm},
-    support_lat_dist_  {732.  * mm},
+    support_front_dist_{732.  * mm},
 
     visibility_ {0},
     verbosity_{false}
@@ -219,13 +219,13 @@ namespace nexus {
 
 
     // PEDESTAL BEAMS
-    // there are two kind of beams: the support T-shaped beams (support) and plain beams. The T-shaped beams are composed by
-    // two parts: the vertical part called "support-bottom" and the horizantal top part called "support-top". The plain beams are
-    // called "lateral".
+    // there are two kind of beams: the support T-shaped beams (support), plain "front" beams (x-direction) and plain
+    // "lateral" beams (z-direction). The T-shaped beams are composed by two parts: the vertical part called "support-bottom"
+    // and the horizantal top part called "support-top".
     G4double pedestal_support_bottom_thickness = 10.  * mm;
     G4double pedestal_support_top_thickness    = 15.  * mm;
     G4double pedestal_support_top_length       = 150. * mm;
-    G4double pedestal_lateral_beam_thickness   = 20.  * mm;
+    G4double pedestal_front_beam_thickness     = 20.  * mm;
     G4Box* pedestal_support_beam_bottom = new G4Box("PEDESTAL_SUPPORT_BEAM_BOTTOM",
                                                     pedestal_x_/2.,
                                                     lead_thickness_/2.,
@@ -236,10 +236,10 @@ namespace nexus {
                                                  pedestal_support_top_thickness/2.,
                                                  pedestal_support_top_length/2.);
 
-    G4Box* pedestal_beam_lat = new G4Box("PEDESTAL_BEAM_LAT",
-                                         pedestal_x_/2.,
-                                         lead_thickness_/2.,
-                                         pedestal_lateral_beam_thickness/2.);
+    G4Box* pedestal_beam_front = new G4Box("PEDESTAL_BEAM_FRONT",
+                                           pedestal_x_/2.,
+                                           lead_thickness_/2.,
+                                           pedestal_front_beam_thickness/2.);
 
     G4LogicalVolume* pedestal_support_beam_bottom_logic = new G4LogicalVolume(pedestal_support_beam_bottom,
                                                                               MaterialsList::Steel316Ti(), "PEDESTAL_SUPPORT_BOTTOM");
@@ -247,8 +247,8 @@ namespace nexus {
     G4LogicalVolume* pedestal_support_beam_top_logic = new G4LogicalVolume(pedestal_support_beam_top,
                                                                            MaterialsList::Steel316Ti(), "PEDESTAL_SUPPORT_TOP");
 
-    G4LogicalVolume* pedestal_beam_lat_logic = new G4LogicalVolume(pedestal_beam_lat,
-                                                                   MaterialsList::Steel316Ti(), "PEDESTAL_SUPPORT_LAT");
+    G4LogicalVolume* pedestal_beam_front_logic = new G4LogicalVolume(pedestal_beam_front,
+                                                                     MaterialsList::Steel316Ti(), "PEDESTAL_SUPPORT_FRONT");
 
     G4double pedestal_y_pos = -lead_y_/2. + lead_thickness_/2.;
     G4double pedestal_top_y_pos = -(shield_y_/2. + steel_thickness_/2.) + pedestal_support_top_thickness/2.; //caution: it is refered to air-box
@@ -264,11 +264,11 @@ namespace nexus {
     new G4PVPlacement(0, G4ThreeVector(0., pedestal_top_y_pos, -support_beam_dist_/2.),
                       pedestal_support_beam_top_logic, "PEDESTAL_SUPPORT_BEAM_TOP_2", air_box_logic_, false, 0);
 
-    new G4PVPlacement(0, G4ThreeVector(0., pedestal_y_pos, support_beam_dist_/2. + support_lat_dist_),
-                      pedestal_beam_lat_logic, "PEDESTAL_BEAM_LAT_1", lead_box_logic, false, 0);
+    new G4PVPlacement(0, G4ThreeVector(0., pedestal_y_pos, support_beam_dist_/2. + support_front_dist_),
+                      pedestal_beam_front_logic, "PEDESTAL_BEAM_FRONT_1", lead_box_logic, false, 0);
 
-    new G4PVPlacement(0, G4ThreeVector(0., pedestal_y_pos, -support_beam_dist_/2. - support_lat_dist_),
-                      pedestal_beam_lat_logic, "PEDESTAL_BEAM_LAT_2", lead_box_logic, false, 0);
+    new G4PVPlacement(0, G4ThreeVector(0., pedestal_y_pos, -support_beam_dist_/2. - support_front_dist_),
+                      pedestal_beam_front_logic, "PEDESTAL_BEAM_FRONT_2", lead_box_logic, false, 0);
 
     // SETTING VISIBILITIES   //////////
     if (visibility_) {
@@ -349,18 +349,18 @@ namespace nexus {
     ped_support_top_gen_ = new BoxPointSampler(pedestal_x_, pedestal_support_top_thickness, pedestal_support_top_length, 0.,
                                                G4ThreeVector(0., ped_gen_y_, support_beam_dist_/2.), 0);
 
-    ped_lat_gen_ = new BoxPointSampler(pedestal_x_, lead_thickness_, pedestal_lateral_beam_thickness, 0.,
-                                       G4ThreeVector(0., pedestal_y_pos, support_beam_dist_/2. + support_lat_dist_), 0);
+    ped_front_gen_ = new BoxPointSampler(pedestal_x_, lead_thickness_, pedestal_front_beam_thickness, 0.,
+                                       G4ThreeVector(0., pedestal_y_pos, support_beam_dist_/2. + support_front_dist_), 0);
 
     // Compute relative volumes
     G4double ped_support_bottom_vol = pedestal_support_beam_bottom->GetCubicVolume();
     G4double ped_support_top_vol    = pedestal_support_beam_top   ->GetCubicVolume();
-    G4double ped_lat_vol            = pedestal_beam_lat           ->GetCubicVolume();
-    G4double ped_total_vol = 2*(ped_support_bottom_vol + ped_support_top_vol + ped_lat_vol);
+    G4double ped_front_vol          = pedestal_beam_front          ->GetCubicVolume();
+    G4double ped_total_vol = 2*(ped_support_bottom_vol + ped_support_top_vol + ped_front_vol);
 
     perc_ped_bottom_vol_ = 2*ped_support_bottom_vol/ped_total_vol;
     perc_ped_top_vol_    = 2*ped_support_top_vol   /ped_total_vol;
-    perc_ped_lat_vol_    = 2*ped_lat_vol           /ped_total_vol;
+    perc_ped_front_vol_    = 2*ped_front_vol       /ped_total_vol;
 
 
     if (verbosity_){
@@ -381,7 +381,7 @@ namespace nexus {
       std::cout << "PEDESTAL GENERATOR PERCENTS" << std::endl;
       std::cout << "BOTTOM " << perc_ped_bottom_vol_ * 100 << std::endl;
       std::cout << "TOP "    << perc_ped_top_vol_    * 100 << std::endl;
-      std::cout << "LAT "    << perc_ped_lat_vol_    * 100 << std::endl;
+      std::cout << "FRONT "  << perc_ped_front_vol_  * 100 << std::endl;
     }
   }
 
@@ -401,7 +401,7 @@ namespace nexus {
     delete front_beam_gen_;
     delete ped_support_bottom_gen_;
     delete ped_support_top_gen_;
-    delete ped_lat_gen_;
+    delete ped_front_gen_;
   }
 
   G4LogicalVolume* Next100Shielding::GetAirLogicalVolume() const
@@ -575,13 +575,13 @@ namespace nexus {
       	    vertex.setZ(vertex.z() - support_beam_dist_);
       	  }
         }
-        else{//LATERAL BEAM
+        else{//FRONT BEAM
           if (G4UniformRand() < 0.5) {
-      	    vertex = ped_lat_gen_->GenerateVertex("INSIDE");
+      	    vertex = ped_front_gen_->GenerateVertex("INSIDE");
       	  }
       	  else{
-      	    vertex = ped_lat_gen_->GenerateVertex("INSIDE");
-      	    vertex.setZ(vertex.z() - (2.*support_lat_dist_ + support_beam_dist_));
+      	    vertex = ped_front_gen_->GenerateVertex("INSIDE");
+      	    vertex.setZ(vertex.z() - (2.*support_front_dist_ + support_beam_dist_));
       	  }
         }
       }

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -41,13 +41,13 @@ namespace nexus {
     shield_z_ {259.4 * cm},
 
     //Steel Structure
-    beam_thickness_      {4.   * mm},
+    beam_thickness_      {5.   * cm}, // 4 and 6 mm
     lateral_z_separation_{1010.* mm}, //distance between the two lateral beams
     roof_z_separation_   {760. * mm}, //distance between x beams
     front_x_separation_  {156. * mm}, //distance between the two front beams
     // Box thickness
-    lead_thickness_ {20. * cm},
-    steel_thickness_{2.0 * mm},
+    lead_thickness_ {20. * cm}, // 2 * mm
+    steel_thickness_{10.0 * cm},
     visibility_ {0},
     verbosity_{false}
 
@@ -187,11 +187,10 @@ namespace nexus {
                       steel_box_logic, "STEEL_BOX", lead_box_logic, false, 0);
 
     // AIR INSIDE
-    G4Box* air_box_solid = new G4Box("INNER_AIR", shield_x_/2., shield_y_/2., shield_z_/2.);
+    G4Box* air_box_solid = new G4Box("INNER_AIR", shield_x_/2., shield_y_/2. + steel_thickness_/2., shield_z_/2.);
 
     air_box_logic_ = new G4LogicalVolume(air_box_solid,
-                                         G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"),
-                                			   "INNER_AIR");
+                                         G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"), "INNER_AIR");
 
     ////Limit the uStepMax=Maximum step length, uTrakMax=Maximum total track length,
     //uTimeMax= Maximum global time for a track, uEkinMin= Minimum remaining kinetic energy for a track
@@ -199,7 +198,7 @@ namespace nexus {
     air_box_logic_->SetUserLimits(new G4UserLimits( DBL_MAX, DBL_MAX, DBL_MAX,100.*keV,0.));
     air_box_logic_->SetVisAttributes(G4VisAttributes::Invisible);
 
-    new G4PVPlacement(0, G4ThreeVector(0., 0., 0.),
+    new G4PVPlacement(0, G4ThreeVector(0., -steel_thickness_/2., 0.),
                       air_box_logic_, "INNER_AIR", steel_box_logic, false, 0);
 
 

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -51,9 +51,12 @@ namespace nexus {
     visibility_ (0)
 
   {
-    /// Shielding is compound by two boxes, the external made of lead,
-    /// and the internal, made of a mix of Steel & Titanium
-    /// The Steel beam structure is placed inside the lead
+    
+    // The shielding is made of two boxes.
+    // The external one is made of lead and the internal one is made of a mix of stainless steel AISI-316Ti.
+    // Besides, inside the lead we have the castle steel beams (steel S-275) that support the lead.
+    // This steel beam structure is composed by tree regions: the lateral beams, the roof, and the
+    // beam structure above the roof.
 
     /// Messenger
     msg_ = new G4GenericMessenger(this, "/Geometry/Next100/", "Control commands of geometry Next100.");

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -311,16 +311,18 @@ namespace nexus {
       steel_box_logic->SetVisAttributes(grey_col);
       G4VisAttributes antiox_col = nexus::BloodRed();
       //  antiox.SetForceSolid(true);
-      roof_logic    ->SetVisAttributes(antiox_col);
-      lat_beam_logic->SetVisAttributes(antiox_col);
-      struct_logic  ->SetVisAttributes(antiox_col);
+      roof_logic      ->SetVisAttributes(antiox_col);
+      lat_beam_logic  ->SetVisAttributes(antiox_col);
+      front_beam_logic->SetVisAttributes(antiox_col);
+      struct_logic    ->SetVisAttributes(antiox_col);
     }
     else {
-      lead_box_logic ->SetVisAttributes(G4VisAttributes::Invisible);
-      steel_box_logic->SetVisAttributes(G4VisAttributes::Invisible);
-      roof_logic     ->SetVisAttributes(G4VisAttributes::Invisible);
-      struct_logic   ->SetVisAttributes(G4VisAttributes::Invisible);
-      lat_beam_logic ->SetVisAttributes(G4VisAttributes::Invisible);
+      lead_box_logic  ->SetVisAttributes(G4VisAttributes::Invisible);
+      steel_box_logic ->SetVisAttributes(G4VisAttributes::Invisible);
+      roof_logic      ->SetVisAttributes(G4VisAttributes::Invisible);
+      struct_logic    ->SetVisAttributes(G4VisAttributes::Invisible);
+      lat_beam_logic  ->SetVisAttributes(G4VisAttributes::Invisible);
+      front_beam_logic->SetVisAttributes(G4VisAttributes::Invisible);
 
       pedestal_support_beam_bottom_logic->SetVisAttributes(G4VisAttributes::Invisible);
       pedestal_support_beam_top_logic   ->SetVisAttributes(G4VisAttributes::Invisible);

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -495,7 +495,15 @@ namespace nexus {
     }
 
     else if (region == "SHIELDING_STEEL") {
-      vertex = steel_gen_->GenerateVertex("WHOLE_VOL");
+      G4VPhysicalVolume *VertexVolume;
+      do {
+          vertex = steel_gen_->GenerateVertex("WHOLE_VOL");
+
+          G4ThreeVector glob_vtx(vertex);
+          glob_vtx.rotate(pi, G4ThreeVector(0., 1., 0.));
+          glob_vtx = glob_vtx + G4ThreeVector(0, 0, GetELzCoord());
+          VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
+      } while (VertexVolume->GetName() != "STEEL_BOX");
     }
 
     else if (region == "INNER_AIR") {

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -234,13 +234,13 @@ namespace nexus {
                                                  pedestal_support_bottom_thickness);
 
     G4LogicalVolume* pedestal_support_beam_bottom_logic = new G4LogicalVolume(pedestal_support_beam_bottom,
-                                                                              MaterialsList::Steel(), "PEDESTAL_SUPPORT_BOTTOM"); // steel inox
+                                                                              MaterialsList::Steel316Ti(), "PEDESTAL_SUPPORT_BOTTOM");
 
     G4LogicalVolume* pedestal_support_beam_top_logic = new G4LogicalVolume(pedestal_support_beam_top,
-                                                                           MaterialsList::Steel(), "PEDESTAL_SUPPORT_TOP"); // steel inox
+                                                                           MaterialsList::Steel316Ti(), "PEDESTAL_SUPPORT_TOP");
 
     G4LogicalVolume* pedestal_support_beam_lat_logic = new G4LogicalVolume(pedestal_support_beam_lat,
-                                                                           MaterialsList::Steel(), "PEDESTAL_SUPPORT_LAT"); // steel inox
+                                                                           MaterialsList::Steel316Ti(), "PEDESTAL_SUPPORT_LAT");
 
     G4double pedestal_y_pos = -lead_y_/2. + lead_thickness_/2.;
     new G4PVPlacement(0, G4ThreeVector(0., pedestal_y_pos, (1027. * mm)/2.),

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -41,10 +41,12 @@ namespace nexus {
     shield_z_ {259.4 * cm},
 
     //Steel Structure
-    beam_thickness_      {4.   * mm},
+    beam_thickness_1     {4.   * mm},
+    beam_thickness_2     {6.   * mm},
     lateral_z_separation_{1010.* mm}, //distance between the two lateral beams
     roof_z_separation_   {760. * mm}, //distance between x beams
     front_x_separation_  {156. * mm}, //distance between the two front beams
+
     // Box thickness
     lead_thickness_ {20.* cm},
     steel_thickness_{2. * mm},
@@ -74,7 +76,7 @@ namespace nexus {
 
     // LEAD BOX   ///////////
     lead_x_ = shield_x_ + 2. * steel_thickness_ + 2. * lead_thickness_;
-    lead_y_ = shield_y_ + 2. * steel_thickness_ + 2. * lead_thickness_ + beam_thickness_;
+    lead_y_ = shield_y_ + 2. * steel_thickness_ + 2. * lead_thickness_ + beam_thickness_2;
     lead_z_ = shield_z_ + 2. * steel_thickness_ + 2. * lead_thickness_;
 
     G4Box* lead_box_solid = new G4Box("LEAD_BOX", lead_x_/2., lead_y_/2., lead_z_/2.);
@@ -88,26 +90,33 @@ namespace nexus {
     // auxiliar positions used in translations
     G4double lat_beam_x   = shield_x_/2. + steel_thickness_ + lead_thickness_/2.;
     G4double front_beam_z = shield_z_/2. + steel_thickness_ + lead_thickness_/2.;
-    G4double top_beam_y   = (shield_y_-beam_thickness_)/2. + steel_thickness_ + beam_thickness_ + lead_thickness_/2.;
-    G4double lat_beam_y   = -(lead_thickness_ + beam_thickness_)/2.;
-    G4double roof_y       = (shield_y_-beam_thickness_)/2. + steel_thickness_ + beam_thickness_/2.;
+    G4double top_beam_y   = (shield_y_-beam_thickness_2)/2. + steel_thickness_ + beam_thickness_2 + lead_thickness_/2.;
+    G4double lat_beam_y   = -(lead_thickness_ + beam_thickness_2)/2.;
+    G4double roof_y       = (shield_y_-beam_thickness_2)/2. + steel_thickness_ + beam_thickness_2/2.;
 
-    G4Box* roof_beam = new G4Box("STRUCT_BEAM", lead_x_/2.                     , beam_thickness_/2., lead_z_/2.);
-    G4Box* aux_box   = new G4Box("AUX_box"    , shield_x_/2. + steel_thickness_, beam_thickness_   , shield_z_/2.+ steel_thickness_);
+    G4Box* roof_beam = new G4Box("STRUCT_BEAM", lead_x_/2.                     , beam_thickness_2/2., lead_z_/2.);
+    G4Box* aux_box   = new G4Box("AUX_box"    , shield_x_/2. + steel_thickness_, beam_thickness_2   , shield_z_/2.+ steel_thickness_);
     G4SubtractionSolid* roof_beam_solid = new G4SubtractionSolid("STRUCT_BEAM", roof_beam, aux_box);
 
+    // vertical bottom beams
     G4Box* lat_beam_solid  = new G4Box("STRUCT_BEAM",
                                        lead_thickness_/2.,
                                        (shield_y_ + 2. * steel_thickness_+ lead_thickness_)/2.,
-                                       beam_thickness_/2.);
+                                       beam_thickness_1/2.);
 
+    G4Box* front_beam_solid = new G4Box("STRUCT_BEAM",
+                                        beam_thickness_2/2.,
+                                        (shield_y_ + 2. * steel_thickness_+ lead_thickness_)/2.,
+                                        lead_thickness_/2.);
+
+    // horizontal top beams
     G4Box* top_xbeam_solid = new G4Box("STRUCT_BEAM",
                                        (shield_x_ + 2.*lead_thickness_ + 2.*steel_thickness_)/2.,
                                        lead_thickness_/2.,
-                                       beam_thickness_/2.);
+                                       beam_thickness_1/2.);
 
     G4Box* top_zbeam_solid = new G4Box("STRUCT_BEAM",
-                                       beam_thickness_/2.,
+                                       beam_thickness_2/2.,
                                        lead_thickness_/2.,
                                        (shield_z_ + 2.*lead_thickness_ + 2.*steel_thickness_)/2.);
 
@@ -135,6 +144,9 @@ namespace nexus {
     G4LogicalVolume* lat_beam_logic  = new G4LogicalVolume(lat_beam_solid,
                                                            MaterialsList::Steel(), "STEEL_BEAM_STRUCTURE_LAT");
 
+    G4LogicalVolume* front_beam_logic = new G4LogicalVolume(front_beam_solid,
+                                                            MaterialsList::Steel(), "STEEL_BEAM_STRUCTURE_FRONT");
+
      G4LogicalVolume* struct_logic   = new G4LogicalVolume(struct_solid,
                                                            MaterialsList::Steel(), "STEEL_BEAM_STRUCTURE_TOP");
 
@@ -158,19 +170,17 @@ namespace nexus {
                       lat_beam_logic, "STEEL_BEAM_STRUCTURE_lat4", lead_box_logic, false, 0, false);
 
     // front beams
-    G4RotationMatrix* rot_beam = new G4RotationMatrix();
-    rot_beam->rotateY(pi/2.);
-    new G4PVPlacement(rot_beam, G4ThreeVector(-front_x_separation_/2., lat_beam_y, front_beam_z),
-                      lat_beam_logic, "STEEL_BEAM_STRUCTURE_lat5", lead_box_logic, false, 0, false);
+    new G4PVPlacement(0, G4ThreeVector(-front_x_separation_/2., lat_beam_y, front_beam_z),
+                      front_beam_logic, "STEEL_BEAM_STRUCTURE_front1", lead_box_logic, false, 0, false);
 
-    new G4PVPlacement(rot_beam, G4ThreeVector(front_x_separation_/2., lat_beam_y, front_beam_z),
-                      lat_beam_logic, "STEEL_BEAM_STRUCTURE_lat6", lead_box_logic, false, 0, false);
+    new G4PVPlacement(0, G4ThreeVector(front_x_separation_/2., lat_beam_y, front_beam_z),
+                      front_beam_logic, "STEEL_BEAM_STRUCTURE_front2", lead_box_logic, false, 0, false);
 
-    new G4PVPlacement(rot_beam, G4ThreeVector(-front_x_separation_/2., lat_beam_y, -front_beam_z),
-                      lat_beam_logic, "STEEL_BEAM_STRUCTURE_lat7", lead_box_logic, false, 0, false);
+    new G4PVPlacement(0, G4ThreeVector(-front_x_separation_/2., lat_beam_y, -front_beam_z),
+                      front_beam_logic, "STEEL_BEAM_STRUCTURE_front3", lead_box_logic, false, 0, false);
 
-    new G4PVPlacement(rot_beam, G4ThreeVector(front_x_separation_/2., lat_beam_y, -front_beam_z),
-                      lat_beam_logic,"STEEL_BEAM_STRUCTURE_lat8", lead_box_logic, false, 0, false);
+    new G4PVPlacement(0, G4ThreeVector(front_x_separation_/2., lat_beam_y, -front_beam_z),
+                      front_beam_logic,"STEEL_BEAM_STRUCTURE_front4", lead_box_logic, false, 0, false);
 
 
     // STEEL BOX   ///////////
@@ -183,7 +193,7 @@ namespace nexus {
     G4LogicalVolume* steel_box_logic = new G4LogicalVolume(steel_box_solid,
                                                            MaterialsList::Steel(), "STEEL_BOX");
 
-    new G4PVPlacement(0, G4ThreeVector(0., -beam_thickness_/2., 0.),
+    new G4PVPlacement(0, G4ThreeVector(0., -beam_thickness_2/2., 0.),
                       steel_box_logic, "STEEL_BOX", lead_box_logic, false, 0);
 
     // AIR INSIDE
@@ -283,28 +293,29 @@ namespace nexus {
                                         G4ThreeVector(0., 0., 0.), 0);
 
     steel_gen_ = new BoxPointSampler(shield_x_, shield_y_, shield_z_, steel_thickness_,
-                                     G4ThreeVector(0., -beam_thickness_/2., 0.), 0);
+                                     G4ThreeVector(0., -beam_thickness_1/2., 0.), 0);
 
     G4double inn_offset = .5 * cm;
     inner_air_gen_ = new BoxPointSampler(shield_x_ - inn_offset, shield_y_ - inn_offset, shield_z_ - inn_offset, 1. * mm,
-                                         G4ThreeVector(0., -beam_thickness_/2., 0.), 0);
+                                         G4ThreeVector(0., -beam_thickness_1/2., 0.), 0);
 
-    lat_roof_gen_ = new BoxPointSampler(lead_thickness_, beam_thickness_, shield_z_ + 2.*steel_thickness_, 0.,
+    // Steel structure generators
+    lat_roof_gen_ = new BoxPointSampler(lead_thickness_, beam_thickness_2, shield_z_ + 2.*steel_thickness_, 0.,
                                         G4ThreeVector(0., roof_y, 0.), 0);
 
-    front_roof_gen_ = new BoxPointSampler(lead_x_, beam_thickness_, lead_thickness_, 0.,
+    front_roof_gen_ = new BoxPointSampler(lead_x_, beam_thickness_2, lead_thickness_, 0.,
                                           G4ThreeVector(0., roof_y, 0.), 0);
 
-    struct_x_gen_ = new BoxPointSampler(shield_x_ + 2.*lead_thickness_ + 2.*steel_thickness_, lead_thickness_, beam_thickness_, 0.,
+    struct_x_gen_ = new BoxPointSampler(shield_x_ + 2.*lead_thickness_ + 2.*steel_thickness_, lead_thickness_, beam_thickness_1, 0.,
                                         G4ThreeVector(0., top_beam_y, roof_z_separation_+lateral_z_separation_/2.), 0);
 
-    struct_z_gen_ = new BoxPointSampler(beam_thickness_, lead_thickness_, shield_z_ + 2.*lead_thickness_ + 2.*steel_thickness_, 0.,
+    struct_z_gen_ = new BoxPointSampler(beam_thickness_2, lead_thickness_, shield_z_ + 2.*lead_thickness_ + 2.*steel_thickness_, 0.,
                                         G4ThreeVector(-front_x_separation_/2., top_beam_y, 0.), 0);
 
-    lat_beam_gen_ = new BoxPointSampler(lead_thickness_, shield_y_ + 2. * steel_thickness_+ lead_thickness_, beam_thickness_, 0.,
+    lat_beam_gen_ = new BoxPointSampler(lead_thickness_, shield_y_ + 2. * steel_thickness_+ lead_thickness_, beam_thickness_1, 0.,
                                         G4ThreeVector(lat_beam_x, -lead_thickness_/2., lateral_z_separation_/2.), 0);
 
-    front_beam_gen_ = new BoxPointSampler(beam_thickness_, shield_y_ + 2. * steel_thickness_+ lead_thickness_, lead_thickness_, 0.,
+    front_beam_gen_ = new BoxPointSampler(beam_thickness_2, shield_y_ + 2. * steel_thickness_+ lead_thickness_, lead_thickness_, 0.,
                                           G4ThreeVector(-front_x_separation_/2., -lead_thickness_/2., front_beam_z), 0);
 
 
@@ -315,10 +326,10 @@ namespace nexus {
     G4double total_vol      = roof_vol + struct_top_vol + (8*lateral_vol);
 
     perc_roof_vol_       = roof_vol/total_vol;
-    perc_front_roof_vol_ = 2*(lead_x_*beam_thickness_*lead_thickness_)/roof_vol;
+    perc_front_roof_vol_ = 2*(lead_x_*beam_thickness_1*lead_thickness_)/roof_vol;
     perc_top_struct_vol_ = struct_top_vol /total_vol;
 
-    G4double struc_beam_x_vol = (shield_x_ + 2.*lead_thickness_ + 2.*steel_thickness_)*lead_thickness_*beam_thickness_;
+    G4double struc_beam_x_vol = (shield_x_ + 2.*lead_thickness_ + 2.*steel_thickness_)*lead_thickness_*beam_thickness_1;
     perc_struc_x_vol_    = 4*struc_beam_x_vol/struct_top_vol;
 
     if (verbosity_){
@@ -462,41 +473,41 @@ namespace nexus {
             	G4double rand_beam = int (8 * G4UniformRand());
             	// std::cout<< "viga numero "<<rand_beam<<std::endl; //0-7
             	if (rand_beam == 0) {
-            	  //lat_1 (lat_beam_x,-beam_thickness_/2.,lateral_z_separation_/2.)
+            	  //lat_1 (lat_beam_x,-beam_thickness_1/2.,lateral_z_separation_/2.)
             	  vertex = lat_beam_gen_->GenerateVertex("INSIDE");
             	}
             	else if (rand_beam ==1){
-            	  // //lat_2 (lat_beam_x,-beam_thickness_/2.,-lateral_z_separation_/2.)
+            	  // //lat_2 (lat_beam_x,-beam_thickness_1/2.,-lateral_z_separation_/2.)
             	  vertex = lat_beam_gen_->GenerateVertex("INSIDE");
             	  vertex.setZ(vertex.z() - lateral_z_separation_);
             	}
             	else if (rand_beam ==2){
-            	  // //lat_3 	(-lat_beam_x,-beam_thickness_/2.,lateral_z_separation_/2.)
+            	  // //lat_3 	(-lat_beam_x,-beam_thickness_1/2.,lateral_z_separation_/2.)
             	  vertex = lat_beam_gen_->GenerateVertex("INSIDE");
             	  vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ + lead_thickness_));
             	}
             	else if (rand_beam ==3){
-            	  // //lat_4 (-lat_beam_x,-beam_thickness_/2.,-lateral_z_separation_/2.)
+            	  // //lat_4 (-lat_beam_x,-beam_thickness_1/2.,-lateral_z_separation_/2.)
             	  vertex = lat_beam_gen_->GenerateVertex("INSIDE");
             	  vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ + lead_thickness_));
             	  vertex.setZ(vertex.z() - lateral_z_separation_);
             	}
             	else if (rand_beam ==4){
-            	  // //lat_5 front_beam (-front_x_separation_/2.,-beam_thickness_/2.,front_beam_z)
+            	  // //lat_5 front_beam (-front_x_separation_/2.,-beam_thickness_1/2.,front_beam_z)
             	  vertex = front_beam_gen_->GenerateVertex("INSIDE");
             	}
             	else if (rand_beam ==5){
-            	  // //lat_6 front_beam (front_x_separation_/2.,-beam_thickness_/2.,front_beam_z)
+            	  // //lat_6 front_beam (front_x_separation_/2.,-beam_thickness_1/2.,front_beam_z)
             	  vertex = front_beam_gen_->GenerateVertex("INSIDE");
             	  vertex.setX(vertex.x() + front_x_separation_);
             	}
             	else if (rand_beam ==6){
-            	  // //lat_7 front_beam (-front_x_separation_/2.,-beam_thickness_/2.,-front_beam_z)
+            	  // //lat_7 front_beam (-front_x_separation_/2.,-beam_thickness_1/2.,-front_beam_z)
             	  vertex = front_beam_gen_->GenerateVertex("INSIDE");
             	  vertex.setZ(vertex.z() - (shield_z_+2*steel_thickness_+lead_thickness_));
             	}
             	else if (rand_beam ==7){
-            	  //lat_8 front_beam (front_x_separation_/2.,-beam_thickness_/2.,-front_beam_z)
+            	  //lat_8 front_beam (front_x_separation_/2.,-beam_thickness_1/2.,-front_beam_z)
             	  vertex = front_beam_gen_->GenerateVertex("INSIDE");
             	  vertex.setX(vertex.x() + front_x_separation_);
             	  vertex.setZ(vertex.z() - (shield_z_+2*steel_thickness_+lead_thickness_));

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -264,10 +264,10 @@ namespace nexus {
                                                                            MaterialsList::Steel316Ti(), "PEDESTAL_SUPPORT_TOP");
 
     G4LogicalVolume* pedestal_beam_front_logic = new G4LogicalVolume(pedestal_beam_front,
-                                                                     MaterialsList::Steel316Ti(), "PEDESTAL_SUPPORT_FRONT");
+                                                                     MaterialsList::Steel316Ti(), "PEDESTAL_BEAM_FRONT");
 
     G4LogicalVolume* pedestal_beam_lateral_logic = new G4LogicalVolume(pedestal_beam_lateral,
-                                                                       MaterialsList::Steel316Ti(), "PEDESTAL_SUPPORT_FRONT");
+                                                                       MaterialsList::Steel316Ti(), "PEDESTAL_BEAM_LATERAL");
 
     G4LogicalVolume* pedestal_roof_logic = new G4LogicalVolume(pedestal_roof,
                                                                MaterialsList::Steel316Ti(), "PEDESTAL_ROOF");
@@ -321,6 +321,12 @@ namespace nexus {
       roof_logic     ->SetVisAttributes(G4VisAttributes::Invisible);
       struct_logic   ->SetVisAttributes(G4VisAttributes::Invisible);
       lat_beam_logic ->SetVisAttributes(G4VisAttributes::Invisible);
+
+      pedestal_support_beam_bottom_logic->SetVisAttributes(G4VisAttributes::Invisible);
+      pedestal_support_beam_top_logic   ->SetVisAttributes(G4VisAttributes::Invisible);
+      pedestal_beam_front_logic         ->SetVisAttributes(G4VisAttributes::Invisible);
+      pedestal_beam_lateral_logic       ->SetVisAttributes(G4VisAttributes::Invisible);
+      pedestal_roof_logic               ->SetVisAttributes(G4VisAttributes::Invisible);
     }
 
 

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -41,13 +41,13 @@ namespace nexus {
     shield_z_ {259.4 * cm},
 
     //Steel Structure
-    beam_thickness_      {5.   * cm}, // 4 and 6 mm
+    beam_thickness_      {4.   * mm},
     lateral_z_separation_{1010.* mm}, //distance between the two lateral beams
     roof_z_separation_   {760. * mm}, //distance between x beams
     front_x_separation_  {156. * mm}, //distance between the two front beams
     // Box thickness
-    lead_thickness_ {20. * cm}, // 2 * mm
-    steel_thickness_{10.0 * cm},
+    lead_thickness_ {20.* cm},
+    steel_thickness_{2. * mm},
     visibility_ {0},
     verbosity_{false}
 
@@ -203,12 +203,10 @@ namespace nexus {
 
 
     // PEDESTAL BEAMS
-
     // T shape beams that support the vessel
-
     // change beam_thickness by real thicknesses
-    G4double pedestal_support_bottom_thickness = beam_thickness_; // 10. mm
-    G4double pedestal_support_top_thickness = beam_thickness_;    // 15. mm
+    G4double pedestal_support_bottom_thickness = 10. * mm;
+    G4double pedestal_support_top_thickness = 15. * mm;
 
     G4Box* pedestal_support_beam_bottom = new G4Box("PEDESTAL_SUPPORT_BEAM_BOTTOM",
                                                     shield_x_/2.,

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -429,7 +429,7 @@ namespace nexus {
 
       G4double inner_vol = air_box_solid  ->GetCubicVolume();
       G4double steel_vol = steel_box_solid->GetCubicVolume() - inner_vol;
-      G4double lead_vol  = lead_box_solid ->GetCubicVolume() - steel_vol;
+      G4double lead_vol  = lead_box_solid ->GetCubicVolume() - inner_vol - steel_vol;
 
       std::cout<<"INNER AIR VOLUME   (m3) "<< inner_vol/1.e9 <<std::endl;
       std::cout<<"INNER STEEL VOLUME (m3) "<< steel_vol/1.e9 <<std::endl;

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -33,23 +33,23 @@ namespace nexus {
   using namespace CLHEP;
 
   Next100Shielding::Next100Shielding():
-    GeometryBase(),
+    GeometryBase{},
 
     // Shielding internal dimensions
-    shield_x_ (158.  * cm),
-    shield_y_ (166.6 * cm),
-    shield_z_ (259.4 * cm),
+    shield_x_ {158.  * cm},
+    shield_y_ {166.6 * cm},
+    shield_z_ {259.4 * cm},
 
     //Steel Structure
-    beam_thickness_      (4.   * mm),
-    lateral_z_separation_(1010.* mm), //distance between the two lateral beams
-    roof_z_separation_   (760. * mm), //distance between x beams
-    front_x_separation_  (156. * mm), //distance between the two front beams
+    beam_thickness_      {4.   * mm},
+    lateral_z_separation_{1010.* mm}, //distance between the two lateral beams
+    roof_z_separation_   {760. * mm}, //distance between x beams
+    front_x_separation_  {156. * mm}, //distance between the two front beams
     // Box thickness
-    lead_thickness_ (20. * cm),
-    steel_thickness_(2.0 * mm),
-    visibility_ (0),
-    verbosity_(false)
+    lead_thickness_ {20. * cm},
+    steel_thickness_{2.0 * mm},
+    visibility_ {0},
+    verbosity_{false}
 
   {
     // The shielding is made of two boxes.

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -37,7 +37,7 @@ namespace nexus {
 
     // Shielding internal dimensions
     shield_x_ (158.  * cm),
-    shield_y_ (166.  * cm),
+    shield_y_ (166.6 * cm),
     shield_z_ (259.4 * cm),
 
     //Steel Structure

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -52,6 +52,7 @@ namespace nexus {
     steel_thickness_{2. * mm},
 
     // Pedestal
+    pedestal_x_        {1534. * mm},
     support_beam_dist_ {1027. * mm},
     support_lat_dist_  {732.  * mm},
 
@@ -226,17 +227,17 @@ namespace nexus {
     G4double pedestal_support_top_length       = 150. * mm;
     G4double pedestal_lateral_beam_thickness   = 20.  * mm;
     G4Box* pedestal_support_beam_bottom = new G4Box("PEDESTAL_SUPPORT_BEAM_BOTTOM",
-                                                    shield_x_/2.,
+                                                    pedestal_x_/2.,
                                                     lead_thickness_/2.,
                                                     pedestal_support_bottom_thickness/2.);
 
     G4Box* pedestal_support_beam_top = new G4Box("PEDESTAL_SUPPORT_BEAM_TOP",
-                                                 shield_x_/2.,
+                                                 pedestal_x_/2.,
                                                  pedestal_support_top_thickness/2.,
                                                  pedestal_support_top_length/2.);
 
     G4Box* pedestal_beam_lat = new G4Box("PEDESTAL_BEAM_LAT",
-                                         shield_x_/2.,
+                                         pedestal_x_/2.,
                                          lead_thickness_/2.,
                                          pedestal_lateral_beam_thickness/2.);
 
@@ -341,14 +342,14 @@ namespace nexus {
 
 
     // PEDESTAL GENERATORS
-    ped_support_bottom_gen_ = new BoxPointSampler(shield_x_, lead_thickness_, pedestal_support_bottom_thickness, 0.,
+    ped_support_bottom_gen_ = new BoxPointSampler(pedestal_x_, lead_thickness_, pedestal_support_bottom_thickness, 0.,
                                                   G4ThreeVector(0., pedestal_y_pos, support_beam_dist_/2.), 0);
 
     G4double ped_gen_y_ = -lead_y_/2. + lead_thickness_ + pedestal_support_top_thickness/2.;
-    ped_support_top_gen_ = new BoxPointSampler(shield_x_, pedestal_support_top_thickness, pedestal_support_top_length, 0.,
+    ped_support_top_gen_ = new BoxPointSampler(pedestal_x_, pedestal_support_top_thickness, pedestal_support_top_length, 0.,
                                                G4ThreeVector(0., ped_gen_y_, support_beam_dist_/2.), 0);
 
-    ped_lat_gen_ = new BoxPointSampler(shield_x_, lead_thickness_, pedestal_lateral_beam_thickness, 0.,
+    ped_lat_gen_ = new BoxPointSampler(pedestal_x_, lead_thickness_, pedestal_lateral_beam_thickness, 0.,
                                        G4ThreeVector(0., pedestal_y_pos, support_beam_dist_/2. + support_lat_dist_), 0);
 
     // Compute relative volumes
@@ -376,6 +377,11 @@ namespace nexus {
       std::cout<<"INNER AIR VOLUME   (m3) "<< inner_vol/1.e9 <<std::endl;
       std::cout<<"INNER STEEL VOLUME (m3) "<< steel_vol/1.e9 <<std::endl;
       std::cout<<"LEAD VOLUME        (m3) "<< lead_vol /1.e9 <<std::endl;
+
+      std::cout << "PEDESTAL GENERATOR PERCENTS" << std::endl;
+      std::cout << "BOTTOM " << perc_ped_bottom_vol_ * 100 << std::endl;
+      std::cout << "TOP "    << perc_ped_top_vol_    * 100 << std::endl;
+      std::cout << "LAT "    << perc_ped_lat_vol_    * 100 << std::endl;
     }
   }
 

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -496,16 +496,15 @@ namespace nexus {
 
     // EDPM SEAL
     edpm_seal_front_gen_ =
-      new BoxPointSampler(edpm_seal_thickness_, steel_y, edpm_seal_thickness_, 0.,
-                          G4ThreeVector(0., -beam_thickness_2/2., 0.), 0);
+      new BoxPointSampler(edpm_seal_thickness_, shield_y_, edpm_seal_thickness_, 0.,
+                          G4ThreeVector(0., -(beam_thickness_2+steel_thickness_)/2., 0.), 0);
 
     edpm_seal_lateral_gen_ =
-      new BoxPointSampler(edpm_seal_thickness_, edpm_seal_thickness_, steel_z, 0.,
-                          G4ThreeVector(0., -beam_thickness_2/2., 0.), 0);
+      new BoxPointSampler(edpm_seal_thickness_, edpm_seal_thickness_, shield_z_, 0.,
+                          G4ThreeVector(0., -(beam_thickness_2+steel_thickness_)/2., 0.), 0);
 
-    G4double edpm_front_vol   = 2*edpm_seal_thickness_ * steel_y * edpm_seal_thickness_;
-    G4double edpm_lateral_vol =   edpm_seal_thickness_ * edpm_seal_thickness_
-                                 * (steel_z + 2*steel_thickness_);
+    G4double edpm_front_vol   = 2*edpm_seal_thickness_ * shield_y_ * edpm_seal_thickness_;
+    G4double edpm_lateral_vol =   edpm_seal_thickness_ * edpm_seal_thickness_ * shield_z_;
 
     perc_edpm_front_vol_   = edpm_front_vol  /(edpm_front_vol + edpm_lateral_vol);
     perc_edpm_lateral_vol_ = edpm_lateral_vol/(edpm_front_vol + edpm_lateral_vol);
@@ -768,15 +767,15 @@ namespace nexus {
       if (rand<perc_edpm_front_vol_){ // front
         vertex = edpm_seal_front_gen_->GenerateVertex("INSIDE");
         if (G4UniformRand() < 0.5){
-          vertex.setZ(vertex.z() + (shield_z_/2. + steel_thickness_ + edpm_seal_thickness_/2.));
+          vertex.setZ(vertex.z() + (shield_z_/2. - edpm_seal_thickness_/2.));
         }
         else{
-          vertex.setZ(vertex.z() - (shield_z_/2. + steel_thickness_ + edpm_seal_thickness_/2.));
+          vertex.setZ(vertex.z() - (shield_z_/2. - edpm_seal_thickness_/2.));
         }
       }
       else{ // lateral
         vertex = edpm_seal_lateral_gen_->GenerateVertex("INSIDE");
-        vertex.setY(vertex.y() + (shield_y_/2. + steel_thickness_ + edpm_seal_thickness_/2.));
+        vertex.setY(vertex.y() + (shield_y_/2. - edpm_seal_thickness_/2.));
       }
     }
 

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -549,6 +549,7 @@ namespace nexus {
     else if (region == "EXTERNAL") {
       vertex = external_gen_->GenerateVertex("WHOLE_VOL");
     }
+
     else if(region=="SHIELDING_STRUCT"){
         G4double rand = G4UniformRand();
 
@@ -556,27 +557,21 @@ namespace nexus {
         	// G4VPhysicalVolume *VertexVolume;
         	// do {
         	if (G4UniformRand() <  perc_front_roof_vol_){
-          	  if (G4UniformRand() < 0.5) {
-          	    vertex = front_roof_gen_->GenerateVertex("INSIDE");
-          	    vertex.setZ(vertex.z() + (shield_z_/2.+steel_thickness_+lead_thickness_/2.));
-    	          // std::cout<<"frontal +"<<std::endl;
-          	  }
-          	  else{
-          	    vertex = front_roof_gen_->GenerateVertex("INSIDE");
-          	    vertex.setZ(vertex.z() - (shield_z_/2.+steel_thickness_+lead_thickness_/2.));
-          	    // std::cout<<"frontal -"<<std::endl;
-          	  }
+            vertex = front_roof_gen_->GenerateVertex("INSIDE");
+            if (G4UniformRand() < 0.5) {
+              vertex.setZ(vertex.z() + (shield_z_/2.+steel_thickness_+lead_thickness_/2.));
+            }
+            else{
+              vertex.setZ(vertex.z() - (shield_z_/2.+steel_thickness_+lead_thickness_/2.));
+            }
         	}
         	else{
+              vertex = lat_roof_gen_->GenerateVertex("INSIDE");
           	  if (G4UniformRand() < 0.5) {
-          	    vertex = lat_roof_gen_->GenerateVertex("INSIDE");
           	    vertex.setX(vertex.x() + (shield_x_/2.+ steel_thickness_ + lead_thickness_/2.));
-          	    // std::cout<<"lateral +"<<std::endl;
           	  }
           	  else{
-          	    vertex = lat_roof_gen_->GenerateVertex("INSIDE");
           	    vertex.setX(vertex.x() - (shield_x_/2.+ steel_thickness_ + lead_thickness_/2.));
-          	    // std::cout<<"lateral -"<<std::endl;
           	  }
         	}
         	// VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(vertex, 0, false);
@@ -587,76 +582,55 @@ namespace nexus {
             	G4double random = G4UniformRand();
             	if (random <  perc_struc_x_vol_){
             	  G4double rand_beam = int (4* G4UniformRand());
-            	  if (rand_beam == 0) {
-            	    vertex = struct_x_gen_->GenerateVertex("INSIDE");
-            	  }
-            	  else if (rand_beam == 1) {
-            	    vertex = struct_x_gen_->GenerateVertex("INSIDE");
+                vertex = struct_x_gen_->GenerateVertex("INSIDE");
+            	  if (rand_beam == 1) {
             	    vertex.setZ(vertex.z()-roof_z_separation_);
             	  }
             	  else if (rand_beam == 2) {
-            	    vertex = struct_x_gen_->GenerateVertex("INSIDE");
             	    vertex.setZ(vertex.z()-(roof_z_separation_+lateral_z_separation_));
             	  }
             	  else if (rand_beam == 3) {
-            	    vertex = struct_x_gen_->GenerateVertex("INSIDE");
             	    vertex.setZ(vertex.z()-(2*roof_z_separation_+lateral_z_separation_));
             	  }
             	}
             	else {
+                vertex = struct_z_gen_->GenerateVertex("INSIDE");
             	  if (G4UniformRand() < 0.5) {
-            	    vertex = struct_z_gen_->GenerateVertex("INSIDE");
-            	  }
-            	  else {
-            	    vertex = struct_z_gen_->GenerateVertex("INSIDE");
             	    vertex.setX(vertex.x()+front_x_separation_);
             	  }
               }
         }
 
-        else{    //LATERAL BEAM STRUCTURE
-            	G4double rand_beam = int (8 * G4UniformRand());
-            	// std::cout<< "viga numero "<<rand_beam<<std::endl; //0-7
-            	if (rand_beam == 0) {
-            	  //lat_1 (lat_beam_x,-beam_thickness_1/2.,lateral_z_separation_/2.)
-            	  vertex = lat_beam_gen_->GenerateVertex("INSIDE");
-            	}
-            	else if (rand_beam ==1){
-            	  // //lat_2 (lat_beam_x,-beam_thickness_1/2.,-lateral_z_separation_/2.)
-            	  vertex = lat_beam_gen_->GenerateVertex("INSIDE");
-            	  vertex.setZ(vertex.z() - lateral_z_separation_);
-            	}
-            	else if (rand_beam ==2){
-            	  // //lat_3 	(-lat_beam_x,-beam_thickness_1/2.,lateral_z_separation_/2.)
-            	  vertex = lat_beam_gen_->GenerateVertex("INSIDE");
-            	  vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ + lead_thickness_));
-            	}
-            	else if (rand_beam ==3){
-            	  // //lat_4 (-lat_beam_x,-beam_thickness_1/2.,-lateral_z_separation_/2.)
-            	  vertex = lat_beam_gen_->GenerateVertex("INSIDE");
-            	  vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ + lead_thickness_));
-            	  vertex.setZ(vertex.z() - lateral_z_separation_);
-            	}
-            	else if (rand_beam ==4){
-            	  // //lat_5 front_beam (-front_x_separation_/2.,-beam_thickness_1/2.,front_beam_z)
-            	  vertex = front_beam_gen_->GenerateVertex("INSIDE");
-            	}
-            	else if (rand_beam ==5){
-            	  // //lat_6 front_beam (front_x_separation_/2.,-beam_thickness_1/2.,front_beam_z)
-            	  vertex = front_beam_gen_->GenerateVertex("INSIDE");
-            	  vertex.setX(vertex.x() + front_x_separation_);
-            	}
-            	else if (rand_beam ==6){
-            	  // //lat_7 front_beam (-front_x_separation_/2.,-beam_thickness_1/2.,-front_beam_z)
-            	  vertex = front_beam_gen_->GenerateVertex("INSIDE");
-            	  vertex.setZ(vertex.z() - (shield_z_+2*steel_thickness_+lead_thickness_));
-            	}
-            	else if (rand_beam ==7){
-            	  //lat_8 front_beam (front_x_separation_/2.,-beam_thickness_1/2.,-front_beam_z)
-            	  vertex = front_beam_gen_->GenerateVertex("INSIDE");
-            	  vertex.setX(vertex.x() + front_x_separation_);
-            	  vertex.setZ(vertex.z() - (shield_z_+2*steel_thickness_+lead_thickness_));
-            	}
+        else{ //LATERAL BEAM STRUCTURE
+              G4double lat_prob = beam_thickness_1/(beam_thickness_1+beam_thickness_2);
+              if (G4UniformRand()<lat_prob){ //lateral
+              	G4double rand_beam = int (4 * G4UniformRand());
+                vertex = lat_beam_gen_->GenerateVertex("INSIDE");
+              	if (rand_beam ==1){
+              	  vertex.setZ(vertex.z() - lateral_z_separation_);
+              	}
+              	else if (rand_beam ==2){
+              	  vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ + lead_thickness_));
+              	}
+              	else if (rand_beam ==3){
+              	  vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ + lead_thickness_));
+              	  vertex.setZ(vertex.z() - lateral_z_separation_);
+              	}
+              }
+              else{ // front
+                G4double rand_beam = int (4 * G4UniformRand());
+                vertex = front_beam_gen_->GenerateVertex("INSIDE");
+              	if (rand_beam ==1){
+              	  vertex.setX(vertex.x() + front_x_separation_);
+              	}
+              	else if (rand_beam ==2){
+              	  vertex.setZ(vertex.z() - (shield_z_+2*steel_thickness_+lead_thickness_));
+              	}
+              	else if (rand_beam ==3){
+              	  vertex.setX(vertex.x() + front_x_separation_);
+              	  vertex.setZ(vertex.z() - (shield_z_+2*steel_thickness_+lead_thickness_));
+              	}
+              }
             }
         }
 
@@ -664,57 +638,39 @@ namespace nexus {
         G4double rand = G4UniformRand();
 
         if (rand < perc_ped_bottom_vol_) { //SUPPORT-BOTTOM
+          vertex = ped_support_bottom_gen_->GenerateVertex("INSIDE");
       	  if (G4UniformRand() < 0.5) {
-      	    vertex = ped_support_bottom_gen_->GenerateVertex("INSIDE");
-      	  }
-      	  else{
-      	    vertex = ped_support_bottom_gen_->GenerateVertex("INSIDE");
       	    vertex.setZ(vertex.z() - support_beam_dist_);
       	  }
         }
         else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_)) { //SUPPORT-TOP
+          vertex = ped_support_top_gen_->GenerateVertex("INSIDE");
           if (G4UniformRand() < 0.5) {
-      	    vertex = ped_support_top_gen_->GenerateVertex("INSIDE");
-      	  }
-      	  else{
-      	    vertex = ped_support_top_gen_->GenerateVertex("INSIDE");
       	    vertex.setZ(vertex.z() - support_beam_dist_);
       	  }
         }
         else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_ + perc_ped_front_vol_)){ //FRONT BEAM
+          vertex = ped_front_gen_->GenerateVertex("INSIDE");
           if (G4UniformRand() < 0.5) {
-      	    vertex = ped_front_gen_->GenerateVertex("INSIDE");
-      	  }
-      	  else{
-      	    vertex = ped_front_gen_->GenerateVertex("INSIDE");
       	    vertex.setZ(vertex.z() - (2.*support_front_dist_ + support_beam_dist_));
       	  }
         }
         else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_ + perc_ped_front_vol_ + perc_ped_lateral_vol_)){ // LATERAL BEAM
+          vertex = ped_lateral_gen_->GenerateVertex("INSIDE");
           if (G4UniformRand() < 0.5) {
-            vertex = ped_lateral_gen_->GenerateVertex("INSIDE");
-          }
-          else{
-            vertex = ped_lateral_gen_->GenerateVertex("INSIDE");
             vertex.setX(vertex.x() - (pedestal_x_ + pedestal_lateral_beam_thickness_));
           }
          }
         else { // ROOF
           if (G4UniformRand() < 0.5) {
+            vertex = ped_roof_lat_gen_->GenerateVertex("INSIDE");
             if (G4UniformRand() < 0.5){
-              vertex = ped_roof_lat_gen_->GenerateVertex("INSIDE");
-            }
-            else{
-              vertex = ped_roof_lat_gen_->GenerateVertex("INSIDE");
               vertex.setX(vertex.x() - pedestal_top_x_ - pedestal_roof_thickness_);
             }
           }
           else{
+            vertex = ped_roof_front_gen_->GenerateVertex("INSIDE");
             if (G4UniformRand() < 0.5){
-              vertex = ped_roof_front_gen_->GenerateVertex("INSIDE");
-            }
-            else{
-              vertex = ped_roof_front_gen_->GenerateVertex("INSIDE");
               vertex.setZ(vertex.z() - pedestal_lateral_length_ + pedestal_roof_thickness_);
             }
           }
@@ -724,22 +680,20 @@ namespace nexus {
     else if(region=="BUBBLE_SEAL"){
       G4double rand = G4UniformRand();
       if (rand<perc_bubble_front_vol_){ // front
+        vertex = bubble_seal_front_gen_->GenerateVertex("INSIDE");
         if (G4UniformRand() < 0.5){
-          vertex = bubble_seal_front_gen_->GenerateVertex("INSIDE");
           vertex.setZ(vertex.z() + (support_beam_dist_/2. + support_front_dist_ + pedestal_front_beam_thickness_/2. + bubble_seal_thickness_/2.));
         }
         else{
-          vertex = bubble_seal_front_gen_->GenerateVertex("INSIDE");
           vertex.setZ(vertex.z() - (support_beam_dist_/2. + support_front_dist_ + pedestal_front_beam_thickness_/2. + bubble_seal_thickness_/2.));
         }
       }
       else{ // lateral
+        vertex = bubble_seal_lateral_gen_->GenerateVertex("INSIDE");
         if (G4UniformRand() < 0.5){
-          vertex = bubble_seal_lateral_gen_->GenerateVertex("INSIDE");
           vertex.setX(vertex.x() + (pedestal_x_/2. + pedestal_lateral_beam_thickness_ + bubble_seal_thickness_/2.));
         }
         else{
-          vertex = bubble_seal_lateral_gen_->GenerateVertex("INSIDE");
           vertex.setX(vertex.x() - (pedestal_x_/2. + pedestal_lateral_beam_thickness_ + bubble_seal_thickness_/2.));
         }
       }
@@ -748,12 +702,11 @@ namespace nexus {
     else if(region=="EDPM_SEAL"){
       G4double rand = G4UniformRand();
       if (rand<perc_edpm_front_vol_){ // front
+        vertex = edpm_seal_front_gen_->GenerateVertex("INSIDE");
         if (G4UniformRand() < 0.5){
-          vertex = edpm_seal_front_gen_->GenerateVertex("INSIDE");
           vertex.setZ(vertex.z() + (shield_z_/2. + steel_thickness_ + edpm_seal_thickness_/2.));
         }
         else{
-          vertex = edpm_seal_front_gen_->GenerateVertex("INSIDE");
           vertex.setZ(vertex.z() - (shield_z_/2. + steel_thickness_ + edpm_seal_thickness_/2.));
         }
       }

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -202,6 +202,57 @@ namespace nexus {
                       air_box_logic_, "INNER_AIR", steel_box_logic, false, 0);
 
 
+    // PEDESTAL BEAMS
+
+    // T shape beams that support the vessel
+
+    // change beam_thickness by real thicknesses
+    G4double pedestal_support_bottom_thickness = beam_thickness_; // 10. mm
+    G4double pedestal_support_top_thickness = beam_thickness_;    // 15. mm
+
+    G4Box* pedestal_support_beam_bottom = new G4Box("PEDESTAL_SUPPORT_BEAM_BOTTOM",
+                                                    shield_x_/2.,
+                                                    lead_thickness_/2.,
+                                                    pedestal_support_bottom_thickness/2.);
+
+    G4Box* pedestal_support_beam_top = new G4Box("PEDESTAL_SUPPORT_BEAM_TOP",
+                                                 shield_x_/2.,
+                                                 pedestal_support_top_thickness/2.,
+                                                 (150. * mm)/2.);
+
+    G4Box* pedestal_support_beam_lat = new G4Box("PEDESTAL_SUPPORT_BEAM_LAT",
+                                                 shield_x_/2.,
+                                                 lead_thickness_/2.,
+                                                 pedestal_support_bottom_thickness);
+
+    G4LogicalVolume* pedestal_support_beam_bottom_logic = new G4LogicalVolume(pedestal_support_beam_bottom,
+                                                                              MaterialsList::Steel(), "PEDESTAL_SUPPORT_BOTTOM"); // steel inox
+
+    G4LogicalVolume* pedestal_support_beam_top_logic = new G4LogicalVolume(pedestal_support_beam_top,
+                                                                           MaterialsList::Steel(), "PEDESTAL_SUPPORT_TOP"); // steel inox
+
+    G4LogicalVolume* pedestal_support_beam_lat_logic = new G4LogicalVolume(pedestal_support_beam_lat,
+                                                                           MaterialsList::Steel(), "PEDESTAL_SUPPORT_LAT"); // steel inox
+
+    G4double pedestal_y_pos = -lead_y_/2. + lead_thickness_/2.;
+    new G4PVPlacement(0, G4ThreeVector(0., pedestal_y_pos, (1027. * mm)/2.),
+                      pedestal_support_beam_bottom_logic, "PEDESTAL_SUPPORT_BEAM_BOTTOM_1", lead_box_logic, false, 0);
+
+    new G4PVPlacement(0, G4ThreeVector(0., pedestal_y_pos, (-1027. * mm)/2.),
+                      pedestal_support_beam_bottom_logic, "PEDESTAL_SUPPORT_BEAM_BOTTOM_2", lead_box_logic, false, 0);
+
+    new G4PVPlacement(0, G4ThreeVector(0., -(shield_y_/2. + steel_thickness_/2.) + pedestal_support_top_thickness/2., (1027. * mm)/2.),
+                      pedestal_support_beam_top_logic, "PEDESTAL_SUPPORT_BEAM_TOP_1", air_box_logic_, false, 0);
+
+    new G4PVPlacement(0, G4ThreeVector(0., -(shield_y_/2. + steel_thickness_/2.) + pedestal_support_top_thickness/2., -(1027. * mm)/2.),
+                      pedestal_support_beam_top_logic, "PEDESTAL_SUPPORT_BEAM_TOP_2", air_box_logic_, false, 0);
+
+    new G4PVPlacement(0, G4ThreeVector(0., pedestal_y_pos, (1027. * mm)/2. + 732 * mm),
+                      pedestal_support_beam_lat_logic, "PEDESTAL_SUPPORT_BEAM_LAT_1", lead_box_logic, false, 0);
+
+    new G4PVPlacement(0, G4ThreeVector(0., pedestal_y_pos, (-1027. * mm)/2. - 732 * mm),
+                      pedestal_support_beam_lat_logic, "PEDESTAL_SUPPORT_BEAM_LAT_2", lead_box_logic, false, 0);
+
     // SETTING VISIBILITIES   //////////
     if (visibility_) {
       G4VisAttributes dark_grey_col = nexus::DarkGrey();

--- a/source/geometries/Next100Shielding.h
+++ b/source/geometries/Next100Shielding.h
@@ -52,6 +52,7 @@ namespace nexus {
     G4double beam_thickness_1, beam_thickness_2;
     G4double lateral_z_separation_, roof_z_separation_ , front_x_separation_;
     G4double lead_thickness_, steel_thickness_;
+    G4double support_beam_dist_, support_lat_dist_;
 
     G4bool visibility_;
     G4bool verbosity_;
@@ -67,11 +68,17 @@ namespace nexus {
     BoxPointSampler* struct_z_gen_;
     BoxPointSampler* lat_beam_gen_;
     BoxPointSampler* front_beam_gen_;
+    BoxPointSampler* ped_support_bottom_gen_;
+    BoxPointSampler* ped_support_top_gen_;
+    BoxPointSampler* ped_lat_gen_;
 
     G4double perc_roof_vol_;
     G4double perc_front_roof_vol_;
     G4double perc_top_struct_vol_;
     G4double perc_struc_x_vol_;
+    G4double perc_ped_bottom_vol_;
+    G4double perc_ped_top_vol_;
+    G4double perc_ped_lat_vol_;
 
 
     // Geometry Navigator

--- a/source/geometries/Next100Shielding.h
+++ b/source/geometries/Next100Shielding.h
@@ -54,12 +54,12 @@ namespace nexus {
     G4double lead_thickness_, steel_thickness_;
     G4double pedestal_x_, pedestal_top_x_;
     G4double support_beam_dist_, support_front_dist_;
-    G4double pedestal_lateral_beam_thickness;
-    G4double pedestal_front_beam_thickness;
-    G4double pedestal_roof_thickness;
-    G4double pedestal_lateral_length;
-    G4double bubble_seal_thickness;
-    G4double edpm_seal_thickness;
+    G4double pedestal_lateral_beam_thickness_;
+    G4double pedestal_front_beam_thickness_;
+    G4double pedestal_roof_thickness_;
+    G4double pedestal_lateral_length_;
+    G4double bubble_seal_thickness_;
+    G4double edpm_seal_thickness_;
 
     G4bool visibility_;
     G4bool verbosity_;

--- a/source/geometries/Next100Shielding.h
+++ b/source/geometries/Next100Shielding.h
@@ -52,7 +52,7 @@ namespace nexus {
     G4double beam_thickness_1, beam_thickness_2;
     G4double lateral_z_separation_, roof_z_separation_ , front_x_separation_;
     G4double lead_thickness_, steel_thickness_;
-    G4double pedestal_x_, support_beam_dist_, support_lat_dist_;
+    G4double pedestal_x_, support_beam_dist_, support_front_dist_;
 
     G4bool visibility_;
     G4bool verbosity_;
@@ -70,7 +70,7 @@ namespace nexus {
     BoxPointSampler* front_beam_gen_;
     BoxPointSampler* ped_support_bottom_gen_;
     BoxPointSampler* ped_support_top_gen_;
-    BoxPointSampler* ped_lat_gen_;
+    BoxPointSampler* ped_front_gen_;
 
     G4double perc_roof_vol_;
     G4double perc_front_roof_vol_;
@@ -78,7 +78,7 @@ namespace nexus {
     G4double perc_struc_x_vol_;
     G4double perc_ped_bottom_vol_;
     G4double perc_ped_top_vol_;
-    G4double perc_ped_lat_vol_;
+    G4double perc_ped_front_vol_;
 
 
     // Geometry Navigator

--- a/source/geometries/Next100Shielding.h
+++ b/source/geometries/Next100Shielding.h
@@ -49,7 +49,7 @@ namespace nexus {
     // Dimensions
     G4double lead_x_, lead_y_, lead_z_;
     G4double shield_x_, shield_y_, shield_z_;
-    G4double  beam_base_thickness_, lateral_z_separation_, roof_z_separation_ , front_x_separation_;
+    G4double beam_base_thickness_, lateral_z_separation_, roof_z_separation_ , front_x_separation_;
     G4double lead_thickness_, steel_thickness_;
 
     // Visibility of the shielding

--- a/source/geometries/Next100Shielding.h
+++ b/source/geometries/Next100Shielding.h
@@ -52,8 +52,8 @@ namespace nexus {
     G4double beam_base_thickness_, lateral_z_separation_, roof_z_separation_ , front_x_separation_;
     G4double lead_thickness_, steel_thickness_;
 
-    // Visibility of the shielding
     G4bool visibility_;
+    G4bool verbosity_;
 
     // Vertex generators
     BoxPointSampler* lead_gen_;

--- a/source/geometries/Next100Shielding.h
+++ b/source/geometries/Next100Shielding.h
@@ -59,6 +59,7 @@ namespace nexus {
     G4double pedestal_roof_thickness;
     G4double pedestal_lateral_length;
     G4double bubble_seal_thickness;
+    G4double edpm_seal_thickness;
 
     G4bool visibility_;
     G4bool verbosity_;
@@ -84,6 +85,8 @@ namespace nexus {
 
     BoxPointSampler* bubble_seal_front_gen_;
     BoxPointSampler* bubble_seal_lateral_gen_;
+    BoxPointSampler* edpm_seal_front_gen_;
+    BoxPointSampler* edpm_seal_lateral_gen_;
 
     G4double perc_roof_vol_;
     G4double perc_front_roof_vol_;
@@ -97,6 +100,8 @@ namespace nexus {
 
     G4double perc_bubble_front_vol_;
     G4double perc_buble_lateral_vol_;
+    G4double perc_edpm_front_vol_;
+    G4double perc_edpm_lateral_vol_;
 
 
     // Geometry Navigator

--- a/source/geometries/Next100Shielding.h
+++ b/source/geometries/Next100Shielding.h
@@ -49,7 +49,7 @@ namespace nexus {
     // Dimensions
     G4double lead_x_, lead_y_, lead_z_;
     G4double shield_x_, shield_y_, shield_z_;
-    G4double beam_base_thickness_, lateral_z_separation_, roof_z_separation_ , front_x_separation_;
+    G4double beam_thickness_, lateral_z_separation_, roof_z_separation_ , front_x_separation_;
     G4double lead_thickness_, steel_thickness_;
 
     G4bool visibility_;

--- a/source/geometries/Next100Shielding.h
+++ b/source/geometries/Next100Shielding.h
@@ -55,8 +55,10 @@ namespace nexus {
     G4double pedestal_x_, pedestal_top_x_;
     G4double support_beam_dist_, support_front_dist_;
     G4double pedestal_lateral_beam_thickness;
+    G4double pedestal_front_beam_thickness;
     G4double pedestal_roof_thickness;
     G4double pedestal_lateral_length;
+    G4double bubble_seal_thickness;
 
     G4bool visibility_;
     G4bool verbosity_;
@@ -80,6 +82,9 @@ namespace nexus {
     BoxPointSampler* ped_roof_lat_gen_;
     BoxPointSampler* ped_roof_front_gen_;
 
+    BoxPointSampler* bubble_seal_front_gen_;
+    BoxPointSampler* bubble_seal_lateral_gen_;
+
     G4double perc_roof_vol_;
     G4double perc_front_roof_vol_;
     G4double perc_top_struct_vol_;
@@ -89,6 +94,9 @@ namespace nexus {
     G4double perc_ped_front_vol_;
     G4double perc_ped_lateral_vol_;
     G4double perc_ped_roof_vol_;
+
+    G4double perc_bubble_front_vol_;
+    G4double perc_buble_lateral_vol_;
 
 
     // Geometry Navigator

--- a/source/geometries/Next100Shielding.h
+++ b/source/geometries/Next100Shielding.h
@@ -52,7 +52,7 @@ namespace nexus {
     G4double beam_thickness_1, beam_thickness_2;
     G4double lateral_z_separation_, roof_z_separation_ , front_x_separation_;
     G4double lead_thickness_, steel_thickness_;
-    G4double support_beam_dist_, support_lat_dist_;
+    G4double pedestal_x_, support_beam_dist_, support_lat_dist_;
 
     G4bool visibility_;
     G4bool verbosity_;

--- a/source/geometries/Next100Shielding.h
+++ b/source/geometries/Next100Shielding.h
@@ -49,7 +49,8 @@ namespace nexus {
     // Dimensions
     G4double lead_x_, lead_y_, lead_z_;
     G4double shield_x_, shield_y_, shield_z_;
-    G4double beam_thickness_, lateral_z_separation_, roof_z_separation_ , front_x_separation_;
+    G4double beam_thickness_1, beam_thickness_2;
+    G4double lateral_z_separation_, roof_z_separation_ , front_x_separation_;
     G4double lead_thickness_, steel_thickness_;
 
     G4bool visibility_;

--- a/source/geometries/Next100Shielding.h
+++ b/source/geometries/Next100Shielding.h
@@ -52,7 +52,11 @@ namespace nexus {
     G4double beam_thickness_1, beam_thickness_2;
     G4double lateral_z_separation_, roof_z_separation_ , front_x_separation_;
     G4double lead_thickness_, steel_thickness_;
-    G4double pedestal_x_, support_beam_dist_, support_front_dist_;
+    G4double pedestal_x_, pedestal_top_x_;
+    G4double support_beam_dist_, support_front_dist_;
+    G4double pedestal_lateral_beam_thickness;
+    G4double pedestal_roof_thickness;
+    G4double pedestal_lateral_length;
 
     G4bool visibility_;
     G4bool verbosity_;
@@ -68,9 +72,13 @@ namespace nexus {
     BoxPointSampler* struct_z_gen_;
     BoxPointSampler* lat_beam_gen_;
     BoxPointSampler* front_beam_gen_;
+
     BoxPointSampler* ped_support_bottom_gen_;
     BoxPointSampler* ped_support_top_gen_;
     BoxPointSampler* ped_front_gen_;
+    BoxPointSampler* ped_lateral_gen_;
+    BoxPointSampler* ped_roof_lat_gen_;
+    BoxPointSampler* ped_roof_front_gen_;
 
     G4double perc_roof_vol_;
     G4double perc_front_roof_vol_;
@@ -79,6 +87,8 @@ namespace nexus {
     G4double perc_ped_bottom_vol_;
     G4double perc_ped_top_vol_;
     G4double perc_ped_front_vol_;
+    G4double perc_ped_lateral_vol_;
+    G4double perc_ped_roof_vol_;
 
 
     // Geometry Navigator

--- a/source/geometries/NextNew.cc
+++ b/source/geometries/NextNew.cc
@@ -493,7 +493,7 @@ namespace nexus {
       vertex = shielding_->GenerateVertex(region);
     }
     //PEDESTAL
-    else if (region == "PEDESTAL") {
+    else if (region == "PEDESTAL_BOARD") {
       vertex = pedestal_->GenerateVertex(region);
     }
     // EXTRA ELEMENTS

--- a/source/geometries/NextNewPedestal.cc
+++ b/source/geometries/NextNewPedestal.cc
@@ -85,7 +85,7 @@ namespace nexus {
   G4ThreeVector NextNewPedestal::GenerateVertex(const G4String& region) const
   {
     G4ThreeVector vertex(0., 0., 0.);
-    if (region == "PEDESTAL") {
+    if (region == "PEDESTAL_BOARD") {
       vertex = table_gen_->GenerateVertex("INSIDE");
     }
     else {


### PR DESCRIPTION
This PR revisits and updates the shielding geometry and generators. The dimensions and components were gently provided by Jordi Torrent and are shown in

[Shielding.pdf](https://github.com/next-exp/nexus/files/6554546/101-Castle.and.new.dimensions.pdf)
[pedastal.pdf](https://github.com/next-exp/nexus/files/6602464/pedastal.pdf)

Besides the relevant change of the new dimensions, two extra changes are made in this revision:
- the steel shielding in the laterals is enlarged, as shown in the drawings. The steel roof is also positioned above the inner steel box.
- solves a bug in the distribution of the vertex generator in the steel shielding structure composed by the roof and the top beams.
I have also tryed to rewrite the code to be more easily readable.