### PR TITLE
Next100 energy plane

### DIFF
--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -123,6 +123,7 @@ namespace nexus {
     this->SetLogicalVolume(lab_logic_);
 
     // VESSEL (initialize first since it defines EL position)
+    vessel_->SetELtoTPdistance(gate_tracking_plane_distance_);
     vessel_->Construct();
     G4LogicalVolume* vessel_logic = vessel_->GetLogicalVolume();
     G4LogicalVolume* vessel_internal_logic  = vessel_->GetInternalLogicalVolume();

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -225,8 +225,7 @@ namespace nexus {
 	     (region == "OPTICAL_PAD") ||
 	     (region == "PMT_BODY") ||
 	     (region == "PMT") ||
-	     (region == "INTERNAL_PMT_BASE") ||
-	     (region == "EXTERNAL_PMT_BASE") ||
+	     (region == "PMT_BASE") ||
 	     (region == "TP_COPPER_PLATE") ||
 	     (region == "DICE_BOARD") ||
 	     (region == "AXIAL_PORT") ||

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -38,7 +38,7 @@ namespace nexus {
     lab_size_ (5. * m),
 
     // common used variables in geomety components
-    gate_tracking_plane_distance_(35. * mm), // to be confirmed
+    gate_tracking_plane_distance_(30. * mm), // to be confirmed
     gate_sapphire_wdw_distance_  (1460.5 * mm),
 
     // Nozzles external diam and y positions

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -41,19 +41,19 @@ namespace nexus {
     gas_hole_diam_ (12. * mm),
 
     // copper plate holes
-    hole_diam_front_ (80. * mm),
-    hole_diam_rear_ (62. * mm),
-    hole_length_front_ (49.5 * mm),
+    hole_diam_front_  (80. * mm),
+    hole_diam_rear_   (62. * mm),
+    hole_length_front_(49.5 * mm),
     hole_length_rear_ (copper_plate_thickn_ - hole_length_front_),
 
     // huts
-    hut_int_diam_ (64. * mm),
-    hut_thickn_ (6. * mm),
-    hut_hole_length_ (45. * mm),
-    hut_length_long_ (120. * mm),
-    hut_length_medium_ (100. * mm),
+    hut_int_diam_     (64. * mm),
+    hut_diam_         (76. * mm), // hut external diam
+    hut_hole_length_  (45. * mm),
+    hut_length_long_  (120.* mm),
+    hut_length_medium_(100.* mm),
     hut_length_short_ (60. * mm),
-    last_hut_long_ (17),
+    last_hut_long_   (17),
     last_hut_medium_ (35),
 
     sapphire_window_thickn_ (6. * mm),
@@ -132,13 +132,12 @@ namespace nexus {
     			                   copper_plate_gas_hole_solid, 0, gas_hole_pos);
 
     /// Glue together the different kinds of huts to the copper plate ///
-    G4double hut_diam   = hut_int_diam_ + 2 * hut_thickn_;
     G4ThreeVector hut_pos;
 
     G4double hut_length = hut_hole_length_ + hut_length_short_;
     G4double transl_z = copper_plate_thickn_/2. + hut_length/2 - offset/2.;
     G4Tubs* short_hut_solid =
-      new G4Tubs("SHORT_HUT", 0., hut_diam/2., (hut_length + offset)/2., 0., twopi);
+      new G4Tubs("SHORT_HUT", 0., hut_diam_/2., (hut_length + offset)/2., 0., twopi);
     hut_pos = short_hut_pos_[0];
     hut_pos.setZ(transl_z);
     G4UnionSolid* copper_plate_hut_solid = new G4UnionSolid("EP_COPPER_PLATE", copper_plate_hole_solid,
@@ -153,7 +152,7 @@ namespace nexus {
 
     hut_length = hut_hole_length_ + hut_length_medium_;
     transl_z = copper_plate_thickn_/2. + hut_length/2 - offset/2.;
-    G4Tubs* medium_hut_solid = new G4Tubs("MEDIUM_HUT", 0., hut_diam/2.,
+    G4Tubs* medium_hut_solid = new G4Tubs("MEDIUM_HUT", 0., hut_diam_/2.,
                                           (hut_length + offset)/2., 0., twopi);
 
     for (unsigned int i=0; i<medium_hut_pos_.size(); i++) {
@@ -165,7 +164,7 @@ namespace nexus {
 
     hut_length = hut_hole_length_ + hut_length_long_;
     transl_z = copper_plate_thickn_/2. + hut_length/2 - offset/2.;
-    G4Tubs* long_hut_solid = new G4Tubs("LONG_HUT", 0., hut_diam/2.,
+    G4Tubs* long_hut_solid = new G4Tubs("LONG_HUT", 0., hut_diam_/2.,
                                         (hut_length + offset)/2., 0., twopi);
 
     for (unsigned int i=0; i<long_hut_pos_.size(); i++) {
@@ -245,11 +244,11 @@ namespace nexus {
       new G4Tubs("HOLE_HUT", 0., hut_int_diam_/2., hut_hole_length_/2., 0., twopi);
 
     G4UnionSolid* vacuum_solid =
-      new G4UnionSolid("HOLE", vacuum_front_solid, vacuum_rear_solid, 0,
+      new G4UnionSolid("EP_HOLE", vacuum_front_solid, vacuum_rear_solid, 0,
                       G4ThreeVector(0., 0., (vacuum_front_length+hole_length_rear_)/2.));
 
     vacuum_solid =
-      new G4UnionSolid("HOLE", vacuum_solid, vacuum_hut_solid, 0,
+      new G4UnionSolid("EP_HOLE", vacuum_solid, vacuum_hut_solid, 0,
                        G4ThreeVector(0., 0., vacuum_front_length/2.+hole_length_rear_+hut_hole_length_/2.));
 
     G4LogicalVolume* vacuum_logic = new G4LogicalVolume(vacuum_solid, vacuum, "EP_HOLE");
@@ -337,7 +336,7 @@ namespace nexus {
     for (int i=0; i<num_PMTs_; i++) {
       pos = pmt_positions_[i];
       pos.setZ(vacuum_posz_);
-      new G4PVPlacement(0, pos, vacuum_logic, "HOLE", mother_logic_, false, i, false);
+      new G4PVPlacement(0, pos, vacuum_logic, "EP_HOLE", mother_logic_, false, i, false);
     }
 
 

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -37,15 +37,19 @@ namespace nexus {
   Next100EnergyPlane::Next100EnergyPlane():
 
     num_PMTs_ (60),
+
+    // copper plate
     copper_plate_thickn_ (120 * mm),
     copper_plate_diam_ (1340. * mm),
     gas_hole_diam_ (12. * mm),
-    // hole_up_posx_ (-62.5 * mm),
-    // hole_up_posy_ (515. * mm),
-    // hole_lat1_posx_ (477 * mm),
-    // hole_lat1_posy_ (-203.8 * mm),
-    // hole_lat2_posx_ (-415 * mm),
-    // hole_lat2_posy_ (-311.2 * mm),
+
+    // copper plate holes
+    hole_diam_front_ (80. * mm),
+    hole_diam_rear_ (62. * mm),
+    hole_length_front_ (49.5 * mm),
+    hole_length_rear_ (copper_plate_thickn_ - hole_length_front_),
+
+    // huts
     hut_int_diam_ (64. * mm),
     hut_thickn_ (6. * mm),
     hut_hole_length_ (45. * mm),
@@ -54,16 +58,15 @@ namespace nexus {
     hut_length_short_ (60. * mm),
     last_hut_long_ (17),
     last_hut_medium_ (35),
-    hole_diam_front_ (80. * mm),
-    hole_diam_rear_ (62. * mm),
-    hole_length_front_ (49.5 * mm),
-    hole_length_rear_ (copper_plate_thickn_ - hole_length_front_),
+
     sapphire_window_thickn_ (6. * mm),
     optical_pad_thickn_ (1.0 * mm),
     tpb_thickn_ (1.*micrometer),
+
     pmt_stand_out_ (2. * mm), // length that PMTs stand out of copper, in the front
     pmt_base_diam_ (46.8 * mm),
     pmt_base_thickn_ (0.5 * mm),
+
     visibility_(1),
     verbosity_(0)
   {
@@ -112,41 +115,24 @@ namespace nexus {
 
   void Next100EnergyPlane::Construct()
   {
-    GeneratePositions();
-
-    /// Copper Plate ///
-    G4Tubs* copper_plate_origin_solid =
-      new G4Tubs("COPPER_PLATE_ORIGIN", 0., copper_plate_diam_/2.,
-		 copper_plate_thickn_/2., 0., twopi);
 
     G4double offset = 1. * cm;
 
-    /// Holes for gas flow ///
+    GeneratePositions();
+
+    /// Copper Plate ///
+    G4Tubs* copper_plate_origin_solid =  new G4Tubs("COPPER_PLATE_ORIGIN", 0., copper_plate_diam_/2.,
+                                                    copper_plate_thickn_/2., 0., twopi);
+
+    /// Hole for gas flow ///
     G4Tubs* copper_plate_gas_hole_solid =
       new G4Tubs("COPPER_PLATE_CENTRAL_HOLE", 0., gas_hole_diam_/2.,
-		 (copper_plate_thickn_ + offset)/2., 0., twopi);
+		             (copper_plate_thickn_ + offset)/2., 0., twopi);
 
     G4ThreeVector gas_hole_pos = G4ThreeVector(0., 0., 0.);
     G4SubtractionSolid* copper_plate_hole_solid =
       new G4SubtractionSolid("EP_COPPER_PLATE", copper_plate_origin_solid,
-    			     copper_plate_gas_hole_solid, 0, gas_hole_pos);
-
-    // gas_hole_pos.setX(hole_up_posx_);
-    // gas_hole_pos.setY(hole_up_posy_);
-    // copper_plate_hole_solid =
-    //   new G4SubtractionSolid("EP_COPPER_PLATE", copper_plate_hole_solid,
-    // 			     copper_plate_gas_hole_solid, 0, gas_hole_pos);
-    // gas_hole_pos.setX(hole_lat1_posx_);
-    // gas_hole_pos.setY(hole_lat1_posy_);
-    // copper_plate_hole_solid =
-    //   new G4SubtractionSolid("EP_COPPER_PLATE", copper_plate_hole_solid,
-    // 			     copper_plate_gas_hole_solid, 0, gas_hole_pos);
-    // gas_hole_pos.setX(hole_lat2_posx_);
-    // gas_hole_pos.setY(hole_lat2_posy_);
-    // copper_plate_hole_solid =
-    //   new G4SubtractionSolid("EP_COPPER_PLATE", copper_plate_hole_solid,
-    // 			     copper_plate_gas_hole_solid, 0, gas_hole_pos);
-
+    			                   copper_plate_gas_hole_solid, 0, gas_hole_pos);
 
     /// Glue together the different kinds of huts to the copper plate ///
     G4double hut_diam   = hut_int_diam_ + 2 * hut_thickn_;
@@ -158,93 +144,84 @@ namespace nexus {
       new G4Tubs("SHORT_HUT", 0., hut_diam/2., (hut_length + offset)/2., 0., twopi);
     hut_pos = short_hut_pos_[0];
     hut_pos.setZ(transl_z);
-    G4UnionSolid* copper_plate_hut_solid =
-      	new G4UnionSolid("EP_COPPER_PLATE", copper_plate_hole_solid,
-			 short_hut_solid, 0, hut_pos);
+    G4UnionSolid* copper_plate_hut_solid = new G4UnionSolid("EP_COPPER_PLATE", copper_plate_hole_solid,
+                                                            short_hut_solid, 0, hut_pos);
+
     for (unsigned int i=1; i<short_hut_pos_.size(); i++) {
       hut_pos = short_hut_pos_[i];
       hut_pos.setZ(transl_z);
-      copper_plate_hut_solid =
-      	new G4UnionSolid("EP_COPPER_PLATE", copper_plate_hut_solid,
-			 short_hut_solid, 0, hut_pos);
+      copper_plate_hut_solid = new G4UnionSolid("EP_COPPER_PLATE", copper_plate_hut_solid,
+			                                          short_hut_solid, 0, hut_pos);
     }
 
     hut_length = hut_hole_length_ + hut_length_medium_;
     transl_z = copper_plate_thickn_/2. + hut_length/2 - offset/2.;
-    G4Tubs* medium_hut_solid =
-      new G4Tubs("MEDIUM_HUT", 0., hut_diam/2., (hut_length + offset)/2., 0., twopi);
+    G4Tubs* medium_hut_solid = new G4Tubs("MEDIUM_HUT", 0., hut_diam/2.,
+                                          (hut_length + offset)/2., 0., twopi);
+
     for (unsigned int i=0; i<medium_hut_pos_.size(); i++) {
       hut_pos = medium_hut_pos_[i];
       hut_pos.setZ(transl_z);
-      copper_plate_hut_solid =
-      	new G4UnionSolid("EP_COPPER_PLATE", copper_plate_hut_solid,
-			 medium_hut_solid, 0, hut_pos);
+      copper_plate_hut_solid = new G4UnionSolid("EP_COPPER_PLATE", copper_plate_hut_solid,
+                                                medium_hut_solid, 0, hut_pos);
     }
 
     hut_length = hut_hole_length_ + hut_length_long_;
     transl_z = copper_plate_thickn_/2. + hut_length/2 - offset/2.;
-    G4Tubs* long_hut_solid =
-      new G4Tubs("LONG_HUT", 0., hut_diam/2., (hut_length + offset)/2., 0., twopi);
+    G4Tubs* long_hut_solid = new G4Tubs("LONG_HUT", 0., hut_diam/2.,
+                                        (hut_length + offset)/2., 0., twopi);
+
     for (unsigned int i=0; i<long_hut_pos_.size(); i++) {
       hut_pos = long_hut_pos_[i];
       hut_pos.setZ(transl_z);
-      copper_plate_hut_solid =
-      	new G4UnionSolid("EP_COPPER_PLATE", copper_plate_hut_solid,
-			 long_hut_solid, 0, hut_pos);
+      copper_plate_hut_solid = new G4UnionSolid("EP_COPPER_PLATE", copper_plate_hut_solid,
+			                                          long_hut_solid, 0, hut_pos);
     }
 
 
     /// Holes in copper ///
-    G4Tubs* hole_front_solid =
-      new G4Tubs("HOLE_FRONT", 0., hole_diam_front_/2.,
-		 (hole_length_front_ + offset)/2., 0., twopi);
-    G4Tubs* hole_rear_solid =
-      new G4Tubs("HOLE_REAR", 0., hole_diam_rear_/2.,
-		 (hole_length_rear_ + offset)/2., 0., twopi);
-    transl_z = (hole_length_front_ + offset)/2. + hole_length_rear_/2.;
-    G4UnionSolid* hole_solid =
-      	new G4UnionSolid("HOLE", hole_front_solid, hole_rear_solid,
-			 0, G4ThreeVector(0., 0., transl_z));
+    G4Tubs* hole_front_solid = new G4Tubs("HOLE_FRONT", 0., hole_diam_front_/2.,
+		                                      (hole_length_front_ + offset)/2., 0., twopi);
 
-    G4Tubs* hole_hut_solid =
-      new G4Tubs("HOLE_HUT", 0., hut_int_diam_/2., hut_hole_length_/2.,
-		  0., twopi);
-    transl_z =
-      (hole_length_front_ + offset)/2. + hole_length_rear_ + hut_hole_length_/2.;
-    hole_solid =
-      	new G4UnionSolid("HOLE", hole_solid, hole_hut_solid,
-			 0, G4ThreeVector(0., 0., transl_z));
+    G4Tubs* hole_rear_solid = new G4Tubs("HOLE_REAR", 0., hole_diam_rear_/2.,
+		                                     (hole_length_rear_ + offset)/2., 0., twopi);
+
+    transl_z = (hole_length_front_ + offset)/2. + hole_length_rear_/2.;
+    G4UnionSolid* hole_solid = new G4UnionSolid("HOLE", hole_front_solid, hole_rear_solid,
+			                                          0, G4ThreeVector(0., 0., transl_z));
+
+    G4Tubs* hole_hut_solid = new G4Tubs("HOLE_HUT", 0., hut_int_diam_/2.,
+                                        hut_hole_length_/2., 0., twopi);
+
+    transl_z = (hole_length_front_ + offset)/2. + hole_length_rear_ + hut_hole_length_/2.;
+    hole_solid = new G4UnionSolid("HOLE", hole_solid, hole_hut_solid,
+			                            0, G4ThreeVector(0., 0., transl_z));
 
     G4ThreeVector hole_pos = pmt_positions_[0];
     transl_z = - copper_plate_thickn_/2. + hole_length_front_/2. - offset/2.;
     hole_pos.setZ(transl_z);
     G4SubtractionSolid* copper_plate_solid =
-      new G4SubtractionSolid("EP_COPPER_PLATE", copper_plate_hut_solid,
-			     hole_solid, 0, hole_pos);;
+      new G4SubtractionSolid("EP_COPPER_PLATE", copper_plate_hut_solid, hole_solid, 0, hole_pos);
 
     for (G4int i=1; i<num_PMTs_; i++) {
       hole_pos = pmt_positions_[i];
       hole_pos.setZ(transl_z);
-      copper_plate_solid =
-	new G4SubtractionSolid("EP_COPPER_PLATE", copper_plate_solid,
-			       hole_solid, 0, hole_pos);
+      copper_plate_solid = new G4SubtractionSolid("EP_COPPER_PLATE", copper_plate_solid,
+			                                            hole_solid, 0, hole_pos);
 
     }
 
     G4LogicalVolume* copper_plate_logic =
       new G4LogicalVolume(copper_plate_solid,
-			  G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"),
-			  "EP_COPPER_PLATE");
+                          G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"), "EP_COPPER_PLATE");
 
     G4double stand_out_length =
       sapphire_window_thickn_ + tpb_thickn_ + optical_pad_thickn_ + pmt_stand_out_;
-    copper_plate_posz_ =
-      GetELzCoord() + end_of_sapphire_posz_ + stand_out_length +
-      copper_plate_thickn_/2.;
-    new G4PVPlacement(0, G4ThreeVector(0., 0., copper_plate_posz_),
-		      copper_plate_logic, "EP_COPPER_PLATE", mother_logic_,
-		      false, 0, false);
 
+    copper_plate_posz_ = GetELzCoord() + end_of_sapphire_posz_ + stand_out_length + copper_plate_thickn_/2.;
+
+    new G4PVPlacement(0, G4ThreeVector(0., 0., copper_plate_posz_), copper_plate_logic,
+                      "EP_COPPER_PLATE", mother_logic_, false, 0, false);
 
     /// Assign optical properties to materials ///
     G4Material* sapphire = materials::Sapphire();
@@ -278,7 +255,7 @@ namespace nexus {
                       G4ThreeVector(0., 0., vacuum_front_length/2.+hole_length_rear_+hut_hole_length_/2.));
 
     G4LogicalVolume* vacuum_logic =
-      new G4LogicalVolume(vacuum_solid, vacuum, "HOLE");
+      new G4LogicalVolume(vacuum_solid, vacuum, "EP_HOLE");
 
     /// Sapphire window ///
     G4Tubs* sapphire_window_solid =
@@ -351,12 +328,11 @@ namespace nexus {
       new G4LogicalVolume(pmt_base_solid,
 			     G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON"), "PMT_BASE");
 
-    G4double pmt_base_posz =
-      vacuum_front_length/2. + hole_length_rear_ + hut_hole_length_/2.;
+    G4double pmt_base_posz = vacuum_front_length/2. + hole_length_rear_ + hut_hole_length_/2.;
+
     G4VPhysicalVolume* pmt_base_phys =
-       new G4PVPlacement(0, G4ThreeVector(0., 0., pmt_base_posz),
-                        pmt_base_logic, "PMT_BASE",
-                        vacuum_logic, false, 0, false);
+       new G4PVPlacement(0, G4ThreeVector(0., 0., pmt_base_posz), pmt_base_logic,
+                         "PMT_BASE", vacuum_logic, false, 0, false);
 
     /// Placing the encapsulating volume with all internal components in place ///
     vacuum_posz_ = copper_plate_posz_ - copper_plate_thickn_/2.
@@ -529,37 +505,36 @@ namespace nexus {
     for (G4int circle=1; circle<=num_conc_circles; circle++) {
       G4double rad     = circle * x_pitch;
       G4double step    = 360.0/num_inner_pmts;
+
       for (G4int place=0; place<num_inner_pmts; place++) {
-	G4double angle = place * step;
-	position.setX(rad * cos(angle*deg));
-	position.setY(rad * sin(angle*deg));
-	pmt_positions_.push_back(position);
-	//G4cout << position << G4endl;
-	total_positions++;
+      	G4double angle = place * step;
+      	position.setX(rad * cos(angle*deg));
+      	position.setY(rad * sin(angle*deg));
+      	pmt_positions_.push_back(position);
+      	total_positions++;
       }
 
       for (G4int i=1; i<circle; i++) {
-	G4double start_x = (circle-(i*0.5))*x_pitch;
-	G4double start_y = i*y_pitch;
-	rad  = std::sqrt(std::pow(start_x, 2) + std::pow(start_y, 2));
-	G4double start_angle = std::atan2(start_y, start_x)/deg;
-      	for (G4int place=0; place<num_inner_pmts; place++) {
-	  G4double angle = start_angle + place * step;
-	  position.setX(rad * cos(angle*deg));
-	  position.setY(rad * sin(angle*deg));
-	  pmt_positions_.push_back(position);
-	  //G4cout << position << G4endl;
-	  total_positions++;
-	}
-      }
+      	G4double start_x = (circle-(i*0.5))*x_pitch;
+      	G4double start_y = i*y_pitch;
+      	rad  = std::sqrt(std::pow(start_x, 2) + std::pow(start_y, 2));
+      	G4double start_angle = std::atan2(start_y, start_x)/deg;
 
+      	for (G4int place=0; place<num_inner_pmts; place++) {
+      	  G4double angle = start_angle + place * step;
+      	  position.setX(rad * cos(angle*deg));
+      	  position.setY(rad * sin(angle*deg));
+      	  pmt_positions_.push_back(position);
+      	  total_positions++;
+	       }
+      }
     }
 
     long_hut_pos_ =
       std::vector<G4ThreeVector>(pmt_positions_.begin(), pmt_positions_.begin()+last_hut_long_+1);
     medium_hut_pos_ =
       std::vector<G4ThreeVector>(pmt_positions_.begin()+last_hut_long_+1,
-				 pmt_positions_.begin()+ last_hut_medium_+1);
+                                 pmt_positions_.begin()+last_hut_medium_+1);
     short_hut_pos_ =
       std::vector<G4ThreeVector>(pmt_positions_.begin()+last_hut_medium_+1, pmt_positions_.end());
 

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -107,9 +107,9 @@ namespace nexus {
   }
 
 
-  void Next100EnergyPlane::SetSapphireSurfaceZPos(G4double z)
+  void Next100EnergyPlane::SetELtoSapphireWDWdistance(G4double z)
   {
-    end_of_sapphire_posz_ = z;
+    gate_sapphire_wdw_dist_ = z;
   }
 
 
@@ -218,7 +218,7 @@ namespace nexus {
     G4double stand_out_length =
       sapphire_window_thickn_ + tpb_thickn_ + optical_pad_thickn_ + pmt_stand_out_;
 
-    copper_plate_posz_ = GetELzCoord() + end_of_sapphire_posz_ + stand_out_length + copper_plate_thickn_/2.;
+    copper_plate_posz_ = GetELzCoord() + gate_sapphire_wdw_dist_ + stand_out_length + copper_plate_thickn_/2.;
 
     new G4PVPlacement(0, G4ThreeVector(0., 0., copper_plate_posz_), copper_plate_logic,
                       "EP_COPPER_PLATE", mother_logic_, false, 0, false);

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -38,7 +38,6 @@ namespace nexus {
     // copper plate
     copper_plate_thickn_ (120 * mm),
     copper_plate_diam_ (1340. * mm),
-    gas_hole_diam_ (12. * mm),
 
     // copper plate holes
     hole_diam_front_  (80. * mm),
@@ -110,11 +109,13 @@ namespace nexus {
                                                     copper_plate_thickn_/2., 0., twopi);
 
     /// Hole for gas flow ///
+    G4double gas_hole_diam   = 12.  * mm;
+    G4double gas_hole_length = 103. * mm;
     G4Tubs* copper_plate_gas_hole_solid =
-      new G4Tubs("COPPER_PLATE_CENTRAL_HOLE", 0., gas_hole_diam_/2.,
-		             (copper_plate_thickn_ + offset)/2., 0., twopi);
+      new G4Tubs("COPPER_PLATE_CENTRAL_HOLE", 0., gas_hole_diam/2.,
+		             (gas_hole_length + offset)/2., 0., twopi);
 
-    G4ThreeVector gas_hole_pos = G4ThreeVector(0., 0., 0.);
+    G4ThreeVector gas_hole_pos = G4ThreeVector(0., 0., -copper_plate_thickn_/2. + gas_hole_length/2.);
     G4SubtractionSolid* copper_plate_hole_solid =
       new G4SubtractionSolid("EP_COPPER_PLATE", copper_plate_origin_solid,
     			                   copper_plate_gas_hole_solid, 0, gas_hole_pos);

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -98,18 +98,6 @@ namespace nexus {
   }
 
 
-  void Next100EnergyPlane::SetMotherLogicalVolume(G4LogicalVolume* mother_logic)
-  {
-    mother_logic_ = mother_logic;
-  }
-
-
-  void Next100EnergyPlane::SetELtoSapphireWDWdistance(G4double z)
-  {
-    gate_sapphire_wdw_dist_ = z;
-  }
-
-
   void Next100EnergyPlane::Construct()
   {
 

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -46,24 +46,24 @@ namespace nexus {
     // hole_lat1_posy_ (-203.8 * mm),
     // hole_lat2_posx_ (-415 * mm),
     // hole_lat2_posy_ (-311.2 * mm),
-    hut_int_diam_ (76. * mm),
-    hut_thickn_ (5. * mm),
+    hut_int_diam_ (64. * mm),
+    hut_thickn_ (6. * mm),
     hut_hole_length_ (45. * mm),
     hut_length_long_ (120. * mm),
     hut_length_medium_ (100. * mm),
-    hut_length_short_ (70. * mm),
+    hut_length_short_ (60. * mm),
     last_hut_long_ (17),
     last_hut_medium_ (35),
-    hole_diam_front_ (84. * mm),
-    hole_diam_rear_ (65. * mm),
-    hole_length_front_ (41.75 * mm), //average of 37 mm of front and 46.5 mm of front+medium
-    hole_length_rear_ (78.25 * mm), //sum of front+rear length must give copper thickness
+    hole_diam_front_ (80. * mm),
+    hole_diam_rear_ (62. * mm),
+    hole_length_front_ (49.5 * mm),
+    hole_length_rear_ (copper_plate_thickn_ - hole_length_front_),
     sapphire_window_thickn_ (6. * mm),
     optical_pad_thickn_ (1.0 * mm),
     tpb_thickn_ (1.*micrometer),
-    pmt_stand_out_ (2. * mm), // length that PMTs stand oput of copper, in the front
-    internal_pmt_base_diam_ (54. * mm),
-    internal_pmt_base_thickn_ (0.2 * mm),
+    pmt_stand_out_ (2. * mm), // length that PMTs stand out of copper, in the front
+    internal_pmt_base_diam_ (46.8 * mm),
+    internal_pmt_base_thickn_ (0.5 * mm),
     visibility_(1),
     verbosity_(0)
   {

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -27,9 +27,6 @@
 #include <G4TransportationManager.hh>
 #include <Randomize.hh>
 
-#include <CLHEP/Units/SystemOfUnits.h>
-#include <CLHEP/Units/PhysicalConstants.h>
-
 namespace nexus {
 
   using namespace CLHEP;
@@ -251,19 +248,18 @@ namespace nexus {
       new G4UnionSolid("HOLE", vacuum_front_solid, vacuum_rear_solid, 0,
                       G4ThreeVector(0., 0., (vacuum_front_length+hole_length_rear_)/2.));
 
-    vacuum_solid = new G4UnionSolid("HOLE", vacuum_solid, vacuum_hut_solid, 0,
-                      G4ThreeVector(0., 0., vacuum_front_length/2.+hole_length_rear_+hut_hole_length_/2.));
+    vacuum_solid =
+      new G4UnionSolid("HOLE", vacuum_solid, vacuum_hut_solid, 0,
+                       G4ThreeVector(0., 0., vacuum_front_length/2.+hole_length_rear_+hut_hole_length_/2.));
 
-    G4LogicalVolume* vacuum_logic =
-      new G4LogicalVolume(vacuum_solid, vacuum, "EP_HOLE");
+    G4LogicalVolume* vacuum_logic = new G4LogicalVolume(vacuum_solid, vacuum, "EP_HOLE");
 
     /// Sapphire window ///
-    G4Tubs* sapphire_window_solid =
-      new G4Tubs("SAPPHIRE_WINDOW", 0., hole_diam_front_/2.,
-		  (sapphire_window_thickn_ + tpb_thickn_)/2., 0., twopi);
+    G4Tubs* sapphire_window_solid = new G4Tubs("SAPPHIRE_WINDOW", 0., hole_diam_front_/2.,
+                                               (sapphire_window_thickn_ + tpb_thickn_)/2., 0., twopi);
 
-    G4LogicalVolume* sapphire_window_logic =
-      new G4LogicalVolume(sapphire_window_solid, sapphire, "SAPPHIRE_WINDOW");
+    G4LogicalVolume* sapphire_window_logic
+      = new G4LogicalVolume(sapphire_window_solid, sapphire, "SAPPHIRE_WINDOW");
 
     G4double window_posz = -vacuum_front_length/2. + (sapphire_window_thickn_ + tpb_thickn_)/2.;
 
@@ -272,21 +268,19 @@ namespace nexus {
                         "SAPPHIRE_WINDOW", vacuum_logic, false, 0, false);
 
     /// TPB coating on sapphire window ///
-    G4Tubs* tpb_solid = new G4Tubs("SAPPHIRE_WNDW_TPB", 0., hole_diam_front_/2,
-     				   tpb_thickn_/2., 0., twopi);
-    G4LogicalVolume* tpb_logic =
-      new G4LogicalVolume(tpb_solid, tpb, "SAPPHIRE_WNDW_TPB");
+    G4Tubs* tpb_solid = new G4Tubs("SAPPHIRE_WDW_TPB", 0., hole_diam_front_/2, tpb_thickn_/2., 0., twopi);
+
+    G4LogicalVolume* tpb_logic = new G4LogicalVolume(tpb_solid, tpb, "SAPPHIRE_WDW_TPB");
 
     G4double tpb_posz = - (sapphire_window_thickn_ + tpb_thickn_)/2. + tpb_thickn_/2.;
 
     new G4PVPlacement(0, G4ThreeVector(0., 0., tpb_posz), tpb_logic,
-     		      "SAPPHIRE_WNDW_TPB", sapphire_window_logic, false, 0, false);
+                      "SAPPHIRE_WDW_TPB", sapphire_window_logic, false, 0, false);
 
 
     /// Optical surface on TPB to model roughness ///
-    G4OpticalSurface* tpb_surf =
-      new G4OpticalSurface("tpb_sapphire_surf",
-			   glisur, ground, dielectric_dielectric, .01);
+    G4OpticalSurface* tpb_surf = new G4OpticalSurface("tpb_sapphire_surf",
+                                                      glisur, ground, dielectric_dielectric, .01);
     new G4LogicalSkinSurface("tpb_sapphire_surf", tpb_logic, tpb_surf);
 
 
@@ -317,16 +311,16 @@ namespace nexus {
     rot_angle_ = pi;
     pmt_rot_->rotateY(rot_angle_);
     new G4PVPlacement(G4Transform3D(*pmt_rot_, pmt_pos), pmt_logic,
-		      "PMT", vacuum_logic, false, 0, false);
+                      "PMT", vacuum_logic, false, 0, false);
 
 
     /// Part of the PMT bases with pins and resistors ///
-    G4Tubs* pmt_base_solid =
-      new G4Tubs("PMT_BASE", 0., pmt_base_diam_/2., pmt_base_thickn_/2., 0., twopi);
+    G4Tubs* pmt_base_solid = new G4Tubs("PMT_BASE", 0., pmt_base_diam_/2.,
+                                        pmt_base_thickn_/2., 0., twopi);
 
-    G4LogicalVolume* pmt_base_logic =
-      new G4LogicalVolume(pmt_base_solid,
-			     G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON"), "PMT_BASE");
+    G4LogicalVolume* pmt_base_logic
+      = new G4LogicalVolume(pmt_base_solid,
+			                      G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON"), "PMT_BASE");
 
     G4double pmt_base_posz = vacuum_front_length/2. + hole_length_rear_ + hut_hole_length_/2.;
 
@@ -336,8 +330,8 @@ namespace nexus {
 
     /// Placing the encapsulating volume with all internal components in place ///
     vacuum_posz_ = copper_plate_posz_ - copper_plate_thickn_/2.
-                    + vacuum_front_length/2. - sapphire_window_thickn_ - tpb_thickn_
-                    - optical_pad_thickn_ - pmt_stand_out_;
+                   + vacuum_front_length/2. - sapphire_window_thickn_ - tpb_thickn_
+                   - optical_pad_thickn_ - pmt_stand_out_;
 
     G4ThreeVector pos;
     for (int i=0; i<num_PMTs_; i++) {
@@ -367,7 +361,7 @@ namespace nexus {
     vacuum_logic->SetVisAttributes(G4VisAttributes::Invisible);
     if (visibility_) {
       G4VisAttributes copper_col = CopperBrown();
-      //copper_col.SetForceSolid(true);
+      copper_col.SetForceSolid(true);
       copper_plate_logic->SetVisAttributes(copper_col);
       G4VisAttributes sapphire_col = nexus::Lilla();
       sapphire_col.SetForceSolid(true);
@@ -381,15 +375,15 @@ namespace nexus {
       G4VisAttributes pmt_base_col = Yellow();
       pmt_base_col.SetForceSolid(true);
       pmt_base_logic->SetVisAttributes(pmt_base_col);
-      //G4VisAttributes vacuum_col = Red();
-      //vacuum_col.SetForceSolid(true);
-      // vacuum_logic->SetVisAttributes(vacuum_col);
+      G4VisAttributes vacuum_col = White();
+      vacuum_logic->SetVisAttributes(vacuum_col);
     } else {
-      copper_plate_logic->SetVisAttributes(G4VisAttributes::Invisible);
+      copper_plate_logic   ->SetVisAttributes(G4VisAttributes::Invisible);
       sapphire_window_logic->SetVisAttributes(G4VisAttributes::Invisible);
-      optical_pad_logic->SetVisAttributes(G4VisAttributes::Invisible);
-      tpb_logic->SetVisAttributes(G4VisAttributes::Invisible);
-      pmt_base_logic->SetVisAttributes(G4VisAttributes::Invisible);
+      optical_pad_logic    ->SetVisAttributes(G4VisAttributes::Invisible);
+      tpb_logic            ->SetVisAttributes(G4VisAttributes::Invisible);
+      pmt_base_logic       ->SetVisAttributes(G4VisAttributes::Invisible);
+      vacuum_logic         ->SetVisAttributes(G4VisAttributes::Invisible);
     }
 
     //////////////////////////

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -201,7 +201,7 @@ namespace nexus {
     G4Tubs* hole_rear_solid =
       new G4Tubs("HOLE_REAR", 0., hole_diam_rear_/2.,
 		 (hole_length_rear_ + offset)/2., 0., twopi);
-    transl_z = (hole_length_front_ + offset)/2. + hole_length_rear_/2 - offset/2.;
+    transl_z = (hole_length_front_ + offset)/2. + hole_length_rear_/2.;
     G4UnionSolid* hole_solid =
       	new G4UnionSolid("HOLE", hole_front_solid, hole_rear_solid,
 			 0, G4ThreeVector(0., 0., transl_z));
@@ -265,7 +265,7 @@ namespace nexus {
       new G4Tubs("HOLE_FRONT", 0., hole_diam_front_/2., vacuum_front_length/2., 0., twopi);
 
     G4Tubs* vacuum_rear_solid =
-      new G4Tubs("HOLE_REAR", 0., hole_diam_rear_/2., hole_length_rear_/2., 0., twopi);
+      new G4Tubs("HOLE_REAR", 0., hole_diam_rear_/2., (hole_length_rear_+offset)/2., 0., twopi);
 
     G4Tubs* vacuum_hut_solid =
       new G4Tubs("HOLE_HUT", 0., hut_int_diam_/2., hut_hole_length_/2., 0., twopi);
@@ -354,14 +354,15 @@ namespace nexus {
     G4double pmt_base_posz =
       vacuum_front_length/2. + hole_length_rear_ + hut_hole_length_/2.;
     G4VPhysicalVolume* pmt_base_phys =
-      new G4PVPlacement(0, G4ThreeVector(0., 0., pmt_base_posz),
+       new G4PVPlacement(0, G4ThreeVector(0., 0., pmt_base_posz),
                         pmt_base_logic, "PMT_BASE",
                         vacuum_logic, false, 0, false);
 
     /// Placing the encapsulating volume with all internal components in place ///
     vacuum_posz_ = copper_plate_posz_ - copper_plate_thickn_/2.
-                  + vacuum_front_length/2. - sapphire_window_thickn_ - tpb_thickn_
-                  - optical_pad_thickn_ - pmt_stand_out_;
+                    + vacuum_front_length/2. - sapphire_window_thickn_ - tpb_thickn_
+                    - optical_pad_thickn_ - pmt_stand_out_;
+
     G4ThreeVector pos;
     for (int i=0; i<num_PMTs_; i++) {
       pos = pmt_positions_[i];

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -399,11 +399,9 @@ namespace nexus {
                                    0., twopi, nullptr,
                                    G4ThreeVector(0., 0., full_copper_posz));
 
-    sapphire_window_gen_   = new CylinderPointSampler2020(sapphire_window_phys);
-
-    optical_pad_gen_       = new CylinderPointSampler2020(optical_pad_phys);
-
-    pmt_base_gen_ = new CylinderPointSampler2020(pmt_base_phys);
+    sapphire_window_gen_ = new CylinderPointSampler2020(sapphire_window_phys);
+    optical_pad_gen_     = new CylinderPointSampler2020(optical_pad_phys);
+    pmt_base_gen_        = new CylinderPointSampler2020(pmt_base_phys);
 
   }
 
@@ -429,19 +427,24 @@ namespace nexus {
         vertex = copper_gen_->GenerateVertex("VOLUME");
         G4ThreeVector glob_vtx(vertex);
         glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
-        VertexVolume =
-          geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
+        VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
       } while (VertexVolume->GetName() != region);
     }
 
     // Sapphire windows
     else if (region == "SAPPHIRE_WINDOW") {
-      vertex = sapphire_window_gen_->GenerateVertex("VOLUME");
-      G4double rand = num_PMTs_ * G4UniformRand();
-      G4ThreeVector sapphire_pos = pmt_positions_[int(rand)];
-      vertex += sapphire_pos;
-      G4double z_translation = vacuum_posz_;
-      vertex.setZ(vertex.z() + z_translation);
+      G4VPhysicalVolume *VertexVolume;
+      do {
+        vertex = sapphire_window_gen_->GenerateVertex("VOLUME");
+        G4double rand = num_PMTs_ * G4UniformRand();
+        G4ThreeVector sapphire_pos = pmt_positions_[int(rand)];
+        vertex += sapphire_pos;
+        G4double z_translation = vacuum_posz_;
+        vertex.setZ(vertex.z() + z_translation);
+        G4ThreeVector glob_vtx(vertex);
+        glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+        VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
+      } while (VertexVolume->GetName() != region);
     }
 
     // Optical pads

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -207,11 +207,10 @@ namespace nexus {
 			 0, G4ThreeVector(0., 0., transl_z));
 
     G4Tubs* hole_hut_solid =
-      new G4Tubs("HOLE_HUT", 0., hut_int_diam_/2., (hut_hole_length_ + offset)/2.,
-		 0., twopi);
+      new G4Tubs("HOLE_HUT", 0., hut_int_diam_/2., hut_hole_length_/2.,
+		  0., twopi);
     transl_z =
-      (hole_length_front_ + offset)/2. + hole_length_rear_ + hut_hole_length_/2.
-      - offset/2.;
+      (hole_length_front_ + offset)/2. + hole_length_rear_ + hut_hole_length_/2.;
     hole_solid =
       	new G4UnionSolid("HOLE", hole_solid, hole_hut_solid,
 			 0, G4ThreeVector(0., 0., transl_z));

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -237,7 +237,7 @@ namespace nexus {
 			  "EP_COPPER_PLATE");
 
     G4double stand_out_length =
-      sapphire_window_thickn_ + optical_pad_thickn_ + pmt_stand_out_;
+      sapphire_window_thickn_ + tpb_thickn_ + optical_pad_thickn_ + pmt_stand_out_;
     copper_plate_posz_ =
       GetELzCoord() + end_of_sapphire_posz_ + stand_out_length +
       copper_plate_thickn_/2.;

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -300,7 +300,7 @@ namespace nexus {
     G4LogicalVolume* tpb_logic =
       new G4LogicalVolume(tpb_solid, tpb, "SAPPHIRE_WNDW_TPB");
 
-    G4double tpb_posz = - sapphire_window_thickn_/2. + tpb_thickn_/2.;
+    G4double tpb_posz = - (sapphire_window_thickn_ + tpb_thickn_)/2. + tpb_thickn_/2.;
 
     new G4PVPlacement(0, G4ThreeVector(0., 0., tpb_posz), tpb_logic,
      		      "SAPPHIRE_WNDW_TPB", sapphire_window_logic, false, 0, false);

--- a/source/geometries/Next100EnergyPlane.h
+++ b/source/geometries/Next100EnergyPlane.h
@@ -102,5 +102,11 @@ namespace nexus {
 
   };
 
+  inline void Next100EnergyPlane::SetELtoSapphireWDWdistance(G4double z) {
+    gate_sapphire_wdw_dist_ = z;}
+
+  inline void Next100EnergyPlane::SetMotherLogicalVolume(G4LogicalVolume* mother_logic) {
+      mother_logic_ = mother_logic;}
+
 } //end namespace nexus
 #endif

--- a/source/geometries/Next100EnergyPlane.h
+++ b/source/geometries/Next100EnergyPlane.h
@@ -60,7 +60,7 @@ namespace nexus {
 
     // Dimensions
     const G4int num_PMTs_;
-    const G4double copper_plate_thickn_, copper_plate_diam_, gas_hole_diam_;
+    const G4double copper_plate_thickn_, copper_plate_diam_;
 
     const G4double hole_diam_front_, hole_diam_rear_;
     const G4double hole_length_front_, hole_length_rear_;

--- a/source/geometries/Next100EnergyPlane.h
+++ b/source/geometries/Next100EnergyPlane.h
@@ -65,7 +65,7 @@ namespace nexus {
     const G4double hole_diam_front_, hole_diam_rear_;
     const G4double hole_length_front_, hole_length_rear_;
 
-    const G4double hut_int_diam_, hut_thickn_, hut_hole_length_;
+    const G4double hut_int_diam_, hut_diam_, hut_hole_length_;
     const G4double hut_length_long_, hut_length_medium_, hut_length_short_;
     const G4int last_hut_long_, last_hut_medium_;
 

--- a/source/geometries/Next100EnergyPlane.h
+++ b/source/geometries/Next100EnergyPlane.h
@@ -72,7 +72,7 @@ namespace nexus {
     const G4double hole_length_front_, hole_length_rear_;
     const G4double sapphire_window_thickn_, optical_pad_thickn_, tpb_thickn_;
     const G4double pmt_stand_out_;
-    const G4double internal_pmt_base_diam_, internal_pmt_base_thickn_;
+    const G4double pmt_base_diam_, pmt_base_thickn_;
 
     // Visibility of the energy plane
     G4bool visibility_, verbosity_;
@@ -99,8 +99,7 @@ namespace nexus {
     CylinderPointSampler2020* copper_gen_;
     CylinderPointSampler2020* sapphire_window_gen_;
     CylinderPointSampler2020* optical_pad_gen_;
-    CylinderPointSampler2020* internal_pmt_base_gen_;
-    CylinderPointSampler2020* external_pmt_base_gen_;
+    CylinderPointSampler2020* pmt_base_gen_;
 
   };
 

--- a/source/geometries/Next100EnergyPlane.h
+++ b/source/geometries/Next100EnergyPlane.h
@@ -40,7 +40,7 @@ namespace nexus {
     void SetMotherLogicalVolume(G4LogicalVolume* mother_logic);
 
     /// Sets the z position of the surface of the sapphire windows
-    void SetSapphireSurfaceZPos(G4double z);
+    void SetELtoSapphireWDWdistance(G4double z);
 
     /// Generate a vertex within a given region of the geometry
     G4ThreeVector GenerateVertex(const G4String& region) const;
@@ -85,7 +85,7 @@ namespace nexus {
     // PMT
     PmtR11410*  pmt_;
 
-    G4double end_of_sapphire_posz_;
+    G4double gate_sapphire_wdw_dist_;
     G4double copper_plate_posz_;
     G4double vacuum_posz_;
     std::vector<G4ThreeVector> pmt_positions_;

--- a/source/geometries/Next100EnergyPlane.h
+++ b/source/geometries/Next100EnergyPlane.h
@@ -60,16 +60,15 @@ namespace nexus {
 
     // Dimensions
     const G4int num_PMTs_;
-    const G4double copper_plate_thickn_, copper_plate_diam_;
-    const G4double gas_hole_diam_;
-    // const G4double hole_up_posx_, hole_up_posy_;
-    // const G4double hole_lat1_posx_, hole_lat1_posy_;
-    // const G4double hole_lat2_posx_, hole_lat2_posy_;
+    const G4double copper_plate_thickn_, copper_plate_diam_, gas_hole_diam_;
+
+    const G4double hole_diam_front_, hole_diam_rear_;
+    const G4double hole_length_front_, hole_length_rear_;
+
     const G4double hut_int_diam_, hut_thickn_, hut_hole_length_;
     const G4double hut_length_long_, hut_length_medium_, hut_length_short_;
     const G4int last_hut_long_, last_hut_medium_;
-    const G4double hole_diam_front_, hole_diam_rear_;
-    const G4double hole_length_front_, hole_length_rear_;
+
     const G4double sapphire_window_thickn_, optical_pad_thickn_, tpb_thickn_;
     const G4double pmt_stand_out_;
     const G4double pmt_base_diam_, pmt_base_thickn_;

--- a/source/geometries/Next100InnerElements.cc
+++ b/source/geometries/Next100InnerElements.cc
@@ -108,10 +108,9 @@ namespace nexus {
     else if ((region == "EP_COPPER_PLATE") ||
              (region == "SAPPHIRE_WINDOW") ||
              (region == "OPTICAL_PAD") ||
-	     (region == "PMT") ||
+	           (region == "PMT") ||
              (region == "PMT_BODY") ||
-	     (region == "INTERNAL_PMT_BASE") ||
-	     (region == "EXTERNAL_PMT_BASE")) {
+	           (region == "PMT_BASE")) {
       vertex = energy_plane_->GenerateVertex(region);
     }
     // Tracking Plane regions

--- a/source/geometries/Next100InnerElements.cc
+++ b/source/geometries/Next100InnerElements.cc
@@ -72,7 +72,7 @@ namespace nexus {
     // Energy Plane
     energy_plane_->SetMotherLogicalVolume(mother_logic_);
     energy_plane_->SetELzCoord(gate_zpos);
-    energy_plane_->SetSapphireSurfaceZPos(gate_sapphire_wdw_distance_);
+    energy_plane_->SetELtoSapphireWDWdistance(gate_sapphire_wdw_distance_);
     energy_plane_->Construct();
 
     // Tracking plane

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -50,11 +50,11 @@ namespace nexus {
     body_length_     (198.6 * cm),
 
     // Endcaps dimensions
-    endcap_in_rad_       (123.61 * cm),
-    endcap_in_body_      (15.15  * cm),
-    endcap_theta_        (29.1   * deg),
-    endcap_in_z_width_   (15.6   * cm),
-    endcap_gate_distance_(48.62  * cm),
+    endcap_in_rad_      (123.61 * cm),
+    endcap_in_body_     (15.15  * cm),
+    endcap_theta_       (29.1   * deg),
+    endcap_in_z_width_  (15.6   * cm),
+    endcap_tp_distance_ (44.92  * cm),
 
     // Ports
     port_base_height_(37. * mm),
@@ -320,7 +320,7 @@ namespace nexus {
 
     G4LogicalVolume* vessel_gas_logic = new G4LogicalVolume(vessel_gas_solid, vessel_gas_mat, "VESSEL_GAS");
     internal_logic_vol_ = vessel_gas_logic;
-    SetELzCoord(-body_length_/2. - endcap_in_z_width_ + endcap_gate_distance_);
+    SetELzCoord(-body_length_/2. - endcap_in_z_width_ + endcap_tp_distance_ + gate_tp_distance_);
     internal_phys_vol_ =
       new G4PVPlacement(0, G4ThreeVector(0.,0.,0.), vessel_gas_logic,
                         "VESSEL_GAS", vessel_logic, false, 0);

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -42,6 +42,7 @@ namespace nexus {
     G4LogicalVolume* GetInternalLogicalVolume();
     G4VPhysicalVolume* GetInternalPhysicalVolume();
 
+    void SetELtoTPdistance(G4double);
     // get Z position of calibration ports
     G4double* GetPortZpositions();
 
@@ -54,7 +55,8 @@ namespace nexus {
     // Dimensions
     G4double vessel_in_rad_, vessel_thickness_;
     G4double body_length_;
-    G4double endcap_in_rad_, endcap_in_body_, endcap_theta_, endcap_in_z_width_, endcap_gate_distance_;
+    G4double endcap_in_rad_, endcap_in_body_, endcap_theta_, endcap_in_z_width_;
+    G4double endcap_tp_distance_, gate_tp_distance_;
     // G4double flange_out_rad_, flange_length_, flange_z_pos_;
     // G4double large_nozzle_length_, small_nozzle_length_;
     G4double port_base_height_, port_tube_height_;
@@ -97,6 +99,10 @@ namespace nexus {
     G4double xe_perc_;
 
   };
+
+  inline void Next100Vessel::SetELtoTPdistance(G4double distance){
+    gate_tp_distance_ = distance;
+  }
 
 } // end namespace nexus
 


### PR DESCRIPTION
This PR reviews the current implementation of the NEXT-100 energy plane. The changes are the following:
- Set the dimensions according with the actual drawings.
- Fix `offset` displacement in the copper holes, in the subtraction solid definition.
- Remove the external pmt base vertex generator, since only the "internal" base exists.

Meassurements were taken from the following 2D drawings by Jordi, whenever possible. If not, the 3D drawings were used.
[02-07.pdf](https://github.com/next-exp/nexus/files/6856722/02-07.Copper.plate.pdf)
[02-08.pdf](https://github.com/next-exp/nexus/files/6856723/02-08.pdf)

Besides, Jordi provided the following measurements for the "HUTs" (this term with U is how the copper hats are named in the code) via private communication:
-18 “HATs” with L=120mm >>> central hexagon
-18 “HATs” with L=100mm >>> second periferic line
-24 “HATs” with L=60mm >>> external periferic line
