### PR TITLE
Add tpb coating into Next100SiPM 

### DIFF
--- a/source/geometries/Next100SiPM.cc
+++ b/source/geometries/Next100SiPM.cc
@@ -33,7 +33,6 @@ Next100SiPM::Next100SiPM():
   mother_depth_       (0),
   naming_order_       (0),
   time_binning_       (1.0 * us),
-  with_coating_       (false),
   coating_thickn_     (2. * micrometer),
   visibility_         (true)
 {
@@ -61,7 +60,6 @@ void Next100SiPM::Construct()
   G4double sipm_length = 4.0 * mm;
   G4double sipm_thickn = 1.3 * mm;
 
-  if(!with_coating_) coating_thickn_ = 0.;
   sipm_thickn = sipm_thickn + coating_thickn_;
 
   dimensions_.setX(sipm_width);
@@ -77,11 +75,8 @@ void Next100SiPM::Construct()
   GeometryBase::SetLogicalVolume(sipm_logic_vol);
 
   // COATING /////////////////////////////////////////////
-
-  G4LogicalVolume* coating_logic_vol;
-  if (with_coating_) {
+  if (coating_thickn_ > 0.) {
     G4String coating_name = sipm_name + "_WLS";
-
 
     G4Box* coating_solid_vol =
       new G4Box(coating_name, sipm_width/2., sipm_length/2., coating_thickn_/2.);
@@ -89,7 +84,7 @@ void Next100SiPM::Construct()
     G4Material* coating_mt = MaterialsList::TPB();
     coating_mt->SetMaterialPropertiesTable(OpticalMaterialProperties::TPB());
 
-    coating_logic_vol = new G4LogicalVolume(coating_solid_vol, coating_mt, coating_name);
+    G4LogicalVolume* coating_logic_vol = new G4LogicalVolume(coating_solid_vol, coating_mt, coating_name);
 
     G4double coating_zpos = sipm_thickn/2. - coating_thickn_/2;
 

--- a/source/geometries/Next100SiPM.cc
+++ b/source/geometries/Next100SiPM.cc
@@ -34,6 +34,7 @@ Next100SiPM::Next100SiPM():
   naming_order_       (0),
   time_binning_       (1.0 * us),
   with_coating_       (false),
+  coating_thickn_     (2. * micrometer), 
   visibility_         (true)
 {
 }
@@ -78,7 +79,6 @@ void Next100SiPM::Construct()
   if (with_coating_) {
     G4String coating_name = sipm_name + "_WLS";
 
-    G4double coating_thickn_  = 1. * micrometer;
 
     G4Box* coating_solid_vol =
       new G4Box(coating_name, sipm_width/2., sipm_length/2., coating_thickn_/2.);

--- a/source/geometries/Next100SiPM.cc
+++ b/source/geometries/Next100SiPM.cc
@@ -61,8 +61,8 @@ void Next100SiPM::Construct()
   G4double sipm_length = 4.0 * mm;
   G4double sipm_thickn = 1.3 * mm;
 
-  if(with_coating_) sipm_thickn = sipm_thickn + coating_thickn_;
-  else coating_thickn_ = 0.;
+  if(!with_coating_) coating_thickn_ = 0.;
+  sipm_thickn = sipm_thickn + coating_thickn_;
 
   dimensions_.setX(sipm_width);
   dimensions_.setY(sipm_length);
@@ -86,10 +86,10 @@ void Next100SiPM::Construct()
     G4Box* coating_solid_vol =
       new G4Box(coating_name, sipm_width/2., sipm_length/2., coating_thickn_/2.);
 
-    G4Material* coating_mt_ = MaterialsList::TPB();
-    coating_mt_->SetMaterialPropertiesTable(OpticalMaterialProperties::TPB());
+    G4Material* coating_mt = MaterialsList::TPB();
+    coating_mt->SetMaterialPropertiesTable(OpticalMaterialProperties::TPB());
 
-    coating_logic_vol = new G4LogicalVolume(coating_solid_vol, coating_mt_, coating_name);
+    coating_logic_vol = new G4LogicalVolume(coating_solid_vol, coating_mt, coating_name);
 
     G4double coating_zpos = sipm_thickn/2. - coating_thickn_/2;
 

--- a/source/geometries/Next100SiPM.cc
+++ b/source/geometries/Next100SiPM.cc
@@ -34,7 +34,7 @@ Next100SiPM::Next100SiPM():
   naming_order_       (0),
   time_binning_       (1.0 * us),
   with_coating_       (false),
-  coating_thickn_     (2. * micrometer), 
+  coating_thickn_     (2. * micrometer),
   visibility_         (true)
 {
 }
@@ -54,12 +54,15 @@ G4ThreeVector Next100SiPM::GetDimensions() const
 void Next100SiPM::Construct()
 {
   // ENCASING //////////////////////////////////////////////
-
+  //dimensions are increased in case of SiPM coating
   G4String sipm_name = "SIPM_S13372";
 
   G4double sipm_width  = 3.0 * mm;
   G4double sipm_length = 4.0 * mm;
   G4double sipm_thickn = 1.3 * mm;
+
+  if(with_coating_) sipm_thickn = sipm_thickn + coating_thickn_;
+  else coating_thickn_ = 0.;
 
   dimensions_.setX(sipm_width);
   dimensions_.setY(sipm_length);
@@ -88,7 +91,7 @@ void Next100SiPM::Construct()
 
     coating_logic_vol = new G4LogicalVolume(coating_solid_vol, coating_mt_, coating_name);
 
-    G4double coating_zpos = sipm_thickn/2. + coating_thickn_/2.;
+    G4double coating_zpos = sipm_thickn/2. - coating_thickn_/2;
 
     new G4PVPlacement(nullptr, G4ThreeVector(0., 0., coating_zpos), coating_logic_vol,
                       coating_name, sipm_logic_vol, false, 0, false);
@@ -109,7 +112,7 @@ void Next100SiPM::Construct()
   G4double window_width  = sipm_width;
   G4double window_length = sipm_length;
   G4double window_thickn = 0.5 * mm;
-  G4double window_zpos   = sipm_thickn/2. - window_thickn/2.;
+  G4double window_zpos   = sipm_thickn/2. - coating_thickn_ - window_thickn/2.;
 
   G4Material* optical_silicone = MaterialsList::OpticalSilicone();
   optical_silicone->SetMaterialPropertiesTable(OpticalMaterialProperties::GlassEpoxy());

--- a/source/geometries/Next100SiPM.cc
+++ b/source/geometries/Next100SiPM.cc
@@ -33,8 +33,8 @@ Next100SiPM::Next100SiPM():
   mother_depth_       (0),
   naming_order_       (0),
   time_binning_       (1.0 * us),
-  visibility_         (true),
-  with_coating_       (false)
+  with_coating_       (false),
+  visibility_         (true)
 {
 }
 

--- a/source/geometries/Next100SiPM.h
+++ b/source/geometries/Next100SiPM.h
@@ -35,6 +35,7 @@ namespace nexus {
     void SetMotherDepth (G4int mother_depth);
     void SetNamingOrder (G4int naming_order);
     void SetTimeBinning (G4double time_binning);
+    void SetSiPMCoating (G4bool with_coating);
     void SetVisibility  (G4bool visibility);
 
   private:
@@ -45,6 +46,7 @@ namespace nexus {
     G4int    naming_order_;
     G4double time_binning_;
 
+    G4bool with_coating_;
     G4bool visibility_;
 
   };
@@ -60,6 +62,9 @@ namespace nexus {
 
   inline void Next100SiPM::SetNamingOrder(G4int naming_order)
   { naming_order_ = naming_order; }
+
+  inline void Next100SiPM::SetSiPMCoating(G4bool with_coating)
+  { with_coating_ = with_coating; }
 
   inline void Next100SiPM::SetVisibility(G4bool visibility)
   { visibility_ = visibility; }

--- a/source/geometries/Next100SiPM.h
+++ b/source/geometries/Next100SiPM.h
@@ -31,13 +31,12 @@ namespace nexus {
     void Construct() override;
 
     // Needed settings for correct numbering
-    void SetSensorDepth   (G4int sensor_depth);
-    void SetMotherDepth   (G4int mother_depth);
-    void SetNamingOrder   (G4int naming_order);
-    void SetTimeBinning   (G4double time_binning);
-    void SetSiPMCoating   (G4bool with_coating);
-    void SetSiPMCoatThick (G4double coating_thickn);
-    void SetVisibility    (G4bool visibility);
+    void SetSensorDepth         (G4int sensor_depth);
+    void SetMotherDepth         (G4int mother_depth);
+    void SetNamingOrder         (G4int naming_order);
+    void SetTimeBinning         (G4double time_binning);
+    void SetSiPMCoatingThickness(G4double coating_thickn);
+    void SetVisibility          (G4bool visibility);
 
   private:
     G4ThreeVector dimensions_;
@@ -47,7 +46,6 @@ namespace nexus {
     G4int    naming_order_;
     G4double time_binning_;
 
-    G4bool with_coating_;
     G4double coating_thickn_;
     G4bool visibility_;
 
@@ -65,10 +63,7 @@ namespace nexus {
   inline void Next100SiPM::SetNamingOrder(G4int naming_order)
   { naming_order_ = naming_order; }
 
-  inline void Next100SiPM::SetSiPMCoating(G4bool with_coating)
-  { with_coating_ = with_coating; }
-
-  inline void Next100SiPM::SetSiPMCoatThick(G4double coating_thickn)
+  inline void Next100SiPM::SetSiPMCoatingThickness(G4double coating_thickn)
   { coating_thickn_ = coating_thickn; }
 
   inline void Next100SiPM::SetVisibility(G4bool visibility)

--- a/source/geometries/Next100SiPM.h
+++ b/source/geometries/Next100SiPM.h
@@ -36,7 +36,7 @@ namespace nexus {
     void SetNamingOrder   (G4int naming_order);
     void SetTimeBinning   (G4double time_binning);
     void SetSiPMCoating   (G4bool with_coating);
-    void SetSiPMCoatThick (G4bool coating_thickn);
+    void SetSiPMCoatThick (G4double coating_thickn);
     void SetVisibility    (G4bool visibility);
 
   private:
@@ -68,7 +68,7 @@ namespace nexus {
   inline void Next100SiPM::SetSiPMCoating(G4bool with_coating)
   { with_coating_ = with_coating; }
 
-  inline void Next100SiPM::SetSiPMCoatThick(G4bool coating_thickn)
+  inline void Next100SiPM::SetSiPMCoatThick(G4double coating_thickn)
   { coating_thickn_ = coating_thickn; }
 
   inline void Next100SiPM::SetVisibility(G4bool visibility)

--- a/source/geometries/Next100SiPM.h
+++ b/source/geometries/Next100SiPM.h
@@ -31,12 +31,13 @@ namespace nexus {
     void Construct() override;
 
     // Needed settings for correct numbering
-    void SetSensorDepth (G4int sensor_depth);
-    void SetMotherDepth (G4int mother_depth);
-    void SetNamingOrder (G4int naming_order);
-    void SetTimeBinning (G4double time_binning);
-    void SetSiPMCoating (G4bool with_coating);
-    void SetVisibility  (G4bool visibility);
+    void SetSensorDepth   (G4int sensor_depth);
+    void SetMotherDepth   (G4int mother_depth);
+    void SetNamingOrder   (G4int naming_order);
+    void SetTimeBinning   (G4double time_binning);
+    void SetSiPMCoating   (G4bool with_coating);
+    void SetSiPMCoatThick (G4bool coating_thickn);
+    void SetVisibility    (G4bool visibility);
 
   private:
     G4ThreeVector dimensions_;
@@ -47,6 +48,7 @@ namespace nexus {
     G4double time_binning_;
 
     G4bool with_coating_;
+    G4double coating_thickn_;
     G4bool visibility_;
 
   };
@@ -65,6 +67,9 @@ namespace nexus {
 
   inline void Next100SiPM::SetSiPMCoating(G4bool with_coating)
   { with_coating_ = with_coating; }
+
+  inline void Next100SiPM::SetSiPMCoatThick(G4bool coating_thickn)
+  { coating_thickn_ = coating_thickn; }
 
   inline void Next100SiPM::SetVisibility(G4bool visibility)
   { visibility_ = visibility; }

--- a/source/geometries/NextDemoSiPMBoard.cc
+++ b/source/geometries/NextDemoSiPMBoard.cc
@@ -42,6 +42,7 @@ NextDemoSiPMBoard::NextDemoSiPMBoard():
   visibility_      (false),
   sipm_visibility_ (true),
   sipm_coating_    (false),
+  sipm_coat_thick_ (0.),
   time_binning_    (1. * microsecond),
   num_columns_     (8),
   num_rows_        (8),
@@ -110,6 +111,7 @@ void NextDemoSiPMBoard::Construct()
 
     sipm->SetVisibility(sipm_visibility_);
     sipm->SetSiPMCoating(sipm_coating_);
+    sipm->SetSiPMCoatThick(sipm_coat_thick_);
     sipm->SetTimeBinning(time_binning_);
     sipm->SetSensorDepth(2);
     sipm->SetMotherDepth(4);
@@ -148,6 +150,12 @@ void NextDemoSiPMBoard::Construct()
     if (hole_diam_ == 0.)
       G4Exception("[NextDemoSiPMBoard]", "Construct()", FatalException,
       "Masks require holes");
+
+  // SiPM coating require thickness
+  if (sipm_coating_)
+    if(sipm_coat_thick_== 0.)
+      G4Exception("[NextDemoSiPMBoard]", "Construct()", FatalException,
+      "SiPM coating require thickness");
 
 
   /// Board-Wrapper volume that contains all other elements

--- a/source/geometries/NextDemoSiPMBoard.cc
+++ b/source/geometries/NextDemoSiPMBoard.cc
@@ -41,7 +41,6 @@ NextDemoSiPMBoard::NextDemoSiPMBoard():
   sipm_verbosity_  (false),
   visibility_      (false),
   sipm_visibility_ (true),
-  sipm_coating_    (false),
   sipm_coat_thick_ (0.),
   time_binning_    (1. * microsecond),
   num_columns_     (8),
@@ -68,7 +67,6 @@ NextDemoSiPMBoard::NextDemoSiPMBoard():
   msg_->DeclareProperty("sipm_verbosity"      ,  sipm_verbosity_, "NextDemoSiPMBoard SiPMs verbosity");
   msg_->DeclareProperty("sipm_board_vis"      ,      visibility_, "NextDemoSiPMBoard visibility.");
   msg_->DeclareProperty("sipm_visibility"     , sipm_visibility_, "NextDemoSiPMBoard SiPMs visibility");
-  msg_->DeclareProperty("sipm_coating"        ,    sipm_coating_, "NextDemoSiPMBoard SiPMs coating");
 
   G4GenericMessenger::Command& time_binning_cmd = msg_->DeclareProperty("sipm_time_binning", time_binning_, "TP SiPMs time binning.");
   time_binning_cmd.SetParameterName("sipm_time_binning", false);
@@ -110,8 +108,7 @@ void NextDemoSiPMBoard::Construct()
     Next100SiPM* sipm = new Next100SiPM();
 
     sipm->SetVisibility(sipm_visibility_);
-    sipm->SetSiPMCoating(sipm_coating_);
-    sipm->SetSiPMCoatThick(sipm_coat_thick_);
+    sipm->SetSiPMCoatingThickness(sipm_coat_thick_);
     sipm->SetTimeBinning(time_binning_);
     sipm->SetSensorDepth(2);
     sipm->SetMotherDepth(4);
@@ -150,13 +147,6 @@ void NextDemoSiPMBoard::Construct()
     if (hole_diam_ == 0.)
       G4Exception("[NextDemoSiPMBoard]", "Construct()", FatalException,
       "Masks require holes");
-
-  // SiPM coating require thickness
-  if (sipm_coating_)
-    if(sipm_coat_thick_== 0.)
-      G4Exception("[NextDemoSiPMBoard]", "Construct()", FatalException,
-      "SiPM coating require thickness");
-
 
   /// Board-Wrapper volume that contains all other elements
   G4String board_name = "SIPM_BOARD";

--- a/source/geometries/NextDemoSiPMBoard.cc
+++ b/source/geometries/NextDemoSiPMBoard.cc
@@ -41,6 +41,7 @@ NextDemoSiPMBoard::NextDemoSiPMBoard():
   sipm_verbosity_  (false),
   visibility_      (false),
   sipm_visibility_ (true),
+  sipm_coating_    (false),
   time_binning_    (1. * microsecond),
   num_columns_     (8),
   num_rows_        (8),
@@ -66,6 +67,7 @@ NextDemoSiPMBoard::NextDemoSiPMBoard():
   msg_->DeclareProperty("sipm_verbosity"      ,  sipm_verbosity_, "NextDemoSiPMBoard SiPMs verbosity");
   msg_->DeclareProperty("sipm_board_vis"      ,      visibility_, "NextDemoSiPMBoard visibility.");
   msg_->DeclareProperty("sipm_visibility"     , sipm_visibility_, "NextDemoSiPMBoard SiPMs visibility");
+  msg_->DeclareProperty("sipm_coating"        ,    sipm_coating_, "NextDemoSiPMBoard SiPMs coating");
 
   G4GenericMessenger::Command& time_binning_cmd = msg_->DeclareProperty("sipm_time_binning", time_binning_, "TP SiPMs time binning.");
   time_binning_cmd.SetParameterName("sipm_time_binning", false);
@@ -107,6 +109,7 @@ void NextDemoSiPMBoard::Construct()
     Next100SiPM* sipm = new Next100SiPM();
 
     sipm->SetVisibility(sipm_visibility_);
+    sipm->SetSiPMCoating(sipm_coating_);
     sipm->SetTimeBinning(time_binning_);
     sipm->SetSensorDepth(2);
     sipm->SetMotherDepth(4);

--- a/source/geometries/NextDemoSiPMBoard.h
+++ b/source/geometries/NextDemoSiPMBoard.h
@@ -42,6 +42,7 @@ namespace nexus {
     void SetHoleX            (G4double x);
     void SetHoleY            (G4double y);
     void SetSiPMType         (G4String type);
+    void SetSiPMCoating      (G4bool coating);
 
     G4ThreeVector GetBoardSize() const;
     G4double      GetKaptonThickness() const;
@@ -52,6 +53,7 @@ namespace nexus {
     G4bool sipm_verbosity_;
     G4bool visibility_;
     G4bool sipm_visibility_;
+    G4bool sipm_coating_;
     G4double time_binning_;
 
     G4int    num_columns_, num_rows_, num_sipms_;
@@ -103,6 +105,9 @@ namespace nexus {
 
   inline void NextDemoSiPMBoard::SetSiPMType(G4String type)
   { sipm_type_ = type; }
+
+  inline void NextDemoSiPMBoard::SetSiPMCoating(G4bool coating)
+  { sipm_coating_ = coating; }
 
   inline G4ThreeVector NextDemoSiPMBoard::GetBoardSize() const
   { return board_size_; }

--- a/source/geometries/NextDemoSiPMBoard.h
+++ b/source/geometries/NextDemoSiPMBoard.h
@@ -34,16 +34,15 @@ namespace nexus {
     G4ThreeVector GenerateVertex(const G4String&) const override;
 
     void SetMotherPhysicalVolume(G4VPhysicalVolume* mother_phys);
-    void SetMaskThickness    (G4double thickn);
-    void SetMembraneThickness(G4double thickn);
-    void SetCoatingThickness (G4double thickn);
-    void SetHoleType         (G4String type);
-    void SetHoleDiameter     (G4double diam);
-    void SetHoleX            (G4double x);
-    void SetHoleY            (G4double y);
-    void SetSiPMType         (G4String type);
-    void SetSiPMCoating      (G4bool coating);
-    void SetSiPMCoatThick    (G4double thickn);
+    void SetMaskThickness       (G4double thickn);
+    void SetMembraneThickness   (G4double thickn);
+    void SetCoatingThickness    (G4double thickn);
+    void SetHoleType            (G4String type);
+    void SetHoleDiameter        (G4double diam);
+    void SetHoleX               (G4double x);
+    void SetHoleY               (G4double y);
+    void SetSiPMType            (G4String type);
+    void SetSiPMCoatingThickness(G4double thickn);
 
     G4ThreeVector GetBoardSize() const;
     G4double      GetKaptonThickness() const;
@@ -54,7 +53,6 @@ namespace nexus {
     G4bool sipm_verbosity_;
     G4bool visibility_;
     G4bool sipm_visibility_;
-    G4bool sipm_coating_;
     G4double sipm_coat_thick_;
     G4double time_binning_;
 
@@ -108,10 +106,7 @@ namespace nexus {
   inline void NextDemoSiPMBoard::SetSiPMType(G4String type)
   { sipm_type_ = type; }
 
-  inline void NextDemoSiPMBoard::SetSiPMCoating(G4bool coating)
-  { sipm_coating_ = coating; }
-
-  inline void NextDemoSiPMBoard::SetSiPMCoatThick(G4double thickn)
+  inline void NextDemoSiPMBoard::SetSiPMCoatingThickness(G4double thickn)
   { sipm_coat_thick_ = thickn; }
 
   inline G4ThreeVector NextDemoSiPMBoard::GetBoardSize() const

--- a/source/geometries/NextDemoSiPMBoard.h
+++ b/source/geometries/NextDemoSiPMBoard.h
@@ -43,6 +43,7 @@ namespace nexus {
     void SetHoleY            (G4double y);
     void SetSiPMType         (G4String type);
     void SetSiPMCoating      (G4bool coating);
+    void SetSiPMCoatThick    (G4bool thickn);
 
     G4ThreeVector GetBoardSize() const;
     G4double      GetKaptonThickness() const;
@@ -54,6 +55,7 @@ namespace nexus {
     G4bool visibility_;
     G4bool sipm_visibility_;
     G4bool sipm_coating_;
+    G4bool sipm_coat_thick_;
     G4double time_binning_;
 
     G4int    num_columns_, num_rows_, num_sipms_;
@@ -108,6 +110,9 @@ namespace nexus {
 
   inline void NextDemoSiPMBoard::SetSiPMCoating(G4bool coating)
   { sipm_coating_ = coating; }
+
+  inline void NextDemoSiPMBoard::SetSiPMCoatThick(G4bool thickn)
+  { sipm_coat_thick_ = thickn; }
 
   inline G4ThreeVector NextDemoSiPMBoard::GetBoardSize() const
   { return board_size_; }

--- a/source/geometries/NextDemoSiPMBoard.h
+++ b/source/geometries/NextDemoSiPMBoard.h
@@ -55,7 +55,7 @@ namespace nexus {
     G4bool visibility_;
     G4bool sipm_visibility_;
     G4bool sipm_coating_;
-    G4bool sipm_coat_thick_;
+    G4double sipm_coat_thick_;
     G4double time_binning_;
 
     G4int    num_columns_, num_rows_, num_sipms_;

--- a/source/geometries/NextDemoSiPMBoard.h
+++ b/source/geometries/NextDemoSiPMBoard.h
@@ -43,7 +43,7 @@ namespace nexus {
     void SetHoleY            (G4double y);
     void SetSiPMType         (G4String type);
     void SetSiPMCoating      (G4bool coating);
-    void SetSiPMCoatThick    (G4bool thickn);
+    void SetSiPMCoatThick    (G4double thickn);
 
     G4ThreeVector GetBoardSize() const;
     G4double      GetKaptonThickness() const;
@@ -111,7 +111,7 @@ namespace nexus {
   inline void NextDemoSiPMBoard::SetSiPMCoating(G4bool coating)
   { sipm_coating_ = coating; }
 
-  inline void NextDemoSiPMBoard::SetSiPMCoatThick(G4bool thickn)
+  inline void NextDemoSiPMBoard::SetSiPMCoatThick(G4double thickn)
   { sipm_coat_thick_ = thickn; }
 
   inline G4ThreeVector NextDemoSiPMBoard::GetBoardSize() const

--- a/source/geometries/NextDemoTrackingPlane.cc
+++ b/source/geometries/NextDemoTrackingPlane.cc
@@ -77,16 +77,17 @@ void NextDemoTrackingPlane::Construct()
   if(verbosity_) G4cout << G4endl << "*** NEXT Demo Tracking Plane ";
 
   /// Defining Tracking Plane parameters
-  G4double gate_board_dist = 0.; // Distance from GATE to SiPM Board kapton surface
-  G4double mask_thickn     = 0.;
-  G4double membrane_thickn = 0.;
-  G4double coating_thickn  = 0.;
-  G4String hole_type       = "";
-  G4double hole_diameter   = 0.;
-  G4double hole_x          = 0.;
-  G4double hole_y          = 0.;
-  G4String sipm_type       = "";
-  G4bool   sipm_coating    = false;
+  G4double gate_board_dist  = 0.; // Distance from GATE to SiPM Board kapton surface
+  G4double mask_thickn      = 0.;
+  G4double membrane_thickn  = 0.;
+  G4double coating_thickn   = 0.;
+  G4String hole_type        = "";
+  G4double hole_diameter    = 0.;
+  G4double hole_x           = 0.;
+  G4double hole_y           = 0.;
+  G4String sipm_type        = "";
+  G4bool   sipm_coating     = false;
+  G4double sipm_coat_thickn = 0.;
 
   if (config_ == "run5") {
     if(verbosity_) G4cout << "run5 ..." << G4endl;
@@ -97,6 +98,8 @@ void NextDemoTrackingPlane::Construct()
     hole_type       = "rounded";
     hole_diameter   = 3.5 * mm;
     sipm_type       = "sensl";
+    sipm_coating    = false;
+
   }
   else if (config_ == "run7") {
     if(verbosity_) G4cout << "run7 ..." << G4endl;
@@ -107,6 +110,7 @@ void NextDemoTrackingPlane::Construct()
     hole_type       = "rounded";
     hole_diameter   = 3.5  * mm;
     sipm_type       = "sensl";
+    sipm_coating    = false;
   }
   else if (config_ == "run8") {
     if(verbosity_) G4cout << "run8 ..." << G4endl;
@@ -117,6 +121,7 @@ void NextDemoTrackingPlane::Construct()
     hole_type       = "rounded";
     hole_diameter   = 4.0  * mm;
     sipm_type       = "sensl";
+    sipm_coating    = false;
   }
   else if (config_ == "run9") {
     if(verbosity_) G4cout << "run9 ..." << G4endl;
@@ -153,8 +158,8 @@ void NextDemoTrackingPlane::Construct()
     sipm_board_->SetHoleX(hole_x);
     sipm_board_->SetHoleY(hole_y);}
   sipm_board_->SetSiPMType(sipm_type);
-  if (sipm_type == "next100"){
-    sipm_board_->SetSiPMCoating(sipm_coating);}
+  sipm_board_->SetSiPMCoating(sipm_coating);
+  sipm_board_->SetSiPMCoatThick(sipm_coat_thickn);
 
   sipm_board_->Construct();
   G4LogicalVolume* board_logic = sipm_board_->GetLogicalVolume();

--- a/source/geometries/NextDemoTrackingPlane.cc
+++ b/source/geometries/NextDemoTrackingPlane.cc
@@ -86,7 +86,6 @@ void NextDemoTrackingPlane::Construct()
   G4double hole_x           = 0.;
   G4double hole_y           = 0.;
   G4String sipm_type        = "";
-  G4bool   sipm_coating     = false;
   G4double sipm_coat_thickn = 0.;
 
   if (config_ == "run5") {
@@ -98,8 +97,6 @@ void NextDemoTrackingPlane::Construct()
     hole_type       = "rounded";
     hole_diameter   = 3.5 * mm;
     sipm_type       = "sensl";
-    sipm_coating    = false;
-
   }
   else if (config_ == "run7") {
     if(verbosity_) G4cout << "run7 ..." << G4endl;
@@ -110,7 +107,6 @@ void NextDemoTrackingPlane::Construct()
     hole_type       = "rounded";
     hole_diameter   = 3.5  * mm;
     sipm_type       = "sensl";
-    sipm_coating    = false;
   }
   else if (config_ == "run8") {
     if(verbosity_) G4cout << "run8 ..." << G4endl;
@@ -121,7 +117,6 @@ void NextDemoTrackingPlane::Construct()
     hole_type       = "rounded";
     hole_diameter   = 4.0  * mm;
     sipm_type       = "sensl";
-    sipm_coating    = false;
   }
   else if (config_ == "run9") {
     if(verbosity_) G4cout << "run9 ..." << G4endl;
@@ -133,7 +128,6 @@ void NextDemoTrackingPlane::Construct()
     hole_x          = 6.0 * mm;
     hole_y          = 5.0 * mm;
     sipm_type       = "next100";
-    sipm_coating    = false;
   }
 
   /// Make sure the pointer to the mother volume is actually defined
@@ -158,8 +152,7 @@ void NextDemoTrackingPlane::Construct()
     sipm_board_->SetHoleX(hole_x);
     sipm_board_->SetHoleY(hole_y);}
   sipm_board_->SetSiPMType(sipm_type);
-  sipm_board_->SetSiPMCoating(sipm_coating);
-  sipm_board_->SetSiPMCoatThick(sipm_coat_thickn);
+  sipm_board_->SetSiPMCoatingThickness(sipm_coat_thickn);
 
   sipm_board_->Construct();
   G4LogicalVolume* board_logic = sipm_board_->GetLogicalVolume();

--- a/source/geometries/NextDemoTrackingPlane.cc
+++ b/source/geometries/NextDemoTrackingPlane.cc
@@ -86,6 +86,7 @@ void NextDemoTrackingPlane::Construct()
   G4double hole_x          = 0.;
   G4double hole_y          = 0.;
   G4String sipm_type       = "";
+  G4bool   sipm_coating    = false;
 
   if (config_ == "run5") {
     if(verbosity_) G4cout << "run5 ..." << G4endl;
@@ -127,6 +128,7 @@ void NextDemoTrackingPlane::Construct()
     hole_x          = 6.0 * mm;
     hole_y          = 5.0 * mm;
     sipm_type       = "next100";
+    sipm_coating    = false;
   }
 
   /// Make sure the pointer to the mother volume is actually defined
@@ -151,6 +153,8 @@ void NextDemoTrackingPlane::Construct()
     sipm_board_->SetHoleX(hole_x);
     sipm_board_->SetHoleY(hole_y);}
   sipm_board_->SetSiPMType(sipm_type);
+  if (sipm_type == "next100"){
+    sipm_board_->SetSiPMCoating(sipm_coating);}
 
   sipm_board_->Construct();
   G4LogicalVolume* board_logic = sipm_board_->GetLogicalVolume();


### PR DESCRIPTION
This PR adds the possibiity to coat the Next100SiPMs with a TPB layer. The coating is added on top of the SiPMs windows, with a 1micrometer thickness. DEMO SiPM board and tracking plane geometries have been modified in order to add the coating option when this SiPMs are used. 