### PR TITLE
Next100 vessel

### DIFF
--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -135,9 +135,12 @@ namespace nexus {
     // VESSEL
     vessel_->Construct();
     G4LogicalVolume* shielding_air_logic = shielding_->GetAirLogicalVolume();
+    // Recall that airbox is slighly displaced in Y dimension. In order to avoid
+    // mistmatch with vertex generators, we place the vessel in the center of the world volume
+    G4ThreeVector vessel_displacement = shielding_->GetAirDisplacement();
     G4LogicalVolume* vessel_logic = vessel_->GetLogicalVolume();
     gate_zpos_in_vessel_ = vessel_->GetELzCoord();
-    new G4PVPlacement(0, G4ThreeVector(0., 0., 0.), vessel_logic,
+    new G4PVPlacement(0, -vessel_displacement, vessel_logic,
     		      "VESSEL", shielding_air_logic, false, 0);
 
     G4LogicalVolume* vessel_internal_logic = vessel_->GetInternalLogicalVolume();

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -198,10 +198,11 @@ namespace nexus {
       vertex = shielding_->GenerateVertex(region);
     }
     // Vessel regions
-    else if ((region == "VESSEL") ||
-	     (region == "VESSEL_FLANGES") ||
-	     (region == "VESSEL_TRACKING_ENDCAP") ||
-	     (region == "VESSEL_ENERGY_ENDCAP")) {
+    else if ((region == "VESSEL")  ||
+             (region == "PORT_1a") ||
+             (region == "PORT_2a") ||
+             (region == "PORT_1b") ||
+             (region == "PORT_2b")) {
       vertex = vessel_->GenerateVertex(region);
     }
     // Inner copper shielding

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -570,6 +570,11 @@ namespace nexus {
     return G4ThreeVector(lead_x_, lead_y_, lead_z_);
   }
 
+  G4ThreeVector Next100Shielding::GetAirDisplacement() const
+  {
+    return G4ThreeVector(0., -(steel_thickness_ + beam_thickness_2)/2., 0.);
+  }
+
   G4ThreeVector Next100Shielding::GenerateVertex(const G4String& region) const
   {
     G4ThreeVector vertex(0., 0., 0.);

--- a/source/geometries/Next100Shielding.h
+++ b/source/geometries/Next100Shielding.h
@@ -33,6 +33,9 @@ namespace nexus {
     // Returns the inner air logical volume to place the vessel into it
     G4LogicalVolume* GetAirLogicalVolume() const;
 
+    // Returns the Air Box global position
+    G4ThreeVector GetAirDisplacement() const;
+
     /// Generate a vertex within a given region of the geometry
     G4ThreeVector GenerateVertex(const G4String& region) const;
 

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -258,39 +258,6 @@ namespace nexus {
       new G4PVPlacement(0, G4ThreeVector(0.,0.,0.), vessel_gas_logic,
                         "VESSEL_GAS", vessel_logic, false, 0);
 
-
-    //// Vacuum Manifold
-    G4double vacuum_manifold_rad = nozzle_ext_diam_/2. - vessel_thickness_;
-    G4double vacuum_manifold_length = (large_nozzle_length_ - vessel_body_length_) / 2. + 9.4*cm; // 10.6 cm comes from Derek's drawings
-                                                                                                  // Switched to 9.4 to be aligned with Energy Plane
-    G4double vacuum_manifold_zpos = -1. * (large_nozzle_length_ - vacuum_manifold_length) / 2.;
-
-    G4Tubs* vacuum_manifold_solid = new G4Tubs("VACUUM_MANIFOLD", 0.*cm, vacuum_manifold_rad,
-					       vacuum_manifold_length/2., 0.*deg, 360.*deg);
-
-    G4LogicalVolume* vacuum_manifold_logic = new G4LogicalVolume(vacuum_manifold_solid,
-								 G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"),
-								 "VACUUM_MANIFOLD");
-
-    new G4PVPlacement(0, G4ThreeVector(0.,0.,vacuum_manifold_zpos), vacuum_manifold_logic,
-		      "VACUUM_MANIFOLD", vessel_gas_logic, false, 0);
-
-
-    G4double vacuum_manifold_gas_rad = vacuum_manifold_rad - vessel_thickness_;
-    G4double vacuum_manifold_gas_length = vacuum_manifold_length - 2. * vessel_thickness_;
-
-    G4Tubs* vacuum_manifold_gas_solid = new G4Tubs("VACUUM_MANIFOLD_GAS", 0.*cm, vacuum_manifold_gas_rad,
-						   vacuum_manifold_gas_length/2., 0.*deg, 360.*deg);
-
-    G4LogicalVolume* vacuum_manifold_gas_logic = new G4LogicalVolume(vacuum_manifold_gas_solid,
-								     G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic"),
-								     "VACUUM_MANIFOLD_GAS");
-
-    new G4PVPlacement(0, G4ThreeVector(0.,0.,0.), vacuum_manifold_gas_logic,
-		      "VACUUM_MANIFOLD_GAS", vacuum_manifold_logic, false, 0);
-
-
-
     // SETTING VISIBILITIES   //////////
     if (visibility_) {
       G4VisAttributes grey = DarkGrey();
@@ -299,15 +266,10 @@ namespace nexus {
       grey.SetForceSolid(true);
       vessel_gas_logic->SetVisAttributes(grey);
       //grey.SetForceSolid(true);
-      vacuum_manifold_logic->SetVisAttributes(grey);
-      //grey.SetForceSolid(true);
-      vacuum_manifold_gas_logic->SetVisAttributes(grey);
     }
     else {
       vessel_logic->SetVisAttributes(G4VisAttributes::Invisible);
       vessel_gas_logic->SetVisAttributes(G4VisAttributes::Invisible);
-      vacuum_manifold_logic->SetVisAttributes(G4VisAttributes::Invisible);
-      vacuum_manifold_gas_logic->SetVisAttributes(G4VisAttributes::Invisible);
     }
 
 

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -28,6 +28,9 @@
 
 #include <CLHEP/Units/SystemOfUnits.h>
 
+#include <math.h>
+#include <algorithm>
+
 namespace nexus {
 
   using namespace CLHEP;
@@ -39,29 +42,22 @@ namespace nexus {
 			       const G4double bottom_nozzle_ypos):
     GeometryBase(),
 
-    // Body dimensions
-    vessel_in_rad_ (68.0  * cm),
-    vessel_body_length_ (160 * cm),
-    vessel_length_ (181.74 * cm),  // Vessel length = 160 cm (from body) + 2. * 10.87cm (from endcaps)
+    // general vessel dimensions
+    vessel_in_rad_    (68.0  * cm),
     vessel_thickness_ (1.  * cm),
-    distance_gate_body_end_ (110. * mm), // to be checked with designs
+
+    // Body
+    body_length_     (198.6 * cm),
 
     // Endcaps dimensions
-    endcap_in_rad_ (108.94 * cm),
-    endcap_theta_ (38.6 * deg),
-    endcap_thickness_ (1. * cm),
-    endcap_in_z_width_ (23.83 * cm),  // in_z_width = 35.7 cm - 1. cm (thickness) - 10.87 cm (from cylindric part)
+    endcap_in_rad_       (123.61 * cm),
+    endcap_theta_        (29.1   * deg),
+    endcap_in_z_width_   (15.6   * cm),
+    endcap_gate_distance_(48.62  * cm),
 
-    // Flange dimensions
-    flange_out_rad_ (73.5 * cm),
-    flange_length_ (8.0 * cm),
-    flange_z_pos_ (80.0 * cm),
-
-    // Nozzle dimensions
-    //  large_nozzle_length_ (320.0 * cm),
-    //  small_nozzle_length_ (240.0 * cm),
-     large_nozzle_length_ (250.0 * cm),
-    small_nozzle_length_ (240.0 * cm),
+    // // Nozzle dimensions
+    // large_nozzle_length_ (250.0 * cm),
+    // small_nozzle_length_ (240.0 * cm),
 
     // Vessel gas
     sc_yield_(16670. * 1/MeV),
@@ -120,112 +116,111 @@ namespace nexus {
   }
 
 
-
   void Next100Vessel::Construct()
   {
     // Body solid
     G4double vessel_out_rad = vessel_in_rad_ + vessel_thickness_;
 
-    G4Tubs* vessel_body_solid = new G4Tubs("VESSEL_BODY", 0., vessel_out_rad, vessel_length_/2.,
+    G4Tubs* vessel_body_solid = new G4Tubs("VESSEL_BODY", 0., vessel_out_rad, body_length_/2.,
 					   0.*deg, 360.*deg);
 
-    G4Tubs* vessel_gas_body_solid = new G4Tubs("VESSEL_GAS_BODY", 0., vessel_in_rad_, vessel_length_/2.,
+    G4Tubs* vessel_gas_body_solid = new G4Tubs("VESSEL_GAS_BODY", 0., vessel_in_rad_, body_length_/2.,
 					       0.*deg, 360.*deg);
 
     // Endcaps solids
-    G4double endcap_out_rad = endcap_in_rad_ + endcap_thickness_;
+    G4double endcap_out_rad = endcap_in_rad_ + vessel_thickness_;
 
-    G4Sphere* vessel_tracking_endcap_solid = new G4Sphere("VESSEL_TRACKING_ENDCAP",
+    G4Sphere* vessel_endcap_solid = new G4Sphere("VESSEL_ENDCAP",
 							  0. * cm,  endcap_out_rad,   //radius
 							  0. * deg, 360. * deg,       // phi
 							  0. * deg, endcap_theta_);   // theta
 
-    G4Sphere* vessel_gas_tracking_endcap_solid = new G4Sphere("VESSEL_GAS_TRACKING_ENDCAP",
+    G4Sphere* vessel_gas_endcap_solid = new G4Sphere("VESSEL_GAS_ENDCAP",
 							      0. * cm,  endcap_in_rad_,   //radius
 							      0. * deg, 360. * deg,       // phi
 							      0. * deg, endcap_theta_);   // theta
 
-    G4Sphere* vessel_energy_endcap_solid = new G4Sphere("VESSEL_ENERGY_ENDCAP",
-							0. * cm,  endcap_out_rad,                   //radius
-							0. * deg, 360. * deg,                       // phi
-							180. * deg - endcap_theta_, endcap_theta_); // theta
-
-    G4Sphere* vessel_gas_energy_endcap_solid = new G4Sphere("VESSEL_GAS_ENERGY_ENDCAP",
-							    0. * cm,  endcap_in_rad_,                   //radius
-							    0. * deg, 360. * deg,                       // phi
-							    180. * deg - endcap_theta_, endcap_theta_); // theta
-
-
     // Flange solid
-    G4Tubs* vessel_flange_solid = new G4Tubs("VESSEL_TRACKING_FLANGE", 0., flange_out_rad_,
-						      flange_length_/2., 0.*deg, 360.*deg);
+    G4double flange_out_rad   = 74.0 * cm;
+    G4double flange_tp_length = 41.5 * mm + 41.5 * mm; // 41.5 mm from the endcap
+    G4double flange_ep_length = 77.5 * mm + 41.5 * mm;
+    G4double flange_ep_z_pos  =   body_length_/2. - flange_ep_length/2. - 15.15 * cm;
+    G4double flange_tp_z_pos  = -(body_length_/2. - flange_tp_length/2. - 15.15 * cm);
 
-    // Nozzle solids
-    G4Tubs* large_nozzle_solid = new G4Tubs("LARGE_NOZZLE", 0.*cm, nozzle_ext_diam_/2.,
-					    large_nozzle_length_/2., 0.*deg, 360.*deg);
+    G4Tubs* vessel_tp_flange_solid = new G4Tubs("VESSEL_TRACKING_FLANGE", vessel_in_rad_, flange_out_rad,
+                                                flange_tp_length/2., 0.*deg, 360.*deg);
+    G4Tubs* vessel_ep_flange_solid = new G4Tubs("VESSEL_ENERGY_FLANGE"  , vessel_in_rad_, flange_out_rad,
+                                                flange_ep_length/2., 0.*deg, 360.*deg);
 
-    G4Tubs* small_nozzle_solid = new G4Tubs("SMALL_NOZZLE", 0.*cm, nozzle_ext_diam_/2.,
-					    small_nozzle_length_/2., 0.*deg, 360.*deg);
-
-    G4Tubs* large_nozzle_gas_solid = new G4Tubs("LARGE_NOZZLE_GAS", 0.*cm, (nozzle_ext_diam_/2. - vessel_thickness_),
-						large_nozzle_length_/2., 0.*deg, 360.*deg);
-
-    G4Tubs* small_nozzle_gas_solid = new G4Tubs("SMALL_NOZZLE_GAS", 0.*cm, (nozzle_ext_diam_/2. - vessel_thickness_),
-						small_nozzle_length_/2., 0.*deg, 360.*deg);
+    // // Nozzle solids
+    // G4Tubs* large_nozzle_solid = new G4Tubs("LARGE_NOZZLE", 0.*cm, nozzle_ext_diam_/2.,
+		// 			    large_nozzle_length_/2., 0.*deg, 360.*deg);
+    //
+    // G4Tubs* small_nozzle_solid = new G4Tubs("SMALL_NOZZLE", 0.*cm, nozzle_ext_diam_/2.,
+		// 			    small_nozzle_length_/2., 0.*deg, 360.*deg);
+    //
+    // G4Tubs* large_nozzle_gas_solid = new G4Tubs("LARGE_NOZZLE_GAS", 0.*cm, (nozzle_ext_diam_/2. - vessel_thickness_),
+		// 				large_nozzle_length_/2., 0.*deg, 360.*deg);
+    //
+    // G4Tubs* small_nozzle_gas_solid = new G4Tubs("SMALL_NOZZLE_GAS", 0.*cm, (nozzle_ext_diam_/2. - vessel_thickness_),
+		// 				small_nozzle_length_/2., 0.*deg, 360.*deg);
 
 
     //// Unions
-    G4double endcap_z_pos = (vessel_length_ / 2.) - (endcap_in_rad_ - endcap_in_z_width_);
-    G4ThreeVector tracking_endcap_pos(0, 0, endcap_z_pos);
-    G4ThreeVector energy_endcap_pos(0, 0, -1. * endcap_z_pos);
-    G4ThreeVector tracking_flange_pos(0, 0, flange_z_pos_);
-    G4ThreeVector energy_flange_pos(0, 0, -1. * flange_z_pos_);
+    G4double endcap_z_pos = (body_length_ / 2.) + endcap_in_z_width_ - endcap_in_rad_;
+    G4ThreeVector energy_endcap_pos  (0, 0,  endcap_z_pos);
+    G4ThreeVector tracking_endcap_pos(0, 0, -endcap_z_pos);
+    G4ThreeVector energy_flange_pos  (0, 0, flange_ep_z_pos);
+    G4ThreeVector tracking_flange_pos(0, 0, flange_tp_z_pos);
 
-    // Body + Tracking endcap
-    G4UnionSolid* vessel_solid = new G4UnionSolid("VESSEL", vessel_body_solid, vessel_tracking_endcap_solid,
-						  0, tracking_endcap_pos);
+    // tracking endcap z --> -z (we can rotate either in X or Y)
+    G4RotationMatrix* xRot = new G4RotationMatrix;
+    xRot->rotateX(180. * deg);
 
-    // Body + Tracking endcap + Energy endcap
-    vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, vessel_energy_endcap_solid,
-				    0, energy_endcap_pos);
+    // Body + Energy endcap
+    G4UnionSolid* vessel_solid = new G4UnionSolid("VESSEL", vessel_body_solid, vessel_endcap_solid,
+						  0, energy_endcap_pos);
 
-    // Body + Tracking endcap + Energy endcap + Tracking flange
+    // Body + Energy endcap + Tracking endcap
+    vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, vessel_endcap_solid,
+				    xRot, tracking_endcap_pos);
+
+    // Body + Energy endcap + Tracking endcap + Energy flange
     vessel_solid = new G4UnionSolid("VESSEL", vessel_solid,
-				    vessel_flange_solid, 0, tracking_flange_pos);
+				    vessel_ep_flange_solid, 0, energy_flange_pos);
 
-    // Body + Tracking endcap + Energy endcap + Tracking flange + Energy flange
+    // Body + Energy endcap + Tracking endcap + Energy flange + Tracking flange
     vessel_solid = new G4UnionSolid("VESSEL", vessel_solid,
-				    vessel_flange_solid, 0, energy_flange_pos);
+				    vessel_tp_flange_solid, 0, tracking_flange_pos);
 
-    // Adding nozzles
-    vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, small_nozzle_solid,
-				    0, G4ThreeVector(0., up_nozzle_ypos_, 0.) );
-    vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, large_nozzle_solid,
-				    0, G4ThreeVector(0., central_nozzle_ypos_, 0.) );
-    vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, large_nozzle_solid,
-				    0, G4ThreeVector(0., down_nozzle_ypos_, 0.) );
-    vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, small_nozzle_solid,
-				    0, G4ThreeVector(0., bottom_nozzle_ypos_, 0.) );
+    // // Adding nozzles
+    // vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, small_nozzle_solid,
+		// 		    0, G4ThreeVector(0., up_nozzle_ypos_, 0.) );
+    // vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, large_nozzle_solid,
+		// 		    0, G4ThreeVector(0., central_nozzle_ypos_, 0.) );
+    // vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, large_nozzle_solid,
+		// 		    0, G4ThreeVector(0., down_nozzle_ypos_, 0.) );
+    // vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, small_nozzle_solid,
+		// 		    0, G4ThreeVector(0., bottom_nozzle_ypos_, 0.) );
 
 
-
-    // Body gas + Tracking endcap gas
+    // Body gas + Energy endcap gas
     G4UnionSolid* vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_body_solid,
-						      vessel_gas_tracking_endcap_solid, 0, tracking_endcap_pos);
+						      vessel_gas_endcap_solid, 0, energy_endcap_pos);
 
-    // Body gas + Tracking endcap gas + Energy endcap gas
+    //  Body gas + Energy endcap gas + Tracking endcap gas
     vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid,
-					vessel_gas_energy_endcap_solid, 0, energy_endcap_pos);
-    // Adding nozzles
-    vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, small_nozzle_gas_solid,
-					0, G4ThreeVector(0., up_nozzle_ypos_, 0.) );
-    vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, large_nozzle_gas_solid,
-					0, G4ThreeVector(0., central_nozzle_ypos_, 0.) );
-    vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, large_nozzle_gas_solid,
-					0, G4ThreeVector(0., down_nozzle_ypos_, 0.) );
-    vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, small_nozzle_gas_solid,
-					0, G4ThreeVector(0., bottom_nozzle_ypos_, 0.) );
+					vessel_gas_endcap_solid, xRot, tracking_endcap_pos);
 
+    // // Adding nozzles
+    // vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, small_nozzle_gas_solid,
+		// 			0, G4ThreeVector(0., up_nozzle_ypos_, 0.) );
+    // vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, large_nozzle_gas_solid,
+		// 			0, G4ThreeVector(0., central_nozzle_ypos_, 0.) );
+    // vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, large_nozzle_gas_solid,
+		// 			0, G4ThreeVector(0., down_nozzle_ypos_, 0.) );
+    // vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, small_nozzle_gas_solid,
+		// 			0, G4ThreeVector(0., bottom_nozzle_ypos_, 0.) );
 
 
     //// The logics
@@ -253,7 +248,7 @@ namespace nexus {
 
     G4LogicalVolume* vessel_gas_logic = new G4LogicalVolume(vessel_gas_solid, vessel_gas_mat, "VESSEL_GAS");
     internal_logic_vol_ = vessel_gas_logic;
-    SetELzCoord(-vessel_body_length_/2. + distance_gate_body_end_);
+    SetELzCoord(-body_length_/2. - endcap_in_z_width_ + endcap_gate_distance_);
     internal_phys_vol_ =
       new G4PVPlacement(0, G4ThreeVector(0.,0.,0.), vessel_gas_logic,
                         "VESSEL_GAS", vessel_logic, false, 0);
@@ -261,40 +256,47 @@ namespace nexus {
     // SETTING VISIBILITIES   //////////
     if (visibility_) {
       G4VisAttributes grey = DarkGrey();
-      //grey.SetForceSolid(true);
       vessel_logic->SetVisAttributes(grey);
       grey.SetForceSolid(true);
       vessel_gas_logic->SetVisAttributes(grey);
-      //grey.SetForceSolid(true);
     }
     else {
       vessel_logic->SetVisAttributes(G4VisAttributes::Invisible);
       vessel_gas_logic->SetVisAttributes(G4VisAttributes::Invisible);
     }
 
-
     // VERTEX GENERATORS   //////////
-    body_gen_  = new CylinderPointSampler(vessel_in_rad_, vessel_length_, vessel_thickness_, 0.);
+    body_gen_  = new CylinderPointSampler(vessel_in_rad_, body_length_, vessel_thickness_, 0.);
 
-    tracking_endcap_gen_ = new SpherePointSampler( endcap_in_rad_, endcap_thickness_, tracking_endcap_pos, 0,
+    energy_endcap_gen_ = new SpherePointSampler( endcap_in_rad_, vessel_thickness_, energy_endcap_pos, 0,
 						   0., twopi, 0., endcap_theta_);
 
-    energy_endcap_gen_ = new SpherePointSampler( endcap_in_rad_, endcap_thickness_, energy_endcap_pos, 0,
-						 0., twopi, 180.*deg - endcap_theta_, endcap_theta_);
+    tracking_endcap_gen_ = new SpherePointSampler( endcap_in_rad_, vessel_thickness_, tracking_endcap_pos, xRot,
+						 0., twopi, 0., endcap_theta_);
 
-    tracking_flange_gen_  = new CylinderPointSampler(vessel_out_rad, flange_length_,
-						     flange_out_rad_-vessel_out_rad, 0., tracking_flange_pos);
+    tracking_flange_gen_  = new CylinderPointSampler(vessel_out_rad, flange_tp_length,
+						     flange_out_rad-vessel_out_rad, 0., tracking_flange_pos);
 
-    energy_flange_gen_  = new CylinderPointSampler(vessel_out_rad, flange_length_,
-						   flange_out_rad_-vessel_out_rad, 0., energy_flange_pos);
+    energy_flange_gen_  = new CylinderPointSampler(vessel_out_rad, flange_ep_length,
+						   flange_out_rad-vessel_out_rad, 0., energy_flange_pos);
 
     // Calculating some prob
-    G4double body_vol = vessel_body_solid->GetCubicVolume() - vessel_gas_body_solid->GetCubicVolume();
-    G4double endcap_vol =  vessel_tracking_endcap_solid->GetCubicVolume() - vessel_gas_tracking_endcap_solid->GetCubicVolume();
-    perc_endcap_vol_ = endcap_vol / (body_vol + 2. * endcap_vol);
+    G4double body_vol   = vessel_body_solid  ->GetCubicVolume() - vessel_gas_body_solid  ->GetCubicVolume();
+    G4double endcap_vol = vessel_endcap_solid->GetCubicVolume() - vessel_gas_endcap_solid->GetCubicVolume();
+    G4double flange_ep_vol = vessel_ep_flange_solid->GetCubicVolume();
+    G4double flange_tp_vol = vessel_tp_flange_solid->GetCubicVolume();
+    G4double vessel_vol = body_vol + 2.*endcap_vol + flange_ep_vol + flange_tp_vol;
+
+    perc_endcap_vol_    = 2.*endcap_vol / vessel_vol;
+    perc_ep_flange_vol_ = flange_ep_vol / vessel_vol;
+    perc_tp_flange_vol_ = flange_tp_vol / vessel_vol;
+
+    // G4double body_vol = vessel_body_solid->GetCubicVolume() - vessel_gas_body_solid->GetCubicVolume();
+    // std::cout << "Body vol (cm3)" << body_vol/1e6 << '\n';
+    // G4double endcap_vol = vessel_endcap_solid->GetCubicVolume() - vessel_gas_endcap_solid->GetCubicVolume();
+    // std::cout << "Endcap vol (cm3)" << endcap_vol/1e6 << '\n';
 
   }
-
 
 
   Next100Vessel::~Next100Vessel()
@@ -319,88 +321,37 @@ namespace nexus {
   }
 
 
-
   G4ThreeVector Next100Vessel::GenerateVertex(const G4String& region) const
   {
     G4ThreeVector vertex(0., 0., 0.);
 
-    // Vertex in the whole VESSEL volume except flanges
+    // Vertex in the whole VESSEL volume
     if (region == "VESSEL") {
       G4double rand = G4UniformRand();
-      if (rand < perc_endcap_vol_) {
-	G4VPhysicalVolume *VertexVolume;
-	do {
-	  vertex = tracking_endcap_gen_->GenerateVertex("VOLUME");  // Tracking endcap
-	  // To check its volume, one needs to rotate and shift the vertex
-	// because the check is done using global coordinates
-	G4ThreeVector glob_vtx(vertex);
-	// First rotate, then shift
-	glob_vtx.rotate(pi, G4ThreeVector(0., 1., 0.));
-	glob_vtx = glob_vtx + G4ThreeVector(0, 0, GetELzCoord());
-	  VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
-	} while (VertexVolume->GetName() != "VESSEL");
+      if (rand < perc_endcap_vol_) { // Endcaps
+        if (G4UniformRand()<0.5){ // Tracking endcap
+        vertex = tracking_endcap_gen_->GenerateVertex("VOLUME");
+        }
+        else{ // Energy endcap
+          vertex = energy_endcap_gen_->GenerateVertex("VOLUME");
+        }
       }
-      else if (rand > 1. - perc_endcap_vol_) {
-	G4VPhysicalVolume *VertexVolume;
-	do {
-	  vertex = energy_endcap_gen_->GenerateVertex("VOLUME");  // Energy endcap
-	  // To check its volume, one needs to rotate and shift the vertex
-	  // because the check is done using global coordinates
-	  G4ThreeVector glob_vtx(vertex);
-	  // First rotate, then shift
-	  glob_vtx.rotate(pi, G4ThreeVector(0., 1., 0.));
-	  glob_vtx = glob_vtx + G4ThreeVector(0, 0, GetELzCoord());
-	  VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
-	} while (VertexVolume->GetName() != "VESSEL");
+      else if (rand < (perc_endcap_vol_ + perc_ep_flange_vol_)){// Energy flange
+        vertex = energy_flange_gen_->GenerateVertex("WHOLE_VOL");
       }
-      else
-	vertex = body_gen_->GenerateVertex("BODY_VOL");  // Body
+      else if (rand < (perc_endcap_vol_ + perc_ep_flange_vol_ + perc_tp_flange_vol_)){// Tracking flange
+        vertex = tracking_flange_gen_->GenerateVertex("WHOLE_VOL");
+      }
+      else // Body
+        	vertex = body_gen_->GenerateVertex("WHOLE_VOL");
     }
 
-    // Vertex in FLANGES
-    else if (region == "VESSEL_FLANGES") {
-      if (G4UniformRand() < 0.5)
-      	vertex = tracking_flange_gen_->GenerateVertex("BODY_VOL");
-      else
-      	vertex = energy_flange_gen_->GenerateVertex("BODY_VOL");
-    }
-
-    // Vertex in TRACKING ENDCAP
-    else if (region == "VESSEL_TRACKING_ENDCAP") {
-      G4VPhysicalVolume *VertexVolume;
-      do {
-	vertex = tracking_endcap_gen_->GenerateVertex("VOLUME");  // Tracking endcap
-	// To check its volume, one needs to rotate and shift the vertex
-	// because the check is done using global coordinates
-	G4ThreeVector glob_vtx(vertex);
-	// First rotate, then shift
-	glob_vtx.rotate(pi, G4ThreeVector(0., 1., 0.));
-	glob_vtx = glob_vtx + G4ThreeVector(0, 0, GetELzCoord());
-	VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
-      } while (VertexVolume->GetName() != "VESSEL");
-    }
-
-    // Vertex in ENERGY ENDCAP
-    else if (region == "VESSEL_ENERGY_ENDCAP") {
-      G4VPhysicalVolume *VertexVolume;
-      do {
-	vertex = energy_endcap_gen_->GenerateVertex("VOLUME");  // Energy endcap
-	// To check its volume, one needs to rotate and shift the vertex
-	// because the check is done using global coordinates
-	G4ThreeVector glob_vtx(vertex);
-	// First rotate, then shift
-	glob_vtx.rotate(pi, G4ThreeVector(0., 1., 0.));
-	glob_vtx = glob_vtx + G4ThreeVector(0, 0, GetELzCoord());
-	VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
-      } while (VertexVolume->GetName() != "VESSEL");
-    }
-     else {
+    else {
       G4Exception("[Next100Vessel]", "GenerateVertex()", FatalException,
 		  "Unknown vertex generation region!");
     }
 
     return vertex;
   }
-
 
 } //end namespace nexus

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -392,12 +392,6 @@ namespace nexus {
     perc_endcap_vol_    = 2.*endcap_vol / vessel_vol;
     perc_ep_flange_vol_ = flange_ep_vol / vessel_vol;
     perc_tp_flange_vol_ = flange_tp_vol / vessel_vol;
-
-    // G4double body_vol = vessel_body_solid->GetCubicVolume() - vessel_gas_body_solid->GetCubicVolume();
-    // std::cout << "Body vol (cm3)" << body_vol/1e6 << '\n';
-    // G4double endcap_vol = vessel_endcap_solid->GetCubicVolume() - vessel_gas_endcap_solid->GetCubicVolume();
-    // std::cout << "Endcap vol (cm3)" << endcap_vol/1e6 << '\n';
-
   }
 
 

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -58,8 +58,8 @@ namespace nexus {
 
     // Ports (values set on Construct())
     // They are defined global since are needed at the vertex generation
-    port_gas_x_(0.),
-    port_gas_y_(0.),
+    port_x_(0.),
+    port_y_(0.),
     port_z_1a_ (0.),
     port_z_1b_ (0.),
     port_z_2a_ (0.),
@@ -160,12 +160,13 @@ namespace nexus {
     G4Tubs* vessel_ep_flange_solid = new G4Tubs("VESSEL_ENERGY_FLANGE"  , vessel_in_rad_, flange_out_rad,
                                                 flange_ep_length/2., 0.*deg, 360.*deg);
 
-    // Calibration ports (approximate values)
+    // Calibration ports
     G4double port_in_rad      = 15.5 * mm;
-    G4double port_cap_height  = 15. * mm;
-    G4double port_cap_rad     = 36. * mm;
-    G4double port_base_height = 37. * mm;
-    G4double port_base_rad    = 21. * mm;
+    G4double port_cap_height  = 15.  * mm;
+    G4double port_cap_rad     = 37.5 * mm;
+    G4double port_base_height = 37.  * mm;
+    G4double port_base_rad    = 21.1 * mm;
+    G4double offset = 1. * mm; // add offset to join gas port
 
     G4Tubs* port_solid_cap  = new G4Tubs("PORT_cap" , 0., port_cap_rad, port_cap_height/2.,
                                          0.*deg, 360.*deg);
@@ -173,7 +174,7 @@ namespace nexus {
                                          0.*deg, 360.*deg);
     G4UnionSolid* port_solid = new G4UnionSolid("PORT", port_solid_base, port_solid_cap,
                                 0, G4ThreeVector(0., 0., (port_base_height + port_cap_height)/2.));
-    G4Tubs* port_gas_solid = new G4Tubs("PORT_GAS", 0., port_in_rad, (port_base_height + vessel_thickness_)/2.,
+    G4Tubs* port_gas_solid = new G4Tubs("PORT_GAS", 0., port_in_rad, (port_base_height + offset)/2.,
                                         0.*deg, 360.*deg);
 
     // // Nozzle solids
@@ -218,10 +219,8 @@ namespace nexus {
 				    vessel_tp_flange_solid, 0, tracking_flange_pos);
 
     // Add ports (x,y at 45*deg)
-    G4double port_x = (vessel_out_rad+port_base_height/2.)/sqrt(2.);
-    G4double port_y = port_x;
-    port_gas_x_ = (vessel_in_rad_+port_base_height/2.+vessel_thickness_/2.)/sqrt(2.);
-    port_gas_y_ = port_gas_x_;
+    port_x_ = (vessel_in_rad_+port_base_height/2.)/sqrt(2.);
+    port_y_ = port_x_;
 
     G4double port_reference_z = -body_length_/2. + endcap_in_body_;
     port_z_1a_ = port_reference_z +   702. * mm;
@@ -234,18 +233,18 @@ namespace nexus {
     port_a_Rot->rotateY(-45. * deg);
 
     vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, port_solid,
-                                    port_a_Rot, G4ThreeVector(port_x, port_y, port_z_1a_));
+                                    port_a_Rot, G4ThreeVector(port_x_, port_y_, port_z_1a_));
     vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, port_solid,
-                                    port_a_Rot, G4ThreeVector(port_x, port_y, port_z_2a_));
+                                    port_a_Rot, G4ThreeVector(port_x_, port_y_, port_z_2a_));
 
     G4RotationMatrix* port_b_Rot = new G4RotationMatrix;
     port_b_Rot->rotateX( 90. * deg);
     port_b_Rot->rotateY( 45. * deg);
 
     vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, port_solid,
-                                    port_b_Rot, G4ThreeVector(-port_x, port_y, port_z_1b_));
+                                    port_b_Rot, G4ThreeVector(-port_x_, port_y_, port_z_1b_));
     vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, port_solid,
-                                    port_b_Rot, G4ThreeVector(-port_x, port_y, port_z_2b_));
+                                    port_b_Rot, G4ThreeVector(-port_x_, port_y_, port_z_2b_));
 
     // // Adding nozzles
     // vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, small_nozzle_solid,
@@ -267,14 +266,17 @@ namespace nexus {
 					vessel_gas_endcap_solid, xRot, tracking_endcap_pos);
 
     // Add gas inside ports
+    G4double port_gas_x = port_x_ - (offset/2.)/sqrt(2.);
+    G4double port_gas_y = port_gas_x;
+
     vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, port_gas_solid,
-                                        port_a_Rot, G4ThreeVector(port_gas_x_, port_gas_y_, port_z_1a_));
+                                        port_a_Rot, G4ThreeVector(port_gas_x, port_gas_y, port_z_1a_));
     vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, port_gas_solid,
-                                        port_a_Rot, G4ThreeVector(port_gas_x_, port_gas_y_, port_z_2a_));
+                                        port_a_Rot, G4ThreeVector(port_gas_x, port_gas_y, port_z_2a_));
     vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, port_gas_solid,
-                                        port_b_Rot, G4ThreeVector(-port_gas_x_, port_gas_y_, port_z_1b_));
+                                        port_b_Rot, G4ThreeVector(-port_gas_x, port_gas_y, port_z_1b_));
     vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, port_gas_solid,
-                                        port_b_Rot, G4ThreeVector(-port_gas_x_, port_gas_y_, port_z_2b_));
+                                        port_b_Rot, G4ThreeVector(-port_gas_x, port_gas_y, port_z_2b_));
     // // Adding nozzles
     // vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, small_nozzle_gas_solid,
 		// 			0, G4ThreeVector(0., up_nozzle_ypos_, 0.) );
@@ -343,7 +345,7 @@ namespace nexus {
     energy_flange_gen_  = new CylinderPointSampler(vessel_out_rad, flange_ep_length,
 						   flange_out_rad-vessel_out_rad, 0., energy_flange_pos);
 
-    port_gen_ = new CylinderPointSampler(0., (port_base_height+vessel_thickness_), port_in_rad, 0.);
+    port_gen_ = new CylinderPointSampler(0., port_base_height, port_in_rad, 0.);
 
     // Calculating some prob
     G4double body_vol   = vessel_body_solid  ->GetCubicVolume() - vessel_gas_body_solid  ->GetCubicVolume();
@@ -417,7 +419,7 @@ namespace nexus {
       vertex = vertex.rotateX( 90. * deg);
       vertex = vertex.rotateZ(-45. * deg);
 
-      G4ThreeVector translate (port_gas_x_, port_gas_y_, port_z_1a_);
+      G4ThreeVector translate (port_x_, port_y_, port_z_1a_);
       vertex = vertex + translate;
     }
 
@@ -427,7 +429,7 @@ namespace nexus {
       vertex = vertex.rotateX( 90. * deg);
       vertex = vertex.rotateZ(-45. * deg);
 
-      G4ThreeVector translate (port_gas_x_, port_gas_y_, port_z_2a_);
+      G4ThreeVector translate (port_x_, port_y_, port_z_2a_);
       vertex = vertex + translate;
     }
 
@@ -437,7 +439,7 @@ namespace nexus {
       vertex = vertex.rotateX( 90. * deg);
       vertex = vertex.rotateZ( 45. * deg);
 
-      G4ThreeVector translate (-port_gas_x_, port_gas_y_, port_z_1b_);
+      G4ThreeVector translate (-port_x_, port_y_, port_z_1b_);
       vertex = vertex + translate;
     }
 
@@ -447,7 +449,7 @@ namespace nexus {
       vertex = vertex.rotateX( 90. * deg);
       vertex = vertex.rotateZ( 45. * deg);
 
-      G4ThreeVector translate (-port_gas_x_, port_gas_y_, port_z_2b_);
+      G4ThreeVector translate (-port_x_, port_y_, port_z_2b_);
       vertex = vertex + translate;
     }
 

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -10,7 +10,7 @@
 #include "MaterialsList.h"
 #include "Visibilities.h"
 #include "OpticalMaterialProperties.h"
-#include "CylinderPointSampler.h"
+#include "CylinderPointSampler2020.h"
 #include "SpherePointSampler.h"
 
 #include <G4GenericMessenger.hh>
@@ -338,13 +338,13 @@ namespace nexus {
     new G4PVPlacement(0, G4ThreeVector(0., 0., 0.), port_tube_gas_logic,
                       "PORT_TUBE_AIR", port_tube_logic, false, 0);
 
-    new G4PVPlacement(port_a_Rot, G4ThreeVector(port_gas_x, port_gas_y, port_z_1a_), port_tube_logic,
+    new G4PVPlacement(port_a_Rot, G4ThreeVector(port_x_, port_y_, port_z_1a_), port_tube_logic,
                       "PORT_TUBE_1a", vessel_gas_logic, false, 0);
-    new G4PVPlacement(port_a_Rot, G4ThreeVector(port_gas_x, port_gas_y, port_z_2a_), port_tube_logic,
+    new G4PVPlacement(port_a_Rot, G4ThreeVector(port_x_, port_y_, port_z_2a_), port_tube_logic,
                       "PORT_TUBE_2a", vessel_gas_logic, false, 0);
-    new G4PVPlacement(port_b_Rot, G4ThreeVector(-port_gas_x, port_gas_y, port_z_1b_), port_tube_logic,
+    new G4PVPlacement(port_b_Rot, G4ThreeVector(-port_x_, port_y_, port_z_1b_), port_tube_logic,
                       "PORT_TUBE_1b", vessel_gas_logic, false, 0);
-    new G4PVPlacement(port_b_Rot, G4ThreeVector(-port_gas_x, port_gas_y, port_z_2b_), port_tube_logic,
+    new G4PVPlacement(port_b_Rot, G4ThreeVector(-port_x_, port_y_, port_z_2b_), port_tube_logic,
                       "PORT_TUBE_2b", vessel_gas_logic, false, 0);
 
     // SETTING VISIBILITIES   //////////
@@ -366,7 +366,8 @@ namespace nexus {
     }
 
     // VERTEX GENERATORS   //////////
-    body_gen_  = new CylinderPointSampler(vessel_in_rad_, body_length_, vessel_thickness_, 0.);
+    body_gen_  = new CylinderPointSampler2020(vessel_in_rad_, vessel_out_rad, body_length_/2.,
+                                              0., 360.*deg, 0, G4ThreeVector(0., 0., 0.));
 
     energy_endcap_gen_ = new SpherePointSampler( endcap_in_rad_, vessel_thickness_, energy_endcap_pos, 0,
 						   0., twopi, 0., endcap_theta_);
@@ -374,13 +375,14 @@ namespace nexus {
     tracking_endcap_gen_ = new SpherePointSampler( endcap_in_rad_, vessel_thickness_, tracking_endcap_pos, xRot,
 						 0., twopi, 0., endcap_theta_);
 
-    tracking_flange_gen_  = new CylinderPointSampler(vessel_out_rad, flange_tp_length,
-						     flange_out_rad-vessel_out_rad, 0., tracking_flange_pos);
+    tracking_flange_gen_ = new CylinderPointSampler2020(vessel_in_rad_, flange_out_rad, flange_tp_length/2.,
+                                                        0., 360.*deg, 0, tracking_flange_pos);
 
-    energy_flange_gen_  = new CylinderPointSampler(vessel_out_rad, flange_ep_length,
-						   flange_out_rad-vessel_out_rad, 0., energy_flange_pos);
+    energy_flange_gen_ = new CylinderPointSampler2020(vessel_in_rad_, flange_out_rad, flange_ep_length/2.,
+                                                      0., 360.*deg, 0, energy_flange_pos);
 
-    port_gen_ = new CylinderPointSampler(0., port_base_height, port_tube_rad, 0.);
+    port_gen_ = new CylinderPointSampler2020(0., port_tube_rad, port_base_height/2.,
+                                             0., 360.*deg, 0, G4ThreeVector(0., 0., 0.));
 
     // Calculating some prob
     G4double body_vol   = vessel_body_solid  ->GetCubicVolume() - vessel_gas_body_solid  ->GetCubicVolume();
@@ -433,17 +435,17 @@ namespace nexus {
         }
       }
       else if (rand < (perc_endcap_vol_ + perc_ep_flange_vol_)){// Energy flange
-        vertex = energy_flange_gen_->GenerateVertex("WHOLE_VOL");
+        vertex = energy_flange_gen_->GenerateVertex("VOLUME");
       }
       else if (rand < (perc_endcap_vol_ + perc_ep_flange_vol_ + perc_tp_flange_vol_)){// Tracking flange
-        vertex = tracking_flange_gen_->GenerateVertex("WHOLE_VOL");
+        vertex = tracking_flange_gen_->GenerateVertex("VOLUME");
       }
       else // Body
-        	vertex = body_gen_->GenerateVertex("WHOLE_VOL");
+        	vertex = body_gen_->GenerateVertex("VOLUME");
     }
 
     else if (region == "PORT_1a"){
-      vertex = port_gen_->GenerateVertex("WHOLE_VOL");
+      vertex = port_gen_->GenerateVertex("VOLUME");
 
       vertex = vertex.rotateX( 90. * deg);
       vertex = vertex.rotateZ(-45. * deg);
@@ -453,7 +455,7 @@ namespace nexus {
     }
 
     else if (region == "PORT_2a"){
-      vertex = port_gen_->GenerateVertex("WHOLE_VOL");
+      vertex = port_gen_->GenerateVertex("VOLUME");
 
       vertex = vertex.rotateX( 90. * deg);
       vertex = vertex.rotateZ(-45. * deg);
@@ -463,7 +465,7 @@ namespace nexus {
     }
 
     else if (region == "PORT_1b"){
-      vertex = port_gen_->GenerateVertex("WHOLE_VOL");
+      vertex = port_gen_->GenerateVertex("VOLUME");
 
       vertex = vertex.rotateX( 90. * deg);
       vertex = vertex.rotateZ( 45. * deg);
@@ -473,7 +475,7 @@ namespace nexus {
     }
 
     else if (region == "PORT_2b"){
-      vertex = port_gen_->GenerateVertex("WHOLE_VOL");
+      vertex = port_gen_->GenerateVertex("VOLUME");
 
       vertex = vertex.rotateX( 90. * deg);
       vertex = vertex.rotateZ( 45. * deg);

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -58,10 +58,11 @@ namespace nexus {
 
     // Ports (values set on Construct())
     port_base_height_(37. * mm),
-    port_tube_height_(port_base_height_),
+    port_tube_height_(port_base_height_), // preliminar
     // They are defined global because are needed at the vertex generation
     port_x_ ((vessel_in_rad_ + port_base_height_ - port_tube_height_/2.)/sqrt(2.)), // inner port pos
     port_y_ (port_x_),
+    source_height_ (5. * mm), // preliminar
     port_z_1a_ (0.), // defined in the Construct()
     port_z_1b_ (0.),
     port_z_2a_ (0.),
@@ -382,7 +383,7 @@ namespace nexus {
     energy_flange_gen_ = new CylinderPointSampler2020(vessel_in_rad_, flange_out_rad, flange_ep_length/2.,
                                                       0., 360.*deg, 0, energy_flange_pos);
 
-    port_gen_ = new CylinderPointSampler2020(0., port_tube_rad, port_tube_height_/2.,
+    port_gen_ = new CylinderPointSampler2020(0., port_tube_rad, source_height_/2.,
                                              0., 360.*deg, 0, G4ThreeVector(0., 0., 0.));
 
     // Calculating some prob
@@ -423,6 +424,8 @@ namespace nexus {
   G4ThreeVector Next100Vessel::GenerateVertex(const G4String& region) const
   {
     G4ThreeVector vertex(0., 0., 0.);
+    G4double source_x = port_x_ - (port_tube_height_-source_height_)/2./sqrt(2.);
+    G4double source_y = source_x;
 
     // Vertex in the whole VESSEL volume
     if (region == "VESSEL") {
@@ -451,7 +454,7 @@ namespace nexus {
       vertex = vertex.rotateX( 90. * deg);
       vertex = vertex.rotateZ(-45. * deg);
 
-      G4ThreeVector translate (port_x_, port_y_, port_z_1a_);
+      G4ThreeVector translate (source_x, source_y, port_z_1a_);
       vertex = vertex + translate;
     }
 
@@ -461,7 +464,7 @@ namespace nexus {
       vertex = vertex.rotateX( 90. * deg);
       vertex = vertex.rotateZ(-45. * deg);
 
-      G4ThreeVector translate (port_x_, port_y_, port_z_2a_);
+      G4ThreeVector translate (source_x, source_y, port_z_2a_);
       vertex = vertex + translate;
     }
 
@@ -471,7 +474,7 @@ namespace nexus {
       vertex = vertex.rotateX( 90. * deg);
       vertex = vertex.rotateZ( 45. * deg);
 
-      G4ThreeVector translate (-port_x_, port_y_, port_z_1b_);
+      G4ThreeVector translate (-source_x, source_y, port_z_1b_);
       vertex = vertex + translate;
     }
 
@@ -481,10 +484,9 @@ namespace nexus {
       vertex = vertex.rotateX( 90. * deg);
       vertex = vertex.rotateZ( 45. * deg);
 
-      G4ThreeVector translate (-port_x_, port_y_, port_z_2b_);
+      G4ThreeVector translate (-source_x, source_y, port_z_2b_);
       vertex = vertex + translate;
     }
-
 
     else {
       G4Exception("[Next100Vessel]", "GenerateVertex()", FatalException,

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -19,7 +19,7 @@ class G4VPhysicalVolume;
 
 namespace nexus {
 
-  class CylinderPointSampler;
+  class CylinderPointSampler2020;
   class SpherePointSampler;
 
   class Next100Vessel: public GeometryBase
@@ -70,12 +70,12 @@ namespace nexus {
     G4VPhysicalVolume* internal_phys_vol_;
 
     // Vertex generators
-    CylinderPointSampler* body_gen_;
+    CylinderPointSampler2020* body_gen_;
     SpherePointSampler*   tracking_endcap_gen_;
     SpherePointSampler*   energy_endcap_gen_;
-    CylinderPointSampler* tracking_flange_gen_;
-    CylinderPointSampler* energy_flange_gen_;
-    CylinderPointSampler* port_gen_;
+    CylinderPointSampler2020* tracking_flange_gen_;
+    CylinderPointSampler2020* energy_flange_gen_;
+    CylinderPointSampler2020* port_gen_;
 
     G4double perc_endcap_vol_;
     G4double perc_ep_flange_vol_;

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -54,6 +54,7 @@ namespace nexus {
     G4double endcap_in_rad_, endcap_in_body_, endcap_theta_, endcap_in_z_width_, endcap_gate_distance_;
     // G4double flange_out_rad_, flange_length_, flange_z_pos_;
     // G4double large_nozzle_length_, small_nozzle_length_;
+    G4double port_base_height_, port_tube_height_;
     G4double port_x_, port_y_, port_z_1a_, port_z_1b_, port_z_2a_, port_z_2b_;
     G4double sc_yield_, e_lifetime_;
     G4double pressure_, temperature_;

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -54,7 +54,7 @@ namespace nexus {
     G4double endcap_in_rad_, endcap_in_body_, endcap_theta_, endcap_in_z_width_, endcap_gate_distance_;
     // G4double flange_out_rad_, flange_length_, flange_z_pos_;
     // G4double large_nozzle_length_, small_nozzle_length_;
-    G4double port_gas_x_, port_gas_y_, port_z_1a_, port_z_1b_, port_z_2a_, port_z_2b_;
+    G4double port_x_, port_y_, port_z_1a_, port_z_1b_, port_z_2a_, port_z_2b_;
     G4double sc_yield_, e_lifetime_;
     G4double pressure_, temperature_;
 

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -49,11 +49,11 @@ namespace nexus {
 
   private:
     // Dimensions
-    G4double vessel_in_rad_, vessel_body_length_, vessel_length_, vessel_thickness_;
-    G4double distance_gate_body_end_;
-    G4double endcap_in_rad_, endcap_theta_, endcap_thickness_, endcap_in_z_width_;
-    G4double flange_out_rad_, flange_length_, flange_z_pos_;
-    G4double large_nozzle_length_, small_nozzle_length_;
+    G4double vessel_in_rad_, vessel_thickness_;
+    G4double body_length_;
+    G4double endcap_in_rad_, endcap_theta_, endcap_in_z_width_, endcap_gate_distance_;
+    // G4double flange_out_rad_, flange_length_, flange_z_pos_;
+    // G4double large_nozzle_length_, small_nozzle_length_;
     G4double sc_yield_, e_lifetime_;
     G4double pressure_, temperature_;
 
@@ -63,7 +63,6 @@ namespace nexus {
     // Dimensions coming from outside
     G4double nozzle_ext_diam_, up_nozzle_ypos_, central_nozzle_ypos_;
     G4double down_nozzle_ypos_, bottom_nozzle_ypos_;
-
 
     // Internal logical and physical volumes
     G4LogicalVolume* internal_logic_vol_;
@@ -77,6 +76,8 @@ namespace nexus {
     CylinderPointSampler* energy_flange_gen_;
 
     G4double perc_endcap_vol_;
+    G4double perc_ep_flange_vol_;
+    G4double perc_tp_flange_vol_;
 
     // Geometry Navigator
     G4Navigator* geom_navigator_;

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -51,9 +51,10 @@ namespace nexus {
     // Dimensions
     G4double vessel_in_rad_, vessel_thickness_;
     G4double body_length_;
-    G4double endcap_in_rad_, endcap_theta_, endcap_in_z_width_, endcap_gate_distance_;
+    G4double endcap_in_rad_, endcap_in_body_, endcap_theta_, endcap_in_z_width_, endcap_gate_distance_;
     // G4double flange_out_rad_, flange_length_, flange_z_pos_;
     // G4double large_nozzle_length_, small_nozzle_length_;
+    G4double port_gas_x_, port_gas_y_, port_z_1a_, port_z_1b_, port_z_2a_, port_z_2b_;
     G4double sc_yield_, e_lifetime_;
     G4double pressure_, temperature_;
 
@@ -74,6 +75,7 @@ namespace nexus {
     SpherePointSampler*   energy_endcap_gen_;
     CylinderPointSampler* tracking_flange_gen_;
     CylinderPointSampler* energy_flange_gen_;
+    CylinderPointSampler* port_gen_;
 
     G4double perc_endcap_vol_;
     G4double perc_ep_flange_vol_;

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -55,7 +55,7 @@ namespace nexus {
     // G4double flange_out_rad_, flange_length_, flange_z_pos_;
     // G4double large_nozzle_length_, small_nozzle_length_;
     G4double port_base_height_, port_tube_height_;
-    G4double port_x_, port_y_, port_z_1a_, port_z_1b_, port_z_2a_, port_z_2b_;
+    G4double port_x_, port_y_, source_height_, port_z_1a_, port_z_1b_, port_z_2a_, port_z_2b_;
     G4double sc_yield_, e_lifetime_;
     G4double pressure_, temperature_;
 


### PR DESCRIPTION
This PR reviews the NEXT100 steel vessel which covers the inner elements. The geometry was almost rewritten, since based on the drawings, the dimensions and some elements did not correspond with the previous implementation. Overall the changes are the following:
- Use the correct dimensions based on drawings.
- Implement the calibration ports and its vertex generators.
- Remove Vacuum manifold: it does not exists.
- Nozzless are left commented, but I suggest to remove them if they are not neccessary.
- Adapt vessel placement inside the inner air, based in the new shielding implementation.

Issues and notes: 
- there are some volume overlaps that should be fixed in subsequent PRs.
- holes in the ICS (future PR) must be aligned with the calibration ports.
- dimensions and components are taken from the 2D drawings whenever possible. If not, they are meassured in the 3D drawings, which sometimes only provide approximate values.

Below, I append a summary of the vessel meassurements and parts, as well as the 2D drawing from which I took the information.
[next100vessel.pdf](https://github.com/next-exp/nexus/files/6900042/next100vessel.pdf)
[00-02.pdf](https://github.com/next-exp/nexus/files/6831307/00-02.pdf)
[000-90.pdf](https://github.com/next-exp/nexus/files/6831308/000-90.pdf)
[000-91.pdf](https://github.com/next-exp/nexus/files/6831309/000-91.pdf)
[000-92.pdf](https://github.com/next-exp/nexus/files/6831310/000-92.pdf)
