### PR TITLE
Next100 tracking plane

### DIFF
--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -38,8 +38,9 @@ namespace nexus {
     lab_size_ (5. * m),
 
     // common used variables in geomety components
-    gate_tracking_plane_distance_(30. * mm), // to be confirmed
-    gate_sapphire_wdw_distance_  (1460.5 * mm),
+    // 0.1 mm gate thickness?
+    gate_tracking_plane_distance_((26.1 + 0.1)   * mm),
+    gate_sapphire_wdw_distance_  ((1458.2 - 0.1) * mm),
 
     specific_vertex_{},
     lab_walls_(false)

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -221,7 +221,7 @@ namespace nexus {
              (region == "PMT") ||
              (region == "PMT_BASE") ||
              (region == "TP_COPPER_PLATE") ||
-             (region == "DICE_BOARD") ||
+             (region == "SIPM_BOARD") ||
              (region == "EL_TABLE") ||
              (region == "FIELD_RING") ||
              (region == "GATE_RING") ||

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -38,7 +38,8 @@ namespace nexus {
     lab_size_ (5. * m),
 
     // common used variables in geomety components
-    // 0.1 mm gate thickness?
+    // 0.1 mm grid thickness
+    // note that if grid thickness change it must be also changed in Next100FieldCage.cc
     gate_tracking_plane_distance_((26.1 + 0.1)   * mm),
     gate_sapphire_wdw_distance_  ((1458.2 - 0.1) * mm),
 

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -223,6 +223,7 @@ namespace nexus {
              (region == "PMT_BASE") ||
              (region == "TP_COPPER_PLATE") ||
              (region == "SIPM_BOARD") ||
+             (region == "DB_PLUG") ||
              (region == "EL_TABLE") ||
              (region == "FIELD_RING") ||
              (region == "GATE_RING") ||

--- a/source/geometries/Next100FieldCage.h
+++ b/source/geometries/Next100FieldCage.h
@@ -49,18 +49,16 @@ namespace nexus {
     // Dimensions
     G4double gate_sapphire_wdw_dist_;
     const G4double active_diam_;
-    const G4double teflon_drift_length_;
-    const G4double cathode_int_diam_, cathode_ext_diam_, cathode_thickn_;
-    const G4double grid_thickn_;
-    const G4double teflon_total_length_, teflon_thickn_;
-    const G4int n_panels_;
-    const G4double tpb_thickn_, el_gap_length_;
-    const G4double hdpe_tube_int_diam_, hdpe_tube_ext_diam_, hdpe_length_;
-    const G4double ring_ext_diam_, ring_int_diam_, ring_thickn_;
-    const G4double drift_ring_dist_, buffer_ring_dist_;
-    const G4double holder_x_, holder_long_y_, holder_short_y_;
+    const G4double cathode_int_diam_, cathode_ext_diam_, cathode_thickn_, grid_thickn_;
+    const G4double teflon_drift_length_, teflon_total_length_, teflon_thickn_, n_panels_;
+    const G4double el_gap_length_;
     const G4double gate_teflon_dist_, gate_ext_diam_, gate_int_diam_, gate_ring_thickn_;
+    const G4double hdpe_tube_int_diam_, hdpe_tube_ext_diam_, hdpe_length_;
+    const G4double ring_ext_diam_, ring_int_diam_, ring_thickn_, drift_ring_dist_, buffer_ring_dist_;
+    const G4double holder_x_, holder_long_y_, holder_short_y_;
+    const G4double tpb_thickn_;
     const G4double overlap_;
+
     // Diffusion constants
     G4double drift_transv_diff_, drift_long_diff_;
     G4double ELtransv_diff_; ///< transversal diffusion in the EL gap
@@ -80,11 +78,9 @@ namespace nexus {
     G4bool verbosity_;
 
     G4double active_length_, buffer_length_;
-
-    G4double  teflon_buffer_length_;
+    G4double teflon_buffer_length_;
     G4double teflon_drift_zpos_,teflon_buffer_zpos_;
     G4double holder_r_;
-
     G4double active_zpos_, cathode_zpos_, gate_zpos_, el_gap_zpos_, anode_zpos_;
     G4double gate_grid_zpos_, anode_grid_zpos_;
 

--- a/source/geometries/Next100InnerElements.cc
+++ b/source/geometries/Next100InnerElements.cc
@@ -119,7 +119,8 @@ namespace nexus {
     }
     // Tracking Plane regions
     else if ((region == "TP_COPPER_PLATE") ||
-             (region == "SIPM_BOARD")) {
+             (region == "SIPM_BOARD") ||
+             (region == "DB_PLUG")) {
       vertex = tracking_plane_->GenerateVertex(region);
     }
     else {

--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -202,8 +202,7 @@ void Next100SiPMBoard::Construct()
 
   G4LogicalVolume* mask_wls_hole_logic_vol =
     new G4LogicalVolume(mask_wls_hole_solid_vol,
-                        mpv_->GetLogicalVolume()->GetMaterial(),
-                        mask_wls_hole_name);
+                        mother_gas, mask_wls_hole_name);
 
   // (Placement of this volume below.)
 

--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -32,7 +32,7 @@ using namespace nexus;
 
 Next100SiPMBoard::Next100SiPMBoard():
   GeometryBase     (),
-  size_            (123.40  * mm),
+  size_            (122.40  * mm),
   pitch_           ( 15.55  * mm),
   margin_          (  7.275 * mm),
   hole_diam_       (  7.00  * mm),

--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -37,7 +37,7 @@ Next100SiPMBoard::Next100SiPMBoard():
   margin_          (  7.275 * mm),
   hole_diam_       (  7.00  * mm),
   board_thickness_ (  0.5   * mm),
-  mask_thickness_  (  2.1   * mm),
+  mask_thickness_  (  6.0   * mm),
   time_binning_    (1. * microsecond),
   visibility_      (true),
   sipm_visibility_ (false),

--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -36,7 +36,7 @@ Next100SiPMBoard::Next100SiPMBoard():
   pitch_           ( 15.55  * mm),
   margin_          (  7.275 * mm),
   hole_diam_       (  7.00  * mm),
-  board_thickness_ (  0.5   * mm),
+  board_thickness_ (  0.2   * mm),
   mask_thickness_  (  6.0   * mm),
   time_binning_    (1. * microsecond),
   visibility_      (true),

--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -225,12 +225,12 @@ void Next100SiPMBoard::Construct()
                     sipm_->GetLogicalVolume(), sipm_->GetLogicalVolume()->GetName(), mask_hole_logic_vol,
                     false, 0, false);
 
-
   ////////////////////////////////////////////////////////////////////
 
   // Placing now 8x8 replicas of the gas hole and SiPM
 
   G4double zpos = board_thickness_ + sipm_thickn/2.;
+  G4VPhysicalVolume* mask_hole_phys_vol;
 
   G4int counter = 0;
 
@@ -250,9 +250,14 @@ void Next100SiPMBoard::Construct()
                         mask_wls_hole_logic_vol, mask_wls_hole_name, mask_wls_logic_vol,
                         false, counter, false);
       // Placement of the hole+SiPM
-      new G4PVPlacement(nullptr, G4ThreeVector(xpos, ypos, mask_hole_zpos),
-                        mask_hole_logic_vol, mask_hole_name, mask_logic_vol,
-                        false, counter, false);
+      mask_hole_phys_vol = new G4PVPlacement(nullptr, G4ThreeVector(xpos, ypos, mask_hole_zpos),
+                                             mask_hole_logic_vol, mask_hole_name, mask_logic_vol,
+                                             false, counter, false);
+
+      new G4LogicalBorderSurface(mask_wall_wls_name+"_OPSURF",
+                                 mask_hole_phys_vol, wall_wls_phys_vol, mask_wls_opsurf);
+      new G4LogicalBorderSurface(mask_wls_name+"_OPSURF",
+                                 wall_wls_phys_vol, mask_hole_phys_vol, mask_wls_opsurf);
 
       counter++;
     }

--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -26,6 +26,7 @@
 #include <G4OpticalSurface.hh>
 #include <G4LogicalSkinSurface.hh>
 #include <G4LogicalBorderSurface.hh>
+#include <G4UnionSolid.hh>
 
 using namespace nexus;
 
@@ -162,6 +163,35 @@ void Next100SiPMBoard::Construct()
     new G4LogicalVolume(mask_hole_solid_vol, mother_gas, mask_hole_name);
 
   // (Placement of this volume below.)
+
+  // HOLE WALLs WLS ///////////////////////////////////////////////////
+
+  G4String mask_wall_wls_name = "SIPM_BOARD_MASK_WALL_WLS";
+
+  G4Box* latwall_wls_solid_vol =
+    new G4Box(mask_wall_wls_name, wls_thickness/2., mask_hole_y/2., mask_hole_length/2.);
+
+  G4Box* uppwall_wls_solid_vol =
+      new G4Box(mask_wall_wls_name, mask_hole_x/2., wls_thickness/2., mask_hole_length/2.);
+
+  G4UnionSolid* wall_wls_solid_vol =
+    new G4UnionSolid(mask_wall_wls_name, latwall_wls_solid_vol, uppwall_wls_solid_vol, 0,
+                     G4ThreeVector(mask_hole_x/2.-wls_thickness/2., -mask_hole_y/2. + wls_thickness/2., 0.));
+
+  wall_wls_solid_vol =
+    new G4UnionSolid(mask_wall_wls_name, wall_wls_solid_vol, uppwall_wls_solid_vol, 0,
+                     G4ThreeVector(mask_hole_x/2.-wls_thickness/2., mask_hole_y/2. - wls_thickness/2., 0.));
+
+  wall_wls_solid_vol =
+    new G4UnionSolid(mask_wall_wls_name, wall_wls_solid_vol, latwall_wls_solid_vol, 0,
+                     G4ThreeVector(mask_hole_x-wls_thickness, 0., 0.));
+
+  G4LogicalVolume* wall_wls_logic_vol =
+    new G4LogicalVolume(wall_wls_solid_vol, tpb, mask_wall_wls_name);
+
+  G4VPhysicalVolume* wall_wls_phys_vol =
+    new G4PVPlacement(nullptr, G4ThreeVector(-mask_hole_x/2. + wls_thickness/2., 0., 0.), wall_wls_logic_vol,
+                      mask_wall_wls_name, mask_hole_logic_vol, false, 0, false);
 
   // MASK WLS GAS HOLE ///////////////////////////////////////////////
 

--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -35,7 +35,6 @@ Next100SiPMBoard::Next100SiPMBoard():
   size_            (122.40  * mm),
   pitch_           ( 15.55  * mm),
   margin_          (  7.275 * mm),
-  hole_diam_       (  7.00  * mm),
   board_thickness_ (  0.2   * mm),
   mask_thickness_  (  6.0   * mm),
   time_binning_    (1. * microsecond),
@@ -148,33 +147,33 @@ void Next100SiPMBoard::Construct()
                              mpv_, mask_wls_phys_vol, mask_wls_opsurf);
 
 
-  // MASK WLS GAS HOLE ///////////////////////////////////////////////
-
-  G4String mask_wls_hole_name   = "SIPM_BOARD_MASK_WLS_HOLE";
-  G4double mask_wls_hole_length = wls_thickness;
-
-  G4Tubs* mask_wls_hole_solid_vol =
-    new G4Tubs(mask_wls_hole_name, 0., hole_diam_/2.,
-               mask_wls_hole_length/2., 0., 360.*deg);
-
-  G4LogicalVolume* mask_wls_hole_logic_vol =
-    new G4LogicalVolume(mask_wls_hole_solid_vol,
-                        mpv_->GetLogicalVolume()->GetMaterial(),
-                        mask_wls_hole_name);
-
-  // (Placement of this volume below.)
-
   // MASK GAS HOLE ///////////////////////////////////////////////////
 
   G4String mask_hole_name   = "SIPM_BOARD_MASK_HOLE";
   G4double mask_hole_length = mask_thickness_ - wls_thickness;
   G4double mask_hole_zpos   = - mask_thickness_/2. + mask_hole_length/2.;
+  G4double mask_hole_x = 6.0 * mm;
+  G4double mask_hole_y = 5.0 * mm;
 
-  G4Tubs* mask_hole_solid_vol =
-    new G4Tubs(mask_hole_name, 0., hole_diam_/2., mask_hole_length/2., 0, 360.*deg);
+  G4Box* mask_hole_solid_vol =
+    new G4Box(mask_hole_name, mask_hole_x/2., mask_hole_y/2., mask_hole_length/2.);
 
   G4LogicalVolume* mask_hole_logic_vol =
     new G4LogicalVolume(mask_hole_solid_vol, mother_gas, mask_hole_name);
+
+  // (Placement of this volume below.)
+
+  // MASK WLS GAS HOLE ///////////////////////////////////////////////
+
+  G4String mask_wls_hole_name   = "SIPM_BOARD_MASK_WLS_HOLE";
+
+  G4Box* mask_wls_hole_solid_vol =
+    new G4Box(mask_wls_hole_name, mask_hole_x/2., mask_hole_y/2., wls_thickness/2.);
+
+  G4LogicalVolume* mask_wls_hole_logic_vol =
+    new G4LogicalVolume(mask_wls_hole_solid_vol,
+                        mpv_->GetLogicalVolume()->GetMaterial(),
+                        mask_wls_hole_name);
 
   // (Placement of this volume below.)
 

--- a/source/geometries/Next100SiPMBoard.h
+++ b/source/geometries/Next100SiPMBoard.h
@@ -47,7 +47,6 @@ namespace nexus {
   private:
     G4GenericMessenger* msg_;
     G4double size_, pitch_, margin_;
-    G4double hole_diam_;
     G4double board_thickness_, mask_thickness_;
     G4double time_binning_;
     std::vector<G4ThreeVector> sipm_positions_;

--- a/source/geometries/Next100SiPMBoard.h
+++ b/source/geometries/Next100SiPMBoard.h
@@ -21,7 +21,7 @@ class G4GenericMessenger;
 namespace nexus {
 
   class BoxPointSampler;
-  class GenericPhotosensor;
+  class Next100SiPM;
 
   // Geometry of the 8x8 SiPM boards used in the tracking plane of NEXT-100
 
@@ -54,7 +54,7 @@ namespace nexus {
     G4bool   visibility_, sipm_visibility_;
     G4VPhysicalVolume*  mpv_;
     BoxPointSampler*    vtxgen_;
-    GenericPhotosensor* sipm_;
+    Next100SiPM* sipm_;
   };
 
   inline void Next100SiPMBoard::SetMotherPhysicalVolume(G4VPhysicalVolume* p)

--- a/source/geometries/Next100TrackingPlane.cc
+++ b/source/geometries/Next100TrackingPlane.cc
@@ -30,7 +30,7 @@ Next100TrackingPlane::Next100TrackingPlane():
   GeometryBase(),
   copper_plate_diameter_  (1340.*mm),
   copper_plate_thickness_ ( 145.*mm),
-  distance_board_board_   (   1.*mm),
+  distance_board_board_   (   2.*mm),
 
   visibility_(true),
   sipm_board_geom_(new Next100SiPMBoard),

--- a/source/geometries/Next100TrackingPlane.cc
+++ b/source/geometries/Next100TrackingPlane.cc
@@ -26,7 +26,7 @@ using namespace nexus;
 Next100TrackingPlane::Next100TrackingPlane():
   GeometryBase(),
   copper_plate_diameter_  (1340.*mm),
-  copper_plate_thickness_ ( 120.*mm),
+  copper_plate_thickness_ ( 145.*mm),
   distance_board_board_   (   1.*mm),
   visibility_(true),
   sipm_board_geom_(new Next100SiPMBoard),

--- a/source/geometries/Next100TrackingPlane.cc
+++ b/source/geometries/Next100TrackingPlane.cc
@@ -9,11 +9,14 @@
 #include "Next100TrackingPlane.h"
 
 #include "Next100SiPMBoard.h"
+#include "MaterialsList.h"
 #include "CylinderPointSampler2020.h"
+#include "BoxPointSampler.h"
 #include "Visibilities.h"
 
 #include <G4GenericMessenger.hh>
 #include <G4Tubs.hh>
+#include <G4Box.hh>
 #include <G4LogicalVolume.hh>
 #include <G4PVPlacement.hh>
 #include <G4NistManager.hh>
@@ -28,6 +31,7 @@ Next100TrackingPlane::Next100TrackingPlane():
   copper_plate_diameter_  (1340.*mm),
   copper_plate_thickness_ ( 145.*mm),
   distance_board_board_   (   1.*mm),
+
   visibility_(true),
   sipm_board_geom_(new Next100SiPMBoard),
   copper_plate_gen_(nullptr),
@@ -47,6 +51,7 @@ Next100TrackingPlane::~Next100TrackingPlane()
   delete msg_;
   delete sipm_board_geom_;
   delete copper_plate_gen_;
+  delete plug_gen_;
 }
 
 
@@ -61,69 +66,89 @@ void Next100TrackingPlane::Construct()
 
   G4String copper_plate_name = "TP_COPPER_PLATE";
 
-  G4Tubs* copper_plate_solid_vol = new G4Tubs(copper_plate_name,
-                                             0., copper_plate_diameter_/2.,
-                                             copper_plate_thickness_/2.,
-                                             0., 360.*deg);
+  G4Tubs* copper_plate_solid = new G4Tubs(copper_plate_name,
+                                          0., copper_plate_diameter_/2.,
+                                          copper_plate_thickness_/2.,
+                                          0., 360.*deg);
 
-  G4LogicalVolume* copper_plate_logic_vol =
-    new G4LogicalVolume(copper_plate_solid_vol,
-                        G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"),
-                        copper_plate_name);
+  G4LogicalVolume* copper_plate_logic =
+    new G4LogicalVolume(copper_plate_solid,
+                        G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"), copper_plate_name);
 
-  G4double zpos = GetELzCoord() - gate_tp_dist_ - copper_plate_thickness_/2.;
+  G4double copper_plate_zpos = GetELzCoord() - gate_tp_dist_ - copper_plate_thickness_/2.;
 
-  G4VPhysicalVolume* copper_plate_phys_vol =
-    new G4PVPlacement(nullptr, G4ThreeVector(0.,0.,zpos),
-                      copper_plate_logic_vol, copper_plate_name, mpv_->GetLogicalVolume(),
+  G4VPhysicalVolume* copper_plate_phys =
+    new G4PVPlacement(nullptr, G4ThreeVector(0.,0.,copper_plate_zpos),
+                      copper_plate_logic, copper_plate_name, mpv_->GetLogicalVolume(),
                       false, 0, false);
 
-  copper_plate_gen_ = new CylinderPointSampler2020(copper_plate_phys_vol);
+  copper_plate_gen_ = new CylinderPointSampler2020(copper_plate_phys);
+
 
   // SIPM BOARDS /////////////////////////////////////////////////////
 
   sipm_board_geom_->SetMotherPhysicalVolume(mpv_);
   sipm_board_geom_->Construct();
-  G4LogicalVolume* sipm_board_logic_vol = sipm_board_geom_->GetLogicalVolume();
+  G4LogicalVolume* sipm_board_logic = sipm_board_geom_->GetLogicalVolume();
 
-  zpos = GetELzCoord() - gate_tp_dist_ + sipm_board_geom_->GetThickness()/2.;
+  G4double zpos = GetELzCoord() - gate_tp_dist_ + sipm_board_geom_->GetThickness()/2.;
 
   // SiPM boards are positioned bottom (negative Y) to top (positive Y)
   // and left (negative X) to right (positive X).
-
   G4int board_index = 1;
 
   // Column on the far left has 5 boards.
   // It is located 3.5 boards away from the center.
-  PlaceSiPMBoardColumns(5, -3.5, zpos, board_index, sipm_board_logic_vol);
+  PlaceSiPMBoardColumns(5, -3.5, zpos, board_index, sipm_board_logic);
 
   // Second column from the left has 7 boards.
   // It is located 2.5 boards away from the center.
-  PlaceSiPMBoardColumns(7, -2.5, zpos, board_index, sipm_board_logic_vol);
+  PlaceSiPMBoardColumns(7, -2.5, zpos, board_index, sipm_board_logic);
 
   // Central block of 4 columns with 8 boards each
-  PlaceSiPMBoardColumns(8, -1.5, zpos, board_index, sipm_board_logic_vol);
-  PlaceSiPMBoardColumns(8, -0.5, zpos, board_index, sipm_board_logic_vol);
-  PlaceSiPMBoardColumns(8,  0.5, zpos, board_index, sipm_board_logic_vol);
-  PlaceSiPMBoardColumns(8,  1.5, zpos, board_index, sipm_board_logic_vol);
+  PlaceSiPMBoardColumns(8, -1.5, zpos, board_index, sipm_board_logic);
+  PlaceSiPMBoardColumns(8, -0.5, zpos, board_index, sipm_board_logic);
+  PlaceSiPMBoardColumns(8,  0.5, zpos, board_index, sipm_board_logic);
+  PlaceSiPMBoardColumns(8,  1.5, zpos, board_index, sipm_board_logic);
 
   // Second column from the right has 7 boards and
   // it's located 2.5 boards away from the center.
-  PlaceSiPMBoardColumns(7,  2.5, zpos, board_index, sipm_board_logic_vol);
+  PlaceSiPMBoardColumns(7,  2.5, zpos, board_index, sipm_board_logic);
 
   // Column on the far right has 5 boards.
   // It is located 3.5 boards away from the center.
-  PlaceSiPMBoardColumns(5,  3.5, zpos, board_index, sipm_board_logic_vol);
+  PlaceSiPMBoardColumns(5,  3.5, zpos, board_index, sipm_board_logic);
+
+  ///// DB PLUGS
+  G4double plug_x = 40. * mm;
+  G4double plug_y =  5. * mm;
+  G4double plug_z =  2. * mm;
+  G4double plug_y_displacement = 90.5 * mm;
+
+  G4Box* plug_solid = new G4Box("DB_PLUG", plug_x/2., plug_y/2., plug_z/2.);
+  G4LogicalVolume* plug_logic = new G4LogicalVolume(plug_solid,  materials::PEEK(), "DB_PLUG");
+  G4double plug_posz = copper_plate_zpos - copper_plate_thickness_/2. - plug_z/2.;
+
+  G4ThreeVector pos;
+  for (int i=0; i<int(board_pos_.size()); i++) {
+    pos = board_pos_[i];
+    pos.setY(pos.getY()-plug_y_displacement);
+    pos.setZ(plug_posz);
+    plug_pos_.push_back(pos);
+    new G4PVPlacement(0, pos, plug_logic, "DB_PLUG", mpv_->GetLogicalVolume(), false, i, false);
+  }
+
+  plug_gen_ = new BoxPointSampler(plug_x, plug_y, plug_z, 0.);
 
 
   // VISIBILITIES //////////////////////////////////////////
-
   if (visibility_) {
     G4VisAttributes copper_brown = CopperBrown();
-    copper_plate_logic_vol->SetVisAttributes(copper_brown);
+    copper_plate_logic->SetVisAttributes(copper_brown);
   } else {
-    copper_plate_logic_vol->SetVisAttributes(G4VisAttributes::GetInvisible());
-    sipm_board_logic_vol  ->SetVisAttributes(G4VisAttributes::GetInvisible());
+    copper_plate_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
+    sipm_board_logic  ->SetVisAttributes(G4VisAttributes::GetInvisible());
+    plug_logic        ->SetVisAttributes(G4VisAttributes::GetInvisible());
   }
 
 }
@@ -141,9 +166,10 @@ void Next100TrackingPlane::PlaceSiPMBoardColumns(G4int num_boards,
 
   for (auto i=0; i<num_boards; i++) {
     G4double ypos = (- 0.5 * (num_boards - 1) + i ) * size;
-    G4ThreeVector position(xpos, ypos, zpos); board_pos_.push_back(position);
-    new G4PVPlacement(nullptr, position,
-                      logic_vol, logic_vol->GetName(), mpv_->GetLogicalVolume(),
+    G4ThreeVector position(xpos, ypos, zpos);
+    board_pos_.push_back(position);
+
+    new G4PVPlacement(nullptr, position, logic_vol, logic_vol->GetName(), mpv_->GetLogicalVolume(),
                       false, board_index, false);
     board_index++;
   }
@@ -172,6 +198,11 @@ G4ThreeVector Next100TrackingPlane::GenerateVertex(const G4String& region) const
     vertex = sipm_board_geom_->GenerateVertex("");
     G4int board_num = G4RandFlat::shootInt((long) 0, board_pos_.size());
     vertex += board_pos_[board_num];
+  }
+  else if (region == "DB_PLUG") {
+    vertex = plug_gen_->GenerateVertex("INSIDE");
+    G4int plug_num = G4RandFlat::shootInt((long) 0, plug_pos_.size());
+    vertex += plug_pos_[plug_num];
   }
   else if (region == "TP_COPPER_PLATE") {
     vertex = copper_plate_gen_->GenerateVertex("VOLUME");

--- a/source/geometries/Next100TrackingPlane.h
+++ b/source/geometries/Next100TrackingPlane.h
@@ -20,6 +20,7 @@ namespace nexus {
 
   class Next100SiPMBoard;
   class CylinderPointSampler2020;
+  class BoxPointSampler;
 
   // Geometry of the tracking plane of the NEXT-100 detector
 
@@ -49,12 +50,14 @@ namespace nexus {
     const G4double distance_board_board_;
 
     std::vector<G4ThreeVector> board_pos_;
+    std::vector<G4ThreeVector> plug_pos_;
 
     G4bool visibility_;
 
     Next100SiPMBoard* sipm_board_geom_;
 
     CylinderPointSampler2020* copper_plate_gen_;
+    BoxPointSampler* plug_gen_;
 
     G4VPhysicalVolume* mpv_; // Pointer to mother's physical volume
 


### PR DESCRIPTION
This PR adapts the Next100 tracking plane. This first version of the PR adds the following:
- Change generic photosensor SiPMs to Next100SiPMs
- Fix copper plate thicknesses.
- Fix SIPM_BOARD vertex which was wrongly named to DICE_BOARD in Next100 class
- Add DB-PLUGS. In the past they were included in the ICS class.
- Fix dimensions according to last design: [gate-tp-distance.pdf](https://github.com/next-exp/nexus/files/7337219/02.pdf)
Notice that the anode ring thickness (`gate_ring_thickn_`) is set to 9.9 mm in order to avoid its overlap with the square sipm boards masks at high radious. By simplicity, the gate ring thickness is set to the same value, therefore the parameter `gate_teflon_dist_` is now refered to the gate-grid instead to the gate ring as before.

The final design is still not decided thus the ultimate sipm holes implementation is left unchanged for the moment. It will likely be one of these:
- Mask holes covered by a coated membrane. No internal hole walls or SiPMs coated (DEMO Run 9).
- Mask internal hole walls coated with coated SIPMs and no membrane (DEMO Run 10).

TO-DO:
- Likely change rounded hole to square hole. But waiting for confirmation and dimensions.