### PR TITLE
DEMO Run 10

### DIFF
--- a/source/geometries/NextDemoInnerElements.cc
+++ b/source/geometries/NextDemoInnerElements.cc
@@ -58,7 +58,8 @@ void NextDemoInnerElements::Construct()
   else if ((config_ != "run5") &
            (config_ != "run7") &
            (config_ != "run8") &
-           (config_ != "run9"))
+           (config_ != "run9") &
+           (config_ != "run10"))
     G4Exception("[NextDemoInnerElements]", "Construct()",
                 FatalException, "Wrong NextDemo configuration.");
 

--- a/source/geometries/NextDemoSiPMBoard.cc
+++ b/source/geometries/NextDemoSiPMBoard.cc
@@ -312,6 +312,10 @@ void NextDemoSiPMBoard::Construct()
                                coating_phys, coating_opsurf);
 
     // Coating holes
+    // If there are no membranes, the mask holes are open to the xe gas, namely the hole mask openings
+    // are not covered and exposed to the gas. There is no membrane to support the coating, therefore
+    // we have to open the corresponding holes in the coating volume at the hole (sipm) positions. This is done
+    // through a xe volume with hole dimensions placed inside the coating at the hole (sipm) positions.
     if (membrane_thickn_ == 0.){
       if (hole_type_ == "rectangular"){
 

--- a/source/geometries/NextDemoSiPMBoard.cc
+++ b/source/geometries/NextDemoSiPMBoard.cc
@@ -58,7 +58,7 @@ NextDemoSiPMBoard::NextDemoSiPMBoard():
   hole_diam_       (3.5  * mm),
   hole_x_          (0.0  * mm),
   hole_y_          (0.0  * mm),
-  hole_coated_     (true),
+  hole_coated_     (false),
   sipm_type_       (""),
   mother_phys_     (nullptr),
   kapton_gen_      (nullptr)
@@ -132,12 +132,12 @@ void NextDemoSiPMBoard::Construct()
   G4Material* mother_gas = mother_phys_->GetLogicalVolume()->GetMaterial();
 
 
-  // /// Board configuration checks
-  // // Coating require membranes
-  // if (coating_thickn_ > 0.)
-  //   if (membrane_thickn_ == 0.)
-  //     G4Exception("[NextDemoSiPMBoard]", "Construct()", FatalException,
-  //     "Coating require membranes");
+  /// Board configuration checks
+  // Coating require membranes
+  if ((!hole_coated_) && (coating_thickn_ > 0.))
+    if (membrane_thickn_ == 0.)
+      G4Exception("[NextDemoSiPMBoard]", "Construct()", FatalException,
+      "Coating require membranes");
 
   // Membranes require masks
   if (membrane_thickn_ > 0.)

--- a/source/geometries/NextDemoSiPMBoard.cc
+++ b/source/geometries/NextDemoSiPMBoard.cc
@@ -344,8 +344,7 @@ void NextDemoSiPMBoard::Construct()
   /// VERBOSITY
   if (verbosity_)
     G4cout << "* SiPM board size:    " << board_size_      << G4endl;
-    G4cout << "* " << num_sipms_ << " SiPMs from Sensl"    << G4endl;
-
+    
     if (sipm_verbosity_) {
       for (G4int sipm_num=0; sipm_num<num_sipms_; sipm_num++)
         G4cout << "* SiPM " << sipm_num << " position: " << sipm_positions_[sipm_num] << G4endl;
@@ -353,9 +352,18 @@ void NextDemoSiPMBoard::Construct()
 
     G4cout << "* Kapton thickness:   " << kapton_thickn_   << G4endl;
     G4cout << "* Mask thickness:     " << mask_thickn_     << G4endl;
-    G4cout << "* Mask hole diameter: " << hole_diam_       << G4endl;
     G4cout << "* Membrane thickness: " << membrane_thickn_ << G4endl;
-    G4cout << "* Coating thickness: "  << coating_thickn_  << G4endl;
+    G4cout << "* Coating thickness:  " << coating_thickn_  << G4endl;
+    G4cout << "* SiPM type:          " << sipm_type_       << G4endl;
+    G4cout << "* Hole type:          " << hole_type_       << G4endl;
+
+    if (hole_type_ == "rectangular"){
+    G4cout << "* Mask hole X size:   " << hole_x_          << G4endl;
+    G4cout << "* Mask hole Y size:   " << hole_y_          << G4endl;
+    }
+    else if (hole_type_ == "rounded"){
+    G4cout << "* Mask hole diameter: " << hole_diam_       << G4endl;
+    }
 
 
   /// VISIBILITIES

--- a/source/geometries/NextDemoSiPMBoard.cc
+++ b/source/geometries/NextDemoSiPMBoard.cc
@@ -232,10 +232,11 @@ void NextDemoSiPMBoard::Construct()
 
   G4double sipm_posz = - mask_thickn_/2. + sipm_z_dim/2.;
 
-  G4VPhysicalVolume* sipm_phys = new G4PVPlacement(sipm_rot, G4ThreeVector(0., 0., sipm_posz), sipm_->GetLogicalVolume(),
-                                                   sipm_->GetLogicalVolume()->GetName(), hole_logic,
-                                                   false, 0, false);
+  new G4PVPlacement(sipm_rot, G4ThreeVector(0., 0., sipm_posz), sipm_->GetLogicalVolume(),
+                                            sipm_->GetLogicalVolume()->GetName(), hole_logic,
+                                            false, 0, false);
 
+  G4VPhysicalVolume* hole_coating_phys;
   if (hole_coated_ && (hole_type_ == "rectangular")){
 
     G4Box* hole_coating_top = new G4Box("HOLE_COATING", hole_x_/2., coating_thickn_/2., mask_thickn_/2.);
@@ -252,14 +253,9 @@ void NextDemoSiPMBoard::Construct()
 
     G4LogicalVolume* hole_coating_logic = new G4LogicalVolume(hole_coating, tpb, "HOLE_COATING");
 
-    G4VPhysicalVolume* hole_coating_phys_ =
+    hole_coating_phys =
           new G4PVPlacement(nullptr, G4ThreeVector(0., hole_y_/2. - coating_thickn_/2., 0.), hole_coating_logic,
                             "HOLE_COATING", hole_logic, false, 0, false);
-
-    new G4LogicalBorderSurface("TEFLON_WLS_HOLE_GAS_OPSURF", hole_coating_phys_,
-                               sipm_phys, coating_opsurf);
-    new G4LogicalBorderSurface("GAS_TEFLON_WLS_HOLE_OPSURF", sipm_phys,
-                               hole_coating_phys_, coating_opsurf);
   }
   else if (hole_coated_ && (hole_type_ == "rounded")){
     G4Exception("[NextDemoSiPMBoard]", "Construct()", FatalException, "Coated rounded holes not implemented");
@@ -285,9 +281,17 @@ void NextDemoSiPMBoard::Construct()
 
 
   /// Placing the Holes with SiPMs & membranes inside
+  G4VPhysicalVolume* hole_phys;
   for (G4int sipm_id=0; sipm_id<num_sipms_; sipm_id++) {
-    new G4PVPlacement(nullptr, sipm_positions_[sipm_id], hole_logic,
-                      hole_name, mask_logic, false, sipm_id, false);
+    hole_phys = new G4PVPlacement(nullptr, sipm_positions_[sipm_id], hole_logic,
+                                  hole_name, mask_logic, false, sipm_id, false);
+
+    if (hole_coated_ && (hole_type_ == "rectangular")){
+      new G4LogicalBorderSurface("HOLE_COATING_GAS_OPSURF", hole_coating_phys,
+                                 hole_phys, coating_opsurf);
+      new G4LogicalBorderSurface("GAS_HOLE_COATING_OPSURF", hole_phys,
+                                 hole_coating_phys, coating_opsurf);
+    }
   }
 
 

--- a/source/geometries/NextDemoSiPMBoard.cc
+++ b/source/geometries/NextDemoSiPMBoard.cc
@@ -4,8 +4,9 @@
 // Geometry of the DEMO++ SiPM board.
 // It consists of an 8x8 array of SensL SiPMs on a kapton board.
 // The board can be covered with a teflon mask, or not.
-// The teflon mask may have membranes covering the holes, or not.
-// The teflon mask may be coated with TPB or not.
+// The teflon mask might have membranes covering the holes, or not.
+// The teflon mask might be coated with TPB or not.
+// The teflon holes might be coated with TPB or not.
 //
 // The NEXT Collaboration
 // -----------------------------------------------------------------------------
@@ -344,7 +345,7 @@ void NextDemoSiPMBoard::Construct()
   /// VERBOSITY
   if (verbosity_)
     G4cout << "* SiPM board size:    " << board_size_      << G4endl;
-    
+
     if (sipm_verbosity_) {
       for (G4int sipm_num=0; sipm_num<num_sipms_; sipm_num++)
         G4cout << "* SiPM " << sipm_num << " position: " << sipm_positions_[sipm_num] << G4endl;

--- a/source/geometries/NextDemoSiPMBoard.cc
+++ b/source/geometries/NextDemoSiPMBoard.cc
@@ -232,9 +232,9 @@ void NextDemoSiPMBoard::Construct()
 
   G4double sipm_posz = - mask_thickn_/2. + sipm_z_dim/2.;
 
-  G4VPhysicalVolume* hole_phys_ = new G4PVPlacement(sipm_rot, G4ThreeVector(0., 0., sipm_posz), sipm_->GetLogicalVolume(),
-                                                    sipm_->GetLogicalVolume()->GetName(), hole_logic,
-                                                    false, 0, false);
+  G4VPhysicalVolume* sipm_phys = new G4PVPlacement(sipm_rot, G4ThreeVector(0., 0., sipm_posz), sipm_->GetLogicalVolume(),
+                                                   sipm_->GetLogicalVolume()->GetName(), hole_logic,
+                                                   false, 0, false);
 
   if (hole_coated_ && (hole_type_ == "rectangular")){
 
@@ -257,8 +257,8 @@ void NextDemoSiPMBoard::Construct()
                             "HOLE_COATING", hole_logic, false, 0, false);
 
     new G4LogicalBorderSurface("TEFLON_WLS_HOLE_GAS_OPSURF", hole_coating_phys_,
-                               hole_phys_, coating_opsurf);
-    new G4LogicalBorderSurface("GAS_TEFLON_WLS_HOLE_OPSURF", hole_phys_,
+                               sipm_phys, coating_opsurf);
+    new G4LogicalBorderSurface("GAS_TEFLON_WLS_HOLE_OPSURF", sipm_phys,
                                hole_coating_phys_, coating_opsurf);
   }
   else if (hole_coated_ && (hole_type_ == "rounded")){

--- a/source/geometries/NextDemoSiPMBoard.h
+++ b/source/geometries/NextDemoSiPMBoard.h
@@ -4,8 +4,9 @@
 // Geometry of the DEMO++ SiPM board.
 // It consists of an 8x8 array of SensL SiPMs on a kapton board.
 // The board can be covered with a teflon mask, or not.
-// The teflon mask may have membranes covering the holes, or not.
-// The teflon mask may be coated with TPB or not.
+// The teflon mask might have membranes covering the holes, or not.
+// The teflon mask might be coated with TPB or not.
+// The teflon holes might be coated with TPB or not.
 //
 // The NEXT Collaboration
 // -----------------------------------------------------------------------------

--- a/source/geometries/NextDemoSiPMBoard.h
+++ b/source/geometries/NextDemoSiPMBoard.h
@@ -43,6 +43,7 @@ namespace nexus {
     void SetHoleY               (G4double y);
     void SetSiPMType            (G4String type);
     void SetSiPMCoatingThickness(G4double thickn);
+    void SetHoleCoating         (G4bool coated);
 
     G4ThreeVector GetBoardSize() const;
     G4double      GetKaptonThickness() const;
@@ -68,6 +69,7 @@ namespace nexus {
     G4double hole_diam_;
     G4double hole_x_;
     G4double hole_y_;
+    G4bool hole_coated_;
     G4String sipm_type_;
 
     G4ThreeVector board_size_;
@@ -108,6 +110,9 @@ namespace nexus {
 
   inline void NextDemoSiPMBoard::SetSiPMCoatingThickness(G4double thickn)
   { sipm_coat_thick_ = thickn; }
+
+  inline void NextDemoSiPMBoard::SetHoleCoating(G4bool coated)
+  { hole_coated_ = coated;}
 
   inline G4ThreeVector NextDemoSiPMBoard::GetBoardSize() const
   { return board_size_; }

--- a/source/geometries/NextDemoTrackingPlane.cc
+++ b/source/geometries/NextDemoTrackingPlane.cc
@@ -2,9 +2,10 @@
 // nexus | NextDemoTrackingPlane.cc
 //
 // Tracking plane of the Demo++ geometry.
-// It implements 2 different TP implementations:
+// It describes 3 different TP implementations:
 // "run5": the one used at the beginning with passing-holes masks
-// "run7" and "run8": the ones used with coated masks and membranes.
+// "run7", "run8" and "run9": the ones used with coated masks and membranes.
+// "run10" (next100-like): no membranes and inner coating (both in sipm and hole)
 //
 // The NEXT Collaboration
 // ----------------------------------------------------------------------------

--- a/source/geometries/NextDemoTrackingPlane.cc
+++ b/source/geometries/NextDemoTrackingPlane.cc
@@ -77,15 +77,16 @@ void NextDemoTrackingPlane::Construct()
   if(verbosity_) G4cout << G4endl << "*** NEXT Demo Tracking Plane ";
 
   /// Defining Tracking Plane parameters
-  G4double gate_board_dist  = 0.; // Distance from GATE to SiPM Board kapton surface
-  G4double mask_thickn      = 0.;
-  G4double membrane_thickn  = 0.;
-  G4double coating_thickn   = 0.;
-  G4String hole_type        = "";
-  G4double hole_diameter    = 0.;
-  G4double hole_x           = 0.;
-  G4double hole_y           = 0.;
-  G4String sipm_type        = "";
+  G4double gate_board_dist = 0.; // Distance from GATE to SiPM Board kapton surface
+  G4double mask_thickn     = 0.;
+  G4double membrane_thickn = 0.;
+  G4double coating_thickn  = 0.;
+  G4String hole_type       = "";
+  G4double hole_diameter   = 0.;
+  G4double hole_x          = 0.;
+  G4double hole_y          = 0.;
+  G4String sipm_type       = "";
+  G4bool   hole_coated     = false;
   G4double sipm_coat_thickn = 0.;
 
   if (config_ == "run5") {
@@ -97,6 +98,7 @@ void NextDemoTrackingPlane::Construct()
     hole_type       = "rounded";
     hole_diameter   = 3.5 * mm;
     sipm_type       = "sensl";
+    hole_coated     = false;
   }
   else if (config_ == "run7") {
     if(verbosity_) G4cout << "run7 ..." << G4endl;
@@ -107,6 +109,7 @@ void NextDemoTrackingPlane::Construct()
     hole_type       = "rounded";
     hole_diameter   = 3.5  * mm;
     sipm_type       = "sensl";
+    hole_coated     = false;
   }
   else if (config_ == "run8") {
     if(verbosity_) G4cout << "run8 ..." << G4endl;
@@ -117,6 +120,7 @@ void NextDemoTrackingPlane::Construct()
     hole_type       = "rounded";
     hole_diameter   = 4.0  * mm;
     sipm_type       = "sensl";
+    hole_coated     = false;
   }
   else if (config_ == "run9") {
     if(verbosity_) G4cout << "run9 ..." << G4endl;
@@ -128,6 +132,20 @@ void NextDemoTrackingPlane::Construct()
     hole_x          = 6.0 * mm;
     hole_y          = 5.0 * mm;
     sipm_type       = "next100";
+    hole_coated     = false;
+  }
+  else if (config_ == "run10") {
+    if(verbosity_) G4cout << "run10 ..." << G4endl;
+    gate_board_dist = 19.66 * mm;
+    mask_thickn     = 6.0 * mm;
+    membrane_thickn = 0.0 * mm;
+    coating_thickn  = 2.0 * micrometer;
+    hole_type       = "rectangular";
+    hole_x          = 6.0 * mm;
+    hole_y          = 5.0 * mm;
+    sipm_type       = "next100";
+    hole_coated     = true;
+    sipm_coat_thickn= 2.0 * micrometer;
   }
 
   /// Make sure the pointer to the mother volume is actually defined
@@ -153,6 +171,7 @@ void NextDemoTrackingPlane::Construct()
     sipm_board_->SetHoleY(hole_y);}
   sipm_board_->SetSiPMType(sipm_type);
   sipm_board_->SetSiPMCoatingThickness(sipm_coat_thickn);
+  sipm_board_->SetHoleCoating(hole_coated);
 
   sipm_board_->Construct();
   G4LogicalVolume* board_logic = sipm_board_->GetLogicalVolume();

--- a/tests/pytest/persistency_test.py
+++ b/tests/pytest/persistency_test.py
@@ -78,7 +78,7 @@ def test_hdf5_structure(detectors):
 
     filename, _, _, _, _ = detectors
     if "DEMOPP" in filename:
-        for run in ["run5", "run7", "run8", "run9"]:
+        for run in ["run5", "run7", "run8", "run9", "run10"]:
             test(filename.format(run=run))
     else:
         test(filename)
@@ -101,7 +101,7 @@ def test_particle_ids_of_hits_exist_in_particle_table(detectors):
 
     filename, _, _, _, _ = detectors
     if "DEMOPP" in filename:
-        for run in ["run5", "run7", "run8", "run9"]:
+        for run in ["run5", "run7", "run8", "run9", "run10"]:
             test(filename.format(run=run))
     else:
         test(filename)
@@ -118,7 +118,7 @@ def test_hit_labels(detectors):
 
     filename, _, _, _, _ = detectors
     if "DEMOPP" in filename:
-        for run in ["run5", "run7", "run8", "run9"]:
+        for run in ["run5", "run7", "run8", "run9", "run10"]:
             test(filename.format(run=run))
     else:
         test(filename)
@@ -136,7 +136,7 @@ def test_primary_always_exists(detectors):
 
     filename, _, _, _, _ = detectors
     if "DEMOPP" in filename:
-        for run in ["run5", "run7", "run8", "run9"]:
+        for run in ["run5", "run7", "run8", "run9", "run10"]:
             test(filename.format(run=run))
     else:
         test(filename)
@@ -154,7 +154,7 @@ def test_sensor_binning_is_saved(detectors):
 
     filename, _, _, _, _ = detectors
     if "DEMOPP" in filename:
-        for run in ["run5", "run7", "run8", "run9"]:
+        for run in ["run5", "run7", "run8", "run9", "run10"]:
             test(filename.format(run=run))
     else:
         test(filename)
@@ -180,7 +180,7 @@ def test_sensor_names_are_the_same_across_tables(detectors):
 
     filename, _, _, _, _ = detectors
     if "DEMOPP" in filename:
-        for run in ["run5", "run7", "run8", "run9"]:
+        for run in ["run5", "run7", "run8", "run9", "run10"]:
             test(filename.format(run=run))
     else:
         test(filename)

--- a/tests/pytest/produce_output_test.py
+++ b/tests/pytest/produce_output_test.py
@@ -243,7 +243,7 @@ def test_create_nexus_output_file_flex100(config_tmpdir, output_tmpdir, NEXUSDIR
 @pytest.mark.order(4)
 def test_create_nexus_output_file_demopp(config_tmpdir, output_tmpdir, NEXUSDIR, full_base_name_demopp, nexus_full_output_file_demopp):
 
-    for run in ["run5", "run7", "run8", "run9"]:
+    for run in ["run5", "run7", "run8", "run9", "run10"]:
 
         init_text = f"""
     /PhysicsList/RegisterPhysics G4EmStandardPhysics_option4

--- a/tests/pytest/sensitive_detectors_test.py
+++ b/tests/pytest/sensitive_detectors_test.py
@@ -41,7 +41,7 @@ def test_sensors_numbering(detectors):
     filename, pmt_ids, board_ids, sipms_per_board, board_ordering = detectors
 
     if "DEMOPP" in filename:
-        for run in ["run5", "run7", "run8", "run9"]:
+        for run in ["run5", "run7", "run8", "run9", "run10"]:
             test(filename.format(run=run), pmt_ids, board_ids, sipms_per_board, board_ordering)
     else:
         test(filename, pmt_ids, board_ids, sipms_per_board, board_ordering)


### PR DESCRIPTION
This PR add DEMO Run 10 tracking plane configuration. The four modifications compared to Run 9 are the following:
- Internal sides of rectangular holes are TPB coated. A new seteable variable `hole_coated` is used.
- Dummy Xenon membranes are removed (setting their thickness to 0).
- Add opening holes in outer mask coating at SIPM positions.
- Add SiPM coating (still not implemented, waiting for a corresponding PR from @halmamol which adds this functionality in the Next100SiPM class).