### PR TITLE
Next100 ICS

### DIFF
--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -146,6 +146,7 @@ namespace nexus {
 
     // INNER COPPER SHIELDING
     ics_->SetLogicalVolume(vessel_internal_logic);
+    ics_->SetELzCoord(gate_zpos_in_vessel_);
     ics_->Construct();
 
     G4ThreeVector gate_pos(0., 0., -gate_zpos_in_vessel_);

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -39,12 +39,17 @@ namespace nexus {
     GeometryBase(),
     // Lab dimensions
     lab_size_ (5. * m),
+
+    // distance between EL gate and TP copper plate
+    gate_tp_distance_(25.6 * mm), // check
+
     // Nozzles external diam and y positions
     nozzle_ext_diam_ (9. * cm),
     up_nozzle_ypos_ (20. * cm),
     central_nozzle_ypos_ (0. * cm),
     down_nozzle_ypos_ (-20. * cm),
     bottom_nozzle_ypos_(-53. * cm),
+
     specific_vertex_{},
     lab_walls_(false)
   {
@@ -142,11 +147,15 @@ namespace nexus {
     inner_elements_->SetLogicalVolume(vessel_internal_logic);
     inner_elements_->SetPhysicalVolume(vessel_internal_phys);
     inner_elements_->SetELzCoord(gate_zpos_in_vessel_);
+    // inner_elements_->SetELtoTPdistance(gate_tp_distance_);
     inner_elements_->Construct();
 
     // INNER COPPER SHIELDING
     ics_->SetLogicalVolume(vessel_internal_logic);
     ics_->SetELzCoord(gate_zpos_in_vessel_);
+    ics_->SetELtoTPdistance(gate_tp_distance_);
+    // ics_->SetFieldCageLength(inner_elements_->GetFieldCageLength());
+    ics_->SetFieldCageLength(1432.*mm + 16.*mm); // gate-teflon distance + teflon length
     ics_->Construct();
 
     G4ThreeVector gate_pos(0., 0., -gate_zpos_in_vessel_);

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -25,9 +25,6 @@
 #include <G4NistManager.hh>
 #include <G4UserLimits.hh>
 
-#include <CLHEP/Units/SystemOfUnits.h>
-#include <CLHEP/Units/PhysicalConstants.h>
-#include <stdexcept>
 
 namespace nexus {
 

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -40,8 +40,9 @@ namespace nexus {
     // Lab dimensions
     lab_size_ (5. * m),
 
-    // distance between EL gate and TP copper plate
-    gate_tp_distance_(25.6 * mm), // check
+    // common used variables in geomety components
+    gate_tracking_plane_distance_(35. * mm), // to be confirmed
+    gate_sapphire_wdw_distance_  (1460.5 * mm),
 
     // Nozzles external diam and y positions
     nozzle_ext_diam_ (9. * cm),
@@ -147,14 +148,15 @@ namespace nexus {
     inner_elements_->SetLogicalVolume(vessel_internal_logic);
     inner_elements_->SetPhysicalVolume(vessel_internal_phys);
     inner_elements_->SetELzCoord(gate_zpos_in_vessel_);
-    // inner_elements_->SetELtoTPdistance(gate_tp_distance_);
+    inner_elements_->SetELtoSapphireWDWdistance(gate_sapphire_wdw_distance_);
+    inner_elements_->SetELtoTPdistance         (gate_tracking_plane_distance_);
     inner_elements_->Construct();
 
     // INNER COPPER SHIELDING
     ics_->SetLogicalVolume(vessel_internal_logic);
     ics_->SetELzCoord(gate_zpos_in_vessel_);
-    ics_->SetELtoTPdistance(gate_tp_distance_);
-    // ics_->SetFieldCageLength(inner_elements_->GetFieldCageLength());
+    ics_->SetELtoSapphireWDWdistance(gate_sapphire_wdw_distance_);
+    ics_->SetELtoTPdistance         (gate_tracking_plane_distance_);
     ics_->SetFieldCageLength(1432.*mm + 16.*mm); // gate-teflon distance + teflon length
     ics_->SetPortZpositions(vessel_->GetPortZpositions());
     ics_->Construct();

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -157,7 +157,6 @@ namespace nexus {
     ics_->SetELzCoord(gate_zpos_in_vessel_);
     ics_->SetELtoSapphireWDWdistance(gate_sapphire_wdw_distance_);
     ics_->SetELtoTPdistance         (gate_tracking_plane_distance_);
-    ics_->SetFieldCageLength(1432.*mm + 16.*mm); // gate-teflon distance + teflon length
     ics_->SetPortZpositions(vessel_->GetPortZpositions());
     ics_->Construct();
 

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -156,6 +156,7 @@ namespace nexus {
     ics_->SetELtoTPdistance(gate_tp_distance_);
     // ics_->SetFieldCageLength(inner_elements_->GetFieldCageLength());
     ics_->SetFieldCageLength(1432.*mm + 16.*mm); // gate-teflon distance + teflon length
+    ics_->SetPortZpositions(vessel_->GetPortZpositions());
     ics_->Construct();
 
     G4ThreeVector gate_pos(0., 0., -gate_zpos_in_vessel_);

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -71,8 +71,7 @@ namespace nexus {
 			      down_nozzle_ypos_, bottom_nozzle_ypos_);
 
   // Internal copper shielding
-  ics_ = new Next100Ics(nozzle_ext_diam_, up_nozzle_ypos_, central_nozzle_ypos_,
-			down_nozzle_ypos_, bottom_nozzle_ypos_);
+  ics_ = new Next100Ics();
 
   // Inner Elements
   inner_elements_ = new Next100InnerElements();

--- a/source/geometries/Next100.h
+++ b/source/geometries/Next100.h
@@ -47,7 +47,7 @@ namespace nexus {
   private:
     // Detector dimensions
     const G4double lab_size_;          /// Size of the air box containing the detector
-    const G4double gate_tp_distance_;
+    const G4double gate_tracking_plane_distance_, gate_sapphire_wdw_distance_;
 
     // External diameter of nozzles and y positions
     const G4double nozzle_ext_diam_;

--- a/source/geometries/Next100.h
+++ b/source/geometries/Next100.h
@@ -47,6 +47,7 @@ namespace nexus {
   private:
     // Detector dimensions
     const G4double lab_size_;          /// Size of the air box containing the detector
+    const G4double gate_tp_distance_;
 
     // External diameter of nozzles and y positions
     const G4double nozzle_ext_diam_;

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -46,7 +46,6 @@ Next100FieldCage::Next100FieldCage():
   // Dimensions
   active_diam_ (984. * mm), // distance between the centers of two opposite panels
   teflon_drift_length_ (1178.*mm), //distance from the gate to the beginning of the cathode volume.
-  gate_sapphire_wdw_dist_ (1460.5 * mm), //distance between gate and the surface of sapphire windows
   cathode_int_diam_ (960. * mm),
   cathode_ext_diam_ (1020. * mm),
   cathode_thickn_ (10. * mm),
@@ -984,10 +983,4 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
 G4ThreeVector Next100FieldCage::GetActivePosition() const
 {
   return G4ThreeVector (0., 0., active_zpos_);
-}
-
-
-G4double Next100FieldCage::GetDistanceGateSapphireWindows() const
-{
-  return active_length_ + grid_thickn_ +  buffer_length_;
 }

--- a/source/geometries/Next100FieldCage.h
+++ b/source/geometries/Next100FieldCage.h
@@ -32,10 +32,11 @@ namespace nexus {
     G4ThreeVector GenerateVertex(const G4String& region) const override;
 
     G4ThreeVector GetActivePosition() const;
-    G4double GetDistanceGateSapphireWindows() const;
 
     void SetMotherLogicalVolume(G4LogicalVolume* mother_logic);
     void SetMotherPhysicalVolume(G4VPhysicalVolume* mother_phys);
+    void SetELtoTPdistance(G4double);
+    void SetELtoSapphireWDWdistance(G4double);
 
   private:
     void DefineMaterials();
@@ -47,8 +48,9 @@ namespace nexus {
     void BuildFieldCage();
 
     // Dimensions
+    G4double gate_sapphire_wdw_dist_;
     const G4double active_diam_;
-    const G4double teflon_drift_length_, gate_sapphire_wdw_dist_;
+    const G4double teflon_drift_length_;
     const G4double cathode_int_diam_, cathode_ext_diam_, cathode_thickn_;
     const G4double grid_thickn_;
     const G4double teflon_total_length_, teflon_thickn_;
@@ -122,6 +124,11 @@ namespace nexus {
     G4double el_gap_gen_disk_x_, el_gap_gen_disk_y_;
     G4double el_gap_gen_disk_zmin_, el_gap_gen_disk_zmax_;
   };
+
+
+  inline void Next100FieldCage::SetELtoSapphireWDWdistance(G4double distance){
+    gate_sapphire_wdw_dist_ = distance;
+  }
 
 } //end namespace nexus
 #endif

--- a/source/geometries/Next100FieldCage.h
+++ b/source/geometries/Next100FieldCage.h
@@ -35,7 +35,6 @@ namespace nexus {
 
     void SetMotherLogicalVolume(G4LogicalVolume* mother_logic);
     void SetMotherPhysicalVolume(G4VPhysicalVolume* mother_phys);
-    void SetELtoTPdistance(G4double);
     void SetELtoSapphireWDWdistance(G4double);
 
   private:

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -57,17 +57,15 @@ namespace nexus {
 
   void Next100Ics::Construct()
   {
-
-    G4double gate_zpos = GetELzCoord();
-    length_ = gate_tp_distance_ + field_cage_length_;
+    G4double length = gate_tp_distance_ + gate_sapphire_wdw_dist_;
 
     G4double offset = 1.* mm;
 
     // ICS
-    G4double ics_z_pos = gate_zpos + length_/2. - gate_tp_distance_;
+    G4double ics_z_pos = GetELzCoord() + length/2. - gate_tp_distance_;
 
     G4Tubs* ics_body = new G4Tubs("ICS", in_rad_, in_rad_ + thickness_,
-                                  length_/2., 0.*deg, 360.*deg);
+                                  length/2., 0.*deg, 360.*deg);
     G4SubtractionSolid* ics_solid;
 
     // Port holes
@@ -111,10 +109,10 @@ namespace nexus {
                                         (thickness_ + offset)/2., 0.*deg, 360.*deg);
 
     ics_solid = new G4SubtractionSolid("ICS", ics_solid, upp_hole_solid,
-                port_upp_Rot, G4ThreeVector(0, (in_rad_ + thickness_/2.), upp_hole_1_z-length_/2.));
+                port_upp_Rot, G4ThreeVector(0, (in_rad_ + thickness_/2.), upp_hole_1_z-length/2.));
 
     ics_solid = new G4SubtractionSolid("ICS", ics_solid, upp_hole_solid,
-                port_upp_Rot, G4ThreeVector(0, (in_rad_ + thickness_/2.), upp_hole_2_z-length_/2.));
+                port_upp_Rot, G4ThreeVector(0, (in_rad_ + thickness_/2.), upp_hole_2_z-length/2.));
 
     /// Lateral holes
     G4double lat_hole_rad = upp_hole_rad;
@@ -124,10 +122,10 @@ namespace nexus {
                                         (thickness_ + offset)/2., 0.*deg, 360.*deg);
 
     ics_solid = new G4SubtractionSolid("ICS", ics_solid, lat_hole_solid,
-                port_a_Rot, G4ThreeVector(port_x, port_y, lat_hole_z-length_/2.));
+                port_a_Rot, G4ThreeVector(port_x, port_y, lat_hole_z-length/2.));
 
     ics_solid = new G4SubtractionSolid("ICS", ics_solid, lat_hole_solid,
-                port_b_Rot, G4ThreeVector(-port_x, port_y, lat_hole_z-length_/2.));
+                port_b_Rot, G4ThreeVector(-port_x, port_y, lat_hole_z-length/2.));
 
 
     G4LogicalVolume* ics_logic =
@@ -149,7 +147,7 @@ namespace nexus {
 
     // VERTEX GENERATOR
     ics_gen_ =
-      new CylinderPointSampler2020(in_rad_, in_rad_ + thickness_, length_/2., 0.*deg, 360.*deg,
+      new CylinderPointSampler2020(in_rad_, in_rad_ + thickness_, length/2., 0.*deg, 360.*deg,
                                    0, G4ThreeVector(0., 0., ics_z_pos));
   }
 

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -23,9 +23,6 @@
 #include <Randomize.hh>
 #include <G4TransportationManager.hh>
 
-#include <CLHEP/Units/SystemOfUnits.h>
-#include <CLHEP/Units/PhysicalConstants.h>
-#include <stdexcept>
 
 namespace nexus {
 
@@ -131,7 +128,7 @@ namespace nexus {
 
 
     /// ICS step at the TP end.
-    // This avoids overlap with sipm boards at high radious
+    // This avoids overlap with sipm boards at high radius
     G4double step_width = 38. * mm; // step lenght in the y dimension
     G4Tubs* tp_step_solid = new G4Tubs("TP_STEP", (in_rad_ - offset), in_rad_ + step_width,
                                        gate_tp_distance_, 0.*deg, 360.*deg);

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -113,9 +113,36 @@ namespace nexus {
     ics_solid = new G4SubtractionSolid("ICS", ics_solid, port_hole_solid,
                 port_b_Rot, G4ThreeVector(-port_x, port_y, port_z_2b_-ics_z_pos));
 
-    // Upper holes
+    /// Upper holes
+    // z distances measured with respect to TP plate, ie the start of ICS
+    G4double upp_hole_rad = 31.  * mm;
+    G4double upp_hole_1_z = 313. * mm;
+    G4double upp_hole_2_z = 313. * mm + 919. * mm;
 
+    G4RotationMatrix* port_upp_Rot = new G4RotationMatrix;
+    port_upp_Rot->rotateX( 90. * deg);
 
+    G4Tubs* upp_hole_solid = new G4Tubs("UPP_HOLE", 0., upp_hole_rad,
+                                        (thickness_ + offset)/2., 0.*deg, 360.*deg);
+
+    ics_solid = new G4SubtractionSolid("ICS", ics_solid, upp_hole_solid,
+                port_upp_Rot, G4ThreeVector(0, (in_rad_ + thickness_/2.), upp_hole_1_z-length_/2.));
+
+    ics_solid = new G4SubtractionSolid("ICS", ics_solid, upp_hole_solid,
+                port_upp_Rot, G4ThreeVector(0, (in_rad_ + thickness_/2.), upp_hole_2_z-length_/2.));
+
+    /// Lateral holes
+    G4double lat_hole_rad = upp_hole_rad;
+    G4double lat_hole_z   = 58.1 * mm;
+
+    G4Tubs* lat_hole_solid = new G4Tubs("LAT_HOLE", 0., lat_hole_rad,
+                                        (thickness_ + offset)/2., 0.*deg, 360.*deg);
+
+    ics_solid = new G4SubtractionSolid("ICS", ics_solid, lat_hole_solid,
+                port_a_Rot, G4ThreeVector(port_x, port_y, lat_hole_z-length_/2.));
+
+    ics_solid = new G4SubtractionSolid("ICS", ics_solid, lat_hole_solid,
+                port_b_Rot, G4ThreeVector(-port_x, port_y, lat_hole_z-length_/2.));
 
 
     G4LogicalVolume* ics_logic =
@@ -156,7 +183,7 @@ namespace nexus {
   }
 
 
-    // VERTEX GENERATORS   //////////
+    // VERTEX GENERATOR
     ics_gen_ =
       new CylinderPointSampler2020(in_rad_, in_rad_ + thickness_, length_/2., 0.*deg, 360.*deg,
                                    0, G4ThreeVector(0., 0., ics_z_pos));
@@ -177,12 +204,11 @@ namespace nexus {
     if (region=="ICS"){
       G4VPhysicalVolume *VertexVolume;
       do {
-        G4ThreeVector glob_vtx(vertex);
-        glob_vtx.rotate(pi, G4ThreeVector(0., 1., 0.));
-        glob_vtx = glob_vtx + G4ThreeVector(0, 0, GetELzCoord());
-        VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
-
         vertex = ics_gen_->GenerateVertex("VOLUME");
+
+        G4ThreeVector glob_vtx(vertex);
+        glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+        VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
       } while (VertexVolume->GetName() != "ICS");
     }
 

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -59,6 +59,8 @@ namespace nexus {
   {
     G4double length = gate_tp_distance_ + gate_sapphire_wdw_dist_;
 
+    // defined for G4UnionSolids to ensure a common volume within the two joined solids
+    // and for G4SubtractionSolids to ensure surface subtraction
     G4double offset = 1.* mm;
 
     // ICS

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -49,7 +49,6 @@ namespace nexus {
     body_thickness_ (12.0 * cm),
 
     // Tracking plane dimensions  (thin version without substractions)
-    tracking_orad_ (65.0 * cm),        // To be checked
     tracking_length_ (10.0 * cm),
 
     //KDB plugs constructed here because the copper tracking plane is divided in two parts,
@@ -60,13 +59,6 @@ namespace nexus {
     // Number of Dice Boards, DB columns
     DB_columns_ (11),
     num_DBs_ (107),
-
-    // Energy plane dimensions
-    energy_theta_ (36.5 * deg),        // This must be consistent with vessel "endcap_theta_ (38.6 * deg)"
-    energy_orad_ (108.94 * cm),        // This must be consistent with vessel "endcap_in_rad_ (108.94 * cm)"
-    energy_thickness_ (9. * cm),
-    energy_sph_zpos_ (-5.76 * cm),     // This must be consistent with vessel "endcap_z_pos_ (-5.76 * cm)"
-    energy_cyl_length_ (13.0 * cm),
 
     visibility_ (0)
   {
@@ -101,71 +93,12 @@ namespace nexus {
     GenerateDBPositions();
 
     // ICS SOLIDS  ///////////
-
     // Body
-    G4Tubs* ics_body_solid = new G4Tubs("ICS_BODY", body_in_rad_, body_in_rad_ + body_thickness_,
+    G4Tubs* ics_solid = new G4Tubs("ICS_BODY", body_in_rad_, body_in_rad_ + body_thickness_,
 					body_length_/2., 0.*deg, 360.*deg);
-
-
-    // Tracking plane
-    G4Tubs* ics_tracking_solid = new G4Tubs("ICS_TRACKING_NH", 0.*cm, tracking_orad_,
-    					       tracking_length_/2., 0.*deg, 360.*deg);
-
-    // // Making DB tails holes
-    // G4Box* ics_tracking_hole_solid = new G4Box("ICS_TRACKING_HOLE", plug_x_/2., plug_y_,  tracking_length_);
-
-    // G4SubtractionSolid* ics_tracking_solid = new G4SubtractionSolid("ICS_TRACKING", ics_tracking_nh_solid,
-    //  								    ics_tracking_hole_solid, 0,DB_positions_[0]);
-    // for (int i=1; i<num_DBs_; i++) {
-    //   ics_tracking_solid = new G4SubtractionSolid("ICS_TRACKING", ics_tracking_solid,
-    //  						  ics_tracking_hole_solid, 0, DB_positions_[i]);
-    // }
-
-    // Energy plane
-    G4Sphere* ics_energy_sph_nh_solid = new G4Sphere("ICS_ENERGY_SPH_NH",
-						     energy_orad_ - energy_thickness_,  energy_orad_,   //radius
-						     0. * deg, 360. * deg,                              // phi
-						     180. * deg - energy_theta_, energy_theta_);        // theta
-
-    G4double hole_diam = nozzle_ext_diam_ + 1.*cm;
-    G4double hole_length = energy_thickness_ + 50.*cm;
-    G4double hole_zpos = -1. * (body_length_/2. + hole_length/2.);
-
-    G4Tubs* nozzle_hole_solid = new G4Tubs("NOZZLE_HOLE", 0.*cm, hole_diam/2., hole_length/2., 0.*deg, 360.*deg);
-
-    G4SubtractionSolid* ics_energy_sph_solid =
-      new G4SubtractionSolid("ICS_ENERGY_SPH", ics_energy_sph_nh_solid,
-			     nozzle_hole_solid, 0, G4ThreeVector(0., up_nozzle_ypos_, hole_zpos) );
-
-    ics_energy_sph_solid =
-      new G4SubtractionSolid("ICS_ENERGY_SPH", ics_energy_sph_solid,
-			     nozzle_hole_solid, 0, G4ThreeVector(0., central_nozzle_ypos_, hole_zpos) );
-
-    ics_energy_sph_solid =
-      new G4SubtractionSolid("ICS_ENERGY_SPH", ics_energy_sph_solid,
-			     nozzle_hole_solid, 0, G4ThreeVector(0., down_nozzle_ypos_, hole_zpos) );
-
-    ics_energy_sph_solid =
-      new G4SubtractionSolid("ICS_ENERGY_SPH", ics_energy_sph_solid,
-			     nozzle_hole_solid, 0, G4ThreeVector(0., bottom_nozzle_ypos_, hole_zpos) );
-
-
-    G4Tubs* ics_energy_cyl_solid =
-      new G4Tubs("ICS_ENERGY_CYL",  body_in_rad_, body_in_rad_ + energy_thickness_,  energy_cyl_length_/2., 0.*deg, 360.*deg);
-
 
     // Unions of parts
     G4double ics_tracking_zpos = body_length_/2. - tracking_length_/2.;
-    G4UnionSolid* ics_solid =
-      new G4UnionSolid("ICS", ics_body_solid, ics_tracking_solid,
-		       0, G4ThreeVector(0., 0., ics_tracking_zpos) );
-
-    ics_solid = new G4UnionSolid("ICS", ics_solid, ics_energy_sph_solid,
-				 0, G4ThreeVector(0., 0., energy_sph_zpos_) );
-
-    G4double energy_cyl_zpos = -1. * (body_length_/2. + energy_cyl_length_/2.);
-    ics_solid = new G4UnionSolid("ICS", ics_solid, ics_energy_cyl_solid,
-				 0, G4ThreeVector(0., 0., energy_cyl_zpos) );
 
     G4LogicalVolume* ics_logic =
       new G4LogicalVolume(ics_solid,
@@ -189,7 +122,6 @@ namespace nexus {
     }
 
 
-
     // SETTING VISIBILITIES   //////////
     if (visibility_) {
       G4VisAttributes copper_col = nexus::CopperBrown();
@@ -198,7 +130,6 @@ namespace nexus {
       G4VisAttributes dirty_white_col =nexus::DirtyWhite();
       dirty_white_col.SetForceSolid(true);
       plug_logic->SetVisAttributes(dirty_white_col);
-
     }
     else {
       ics_logic->SetVisAttributes(G4VisAttributes::Invisible);
@@ -206,35 +137,35 @@ namespace nexus {
   }
 
 
-    // VERTEX GENERATORS   //////////
-    body_gen_ =
-      new CylinderPointSampler(body_in_rad_, body_length_, body_thickness_, 0.);
-
-    tracking_gen_ =
-      new CylinderPointSampler(0.*cm, tracking_length_, tracking_orad_, 0.,
-					     G4ThreeVector(0., 0., ics_tracking_zpos));
-
-    energy_cyl_gen_ =
-      new CylinderPointSampler(body_in_rad_, energy_cyl_length_, energy_thickness_, 0.,  G4ThreeVector(0., 0., energy_cyl_zpos));
-
-    energy_sph_gen_ = new SpherePointSampler(energy_orad_ - energy_thickness_, energy_thickness_, G4ThreeVector(0., 0., energy_sph_zpos_),
-					     0,	0., twopi, 180.*deg - energy_theta_, energy_theta_);
-
-
-    plug_gen_ = new BoxPointSampler(plug_x_, plug_y_, plug_z_,0.,
-				    G4ThreeVector(0.,0.,0.),0);
-
-
-    // Calculating some probs
-    G4double body_vol = ics_body_solid->GetCubicVolume();
-    G4double tracking_vol = ics_tracking_solid->GetCubicVolume();
-    G4double energy_cyl_vol = ics_energy_cyl_solid->GetCubicVolume();
-    G4double energy_sph_vol = ics_energy_sph_solid->GetCubicVolume();
-    G4double total_vol = body_vol + tracking_vol + energy_cyl_vol + energy_sph_vol;
-
-    perc_body_vol_ = body_vol / total_vol;
-    perc_tracking_vol_ = (body_vol + tracking_vol) / total_vol;
-    perc_energy_cyl_vol_ = (body_vol + tracking_vol + energy_cyl_vol) / total_vol;
+    // // VERTEX GENERATORS   //////////
+    // body_gen_ =
+    //   new CylinderPointSampler(body_in_rad_, body_length_, body_thickness_, 0.);
+    //
+    // tracking_gen_ =
+    //   new CylinderPointSampler(0.*cm, tracking_length_, tracking_orad_, 0.,
+		// 			     G4ThreeVector(0., 0., ics_tracking_zpos));
+    //
+    // energy_cyl_gen_ =
+    //   new CylinderPointSampler(body_in_rad_, energy_cyl_length_, energy_thickness_, 0.,  G4ThreeVector(0., 0., energy_cyl_zpos));
+    //
+    // energy_sph_gen_ = new SpherePointSampler(energy_orad_ - energy_thickness_, energy_thickness_, G4ThreeVector(0., 0., energy_sph_zpos_),
+		// 			     0,	0., twopi, 180.*deg - energy_theta_, energy_theta_);
+    //
+    //
+    // plug_gen_ = new BoxPointSampler(plug_x_, plug_y_, plug_z_,0.,
+		// 		    G4ThreeVector(0.,0.,0.),0);
+    //
+    //
+    // // Calculating some probs
+    // G4double body_vol = ics_body_solid->GetCubicVolume();
+    // G4double tracking_vol = ics_tracking_solid->GetCubicVolume();
+    // G4double energy_cyl_vol = ics_energy_cyl_solid->GetCubicVolume();
+    // G4double energy_sph_vol = ics_energy_sph_solid->GetCubicVolume();
+    // G4double total_vol = body_vol + tracking_vol + energy_cyl_vol + energy_sph_vol;
+    //
+    // perc_body_vol_ = body_vol / total_vol;
+    // perc_tracking_vol_ = (body_vol + tracking_vol) / total_vol;
+    // perc_energy_cyl_vol_ = (body_vol + tracking_vol + energy_cyl_vol) / total_vol;
   }
 
 
@@ -251,63 +182,63 @@ namespace nexus {
   {
     G4ThreeVector vertex(0., 0., 0.);
 
-    // Vertex in the whole ICS volume
-    if (region == "ICS") {
-
-      G4double rand = G4UniformRand();
-
-      if (rand < perc_body_vol_){
-	vertex = body_gen_->GenerateVertex("BODY_VOL");        // Body
-      }
-
-
-      else if  (rand < perc_tracking_vol_){
-	G4VPhysicalVolume *VertexVolume;
-	do {
-	  vertex = tracking_gen_->GenerateVertex("BODY_VOL");    // Tracking plane
-	  // To check its volume, one needs to rotate and shift the vertex
-	  // because the check is done using global coordinates
-	  G4ThreeVector glob_vtx(vertex);
-	  // First rotate, then shift
-	  glob_vtx.rotate(pi, G4ThreeVector(0., 1., 0.));
-	  glob_vtx = glob_vtx + G4ThreeVector(0, 0, GetELzCoord());
-	  VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
-	} while (VertexVolume->GetName() != "ICS");
-      }
-
-      else if  (rand < perc_energy_cyl_vol_)
-	vertex = energy_cyl_gen_->GenerateVertex("BODY_VOL");  // Energy plane, cylindric section
-
-      else {
-	G4VPhysicalVolume *VertexVolume;
-	do {
-	  vertex = energy_sph_gen_->GenerateVertex("VOLUME");     // Energy plane, spherical section
-	  // To check its volume, one needs to rotate and shift the vertex
-	// because the check is done using global coordinates
-	G4ThreeVector glob_vtx(vertex);
-	// First rotate, then shift
-	glob_vtx.rotate(pi, G4ThreeVector(0., 1., 0.));
-	glob_vtx = glob_vtx + G4ThreeVector(0, 0, GetELzCoord());
-	  VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
-	} while (VertexVolume->GetName() != "ICS");
-      }
-    }
-
-    // PIGGY TAIL PLUG
-    else if (region == "DB_PLUG") {
-      G4ThreeVector ini_vertex = plug_gen_->GenerateVertex("INSIDE");
-      G4double rand = num_DBs_ * G4UniformRand();
-      G4ThreeVector db_pos = DB_positions_[int(rand)];
-      vertex = ini_vertex + db_pos;
-      vertex.setY(vertex.y()- 10.*mm);
-      vertex.setZ(vertex.z() + plug_posz_);
-    }
-
-
-    else {
-      G4Exception("[Next100Ics]", "GenerateVertex()", FatalException,
-		  "Unknown vertex generation region!");
-    }
+  //   // Vertex in the whole ICS volume
+  //   if (region == "ICS") {
+  //
+  //     G4double rand = G4UniformRand();
+  //
+  //     if (rand < perc_body_vol_){
+	// vertex = body_gen_->GenerateVertex("BODY_VOL");        // Body
+  //     }
+  //
+  //
+  //     else if  (rand < perc_tracking_vol_){
+	// G4VPhysicalVolume *VertexVolume;
+	// do {
+	//   vertex = tracking_gen_->GenerateVertex("BODY_VOL");    // Tracking plane
+	//   // To check its volume, one needs to rotate and shift the vertex
+	//   // because the check is done using global coordinates
+	//   G4ThreeVector glob_vtx(vertex);
+	//   // First rotate, then shift
+	//   glob_vtx.rotate(pi, G4ThreeVector(0., 1., 0.));
+	//   glob_vtx = glob_vtx + G4ThreeVector(0, 0, GetELzCoord());
+	//   VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
+	// } while (VertexVolume->GetName() != "ICS");
+  //     }
+  //
+  //     else if  (rand < perc_energy_cyl_vol_)
+	// vertex = energy_cyl_gen_->GenerateVertex("BODY_VOL");  // Energy plane, cylindric section
+  //
+  //     else {
+	// G4VPhysicalVolume *VertexVolume;
+	// do {
+	//   vertex = energy_sph_gen_->GenerateVertex("VOLUME");     // Energy plane, spherical section
+	//   // To check its volume, one needs to rotate and shift the vertex
+	// // because the check is done using global coordinates
+	// G4ThreeVector glob_vtx(vertex);
+	// // First rotate, then shift
+	// glob_vtx.rotate(pi, G4ThreeVector(0., 1., 0.));
+	// glob_vtx = glob_vtx + G4ThreeVector(0, 0, GetELzCoord());
+	//   VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
+	// } while (VertexVolume->GetName() != "ICS");
+  //     }
+  //   }
+  //
+  //   // PIGGY TAIL PLUG
+  //   else if (region == "DB_PLUG") {
+  //     G4ThreeVector ini_vertex = plug_gen_->GenerateVertex("INSIDE");
+  //     G4double rand = num_DBs_ * G4UniformRand();
+  //     G4ThreeVector db_pos = DB_positions_[int(rand)];
+  //     vertex = ini_vertex + db_pos;
+  //     vertex.setY(vertex.y()- 10.*mm);
+  //     vertex.setZ(vertex.z() + plug_posz_);
+  //   }
+  //
+  //
+  //   else {
+  //     G4Exception("[Next100Ics]", "GenerateVertex()", FatalException,
+	// 	  "Unknown vertex generation region!");
+  //   }
 
 
     return vertex;

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -128,6 +128,15 @@ namespace nexus {
                 port_b_Rot, G4ThreeVector(-port_x, port_y, lat_hole_z-length/2.));
 
 
+    /// ICS step at the TP end.
+    // This avoids overlap with sipm boards at high radious
+    G4double step_width = 38. * mm; // step lenght in the y dimension
+    G4Tubs* tp_step_solid = new G4Tubs("TP_STEP", (in_rad_ - offset), in_rad_ + step_width,
+                                       gate_tp_distance_, 0.*deg, 360.*deg);
+
+    ics_solid = new G4SubtractionSolid("ICS", ics_solid, tp_step_solid,
+                                      0, G4ThreeVector(0., 0., -length/2.+gate_tp_distance_/2.));
+
     G4LogicalVolume* ics_logic =
       new G4LogicalVolume(ics_solid,
         G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"), "ICS");

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -34,8 +34,8 @@ namespace nexus {
   Next100Ics::Next100Ics():
     GeometryBase(),
 
-    in_rad_   (56.0 * cm),
-    thickness_(12.0 * cm),
+    in_rad_   (55.465 * cm),
+    thickness_(12.0   * cm),
 
     visibility_ (0)
   {

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -39,10 +39,8 @@ namespace nexus {
   Next100Ics::Next100Ics():
     GeometryBase(),
 
-    // Body dimensions
-    body_in_rad_ (56.0  * cm),
-    body_length_ (160.0 * cm),
-    body_thickness_ (12.0 * cm),
+    in_rad_   (56.0 * cm),
+    thickness_(12.0 * cm),
 
     // Tracking plane dimensions  (thin version without substractions)
     tracking_length_ (10.0 * cm),
@@ -78,25 +76,26 @@ namespace nexus {
   {
 
     G4double gate_zpos = GetELzCoord();
+    length_ = gate_tp_distance_ + field_cage_length_;
 
     // Dice Boards holes positions
     GenerateDBPositions();
 
     // ICS
-    G4Tubs* ics_solid = new G4Tubs("ICS_BODY", body_in_rad_, body_in_rad_ + body_thickness_,
-					body_length_/2., 0.*deg, 360.*deg);
+    G4Tubs* ics_solid = new G4Tubs("ICS", in_rad_, in_rad_ + thickness_,
+                                   length_/2., 0.*deg, 360.*deg);
 
     G4LogicalVolume* ics_logic =
       new G4LogicalVolume(ics_solid,
 			  G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"), "ICS");
 
-    G4double ics_z_pos = gate_zpos + body_length_/2.;
+    G4double ics_z_pos = gate_zpos + length_/2. - gate_tp_distance_;
     new G4PVPlacement(0, G4ThreeVector(0., 0., ics_z_pos),
                       ics_logic, "ICS", mother_logic_, false, 0, false);
 
 
     ///// DB plugs placement
-    G4double ics_tracking_zpos = body_length_/2. - tracking_length_/2.;
+    G4double ics_tracking_zpos = length_/2. - tracking_length_/2.;
     G4Box* plug_solid = new G4Box("DB_PLUG", plug_x_/2., plug_y_/2., plug_z_/2.);
     G4LogicalVolume* plug_logic = new G4LogicalVolume(plug_solid,  materials::PEEK(), "DB_PLUG");
      plug_posz_ = ics_tracking_zpos + tracking_length_/2. + plug_z_ ;
@@ -125,109 +124,18 @@ namespace nexus {
   }
 
 
-    // // VERTEX GENERATORS   //////////
-    // body_gen_ =
-    //   new CylinderPointSampler(body_in_rad_, body_length_, body_thickness_, 0.);
-    //
-    // tracking_gen_ =
-    //   new CylinderPointSampler(0.*cm, tracking_length_, tracking_orad_, 0.,
-		// 			     G4ThreeVector(0., 0., ics_tracking_zpos));
-    //
-    // energy_cyl_gen_ =
-    //   new CylinderPointSampler(body_in_rad_, energy_cyl_length_, energy_thickness_, 0.,  G4ThreeVector(0., 0., energy_cyl_zpos));
-    //
-    // energy_sph_gen_ = new SpherePointSampler(energy_orad_ - energy_thickness_, energy_thickness_, G4ThreeVector(0., 0., energy_sph_zpos_),
-		// 			     0,	0., twopi, 180.*deg - energy_theta_, energy_theta_);
-    //
-    //
-    // plug_gen_ = new BoxPointSampler(plug_x_, plug_y_, plug_z_,0.,
-		// 		    G4ThreeVector(0.,0.,0.),0);
-    //
-    //
-    // // Calculating some probs
-    // G4double body_vol = ics_body_solid->GetCubicVolume();
-    // G4double tracking_vol = ics_tracking_solid->GetCubicVolume();
-    // G4double energy_cyl_vol = ics_energy_cyl_solid->GetCubicVolume();
-    // G4double energy_sph_vol = ics_energy_sph_solid->GetCubicVolume();
-    // G4double total_vol = body_vol + tracking_vol + energy_cyl_vol + energy_sph_vol;
-    //
-    // perc_body_vol_ = body_vol / total_vol;
-    // perc_tracking_vol_ = (body_vol + tracking_vol) / total_vol;
-    // perc_energy_cyl_vol_ = (body_vol + tracking_vol + energy_cyl_vol) / total_vol;
+    // VERTEX GENERATORS   //////////
   }
-
 
 
   Next100Ics::~Next100Ics()
   {
-    delete body_gen_;
-    delete plug_gen_;
   }
-
 
 
   G4ThreeVector Next100Ics::GenerateVertex(const G4String& region) const
   {
     G4ThreeVector vertex(0., 0., 0.);
-
-  //   // Vertex in the whole ICS volume
-  //   if (region == "ICS") {
-  //
-  //     G4double rand = G4UniformRand();
-  //
-  //     if (rand < perc_body_vol_){
-	// vertex = body_gen_->GenerateVertex("BODY_VOL");        // Body
-  //     }
-  //
-  //
-  //     else if  (rand < perc_tracking_vol_){
-	// G4VPhysicalVolume *VertexVolume;
-	// do {
-	//   vertex = tracking_gen_->GenerateVertex("BODY_VOL");    // Tracking plane
-	//   // To check its volume, one needs to rotate and shift the vertex
-	//   // because the check is done using global coordinates
-	//   G4ThreeVector glob_vtx(vertex);
-	//   // First rotate, then shift
-	//   glob_vtx.rotate(pi, G4ThreeVector(0., 1., 0.));
-	//   glob_vtx = glob_vtx + G4ThreeVector(0, 0, GetELzCoord());
-	//   VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
-	// } while (VertexVolume->GetName() != "ICS");
-  //     }
-  //
-  //     else if  (rand < perc_energy_cyl_vol_)
-	// vertex = energy_cyl_gen_->GenerateVertex("BODY_VOL");  // Energy plane, cylindric section
-  //
-  //     else {
-	// G4VPhysicalVolume *VertexVolume;
-	// do {
-	//   vertex = energy_sph_gen_->GenerateVertex("VOLUME");     // Energy plane, spherical section
-	//   // To check its volume, one needs to rotate and shift the vertex
-	// // because the check is done using global coordinates
-	// G4ThreeVector glob_vtx(vertex);
-	// // First rotate, then shift
-	// glob_vtx.rotate(pi, G4ThreeVector(0., 1., 0.));
-	// glob_vtx = glob_vtx + G4ThreeVector(0, 0, GetELzCoord());
-	//   VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
-	// } while (VertexVolume->GetName() != "ICS");
-  //     }
-  //   }
-  //
-  //   // PIGGY TAIL PLUG
-  //   else if (region == "DB_PLUG") {
-  //     G4ThreeVector ini_vertex = plug_gen_->GenerateVertex("INSIDE");
-  //     G4double rand = num_DBs_ * G4UniformRand();
-  //     G4ThreeVector db_pos = DB_positions_[int(rand)];
-  //     vertex = ini_vertex + db_pos;
-  //     vertex.setY(vertex.y()- 10.*mm);
-  //     vertex.setZ(vertex.z() + plug_posz_);
-  //   }
-  //
-  //
-  //   else {
-  //     G4Exception("[Next100Ics]", "GenerateVertex()", FatalException,
-	// 	  "Unknown vertex generation region!");
-  //   }
-
 
     return vertex;
   }

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -77,26 +77,26 @@ namespace nexus {
   void Next100Ics::Construct()
   {
 
+    G4double gate_zpos = GetELzCoord();
+
     // Dice Boards holes positions
     GenerateDBPositions();
 
-    // ICS SOLIDS  ///////////
-    // Body
+    // ICS
     G4Tubs* ics_solid = new G4Tubs("ICS_BODY", body_in_rad_, body_in_rad_ + body_thickness_,
 					body_length_/2., 0.*deg, 360.*deg);
-
-    // Unions of parts
-    G4double ics_tracking_zpos = body_length_/2. - tracking_length_/2.;
 
     G4LogicalVolume* ics_logic =
       new G4LogicalVolume(ics_solid,
 			  G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"), "ICS");
 
-    //this->SetLogicalVolume(ics_logic);
-    new G4PVPlacement(0, G4ThreeVector(0.,0.,0.), ics_logic, "ICS", mother_logic_, false, 0, false);
+    G4double ics_z_pos = gate_zpos + body_length_/2.;
+    new G4PVPlacement(0, G4ThreeVector(0., 0., ics_z_pos),
+                      ics_logic, "ICS", mother_logic_, false, 0, false);
 
 
     ///// DB plugs placement
+    G4double ics_tracking_zpos = body_length_/2. - tracking_length_/2.;
     G4Box* plug_solid = new G4Box("DB_PLUG", plug_x_/2., plug_y_/2., plug_z_/2.);
     G4LogicalVolume* plug_logic = new G4LogicalVolume(plug_solid,  materials::PEEK(), "DB_PLUG");
      plug_posz_ = ics_tracking_zpos + tracking_length_/2. + plug_z_ ;

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -36,11 +36,7 @@ namespace nexus {
 
   using namespace CLHEP;
 
-  Next100Ics::Next100Ics(const G4double nozzle_ext_diam,
-			 const G4double up_nozzle_ypos,
-			 const G4double central_nozzle_ypos,
-			 const G4double down_nozzle_ypos,
-			 const G4double bottom_nozzle_ypos):
+  Next100Ics::Next100Ics():
     GeometryBase(),
 
     // Body dimensions
@@ -62,14 +58,6 @@ namespace nexus {
 
     visibility_ (0)
   {
-
-    /// Needed External variables
-    nozzle_ext_diam_ = nozzle_ext_diam;
-    up_nozzle_ypos_ = up_nozzle_ypos;
-    central_nozzle_ypos_ = central_nozzle_ypos;
-    down_nozzle_ypos_ = down_nozzle_ypos;
-    bottom_nozzle_ypos_ = bottom_nozzle_ypos;
-
 
     // Initializing the geometry navigator (used in vertex generation)
     geom_navigator_ = G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking();

--- a/source/geometries/Next100Ics.h
+++ b/source/geometries/Next100Ics.h
@@ -34,7 +34,6 @@ namespace nexus {
 
     void SetELtoTPdistance(G4double);
     void SetELtoSapphireWDWdistance(G4double);
-    void SetFieldCageLength(G4double length);
     void SetPortZpositions(G4double port_positions[]);
 
     /// Generate a vertex within a given region of the geometry
@@ -49,7 +48,6 @@ namespace nexus {
 
     // Dimensions
     G4double gate_tp_distance_, gate_sapphire_wdw_dist_;
-    G4double field_cage_length_;
     G4double in_rad_, thickness_;
     G4double port_z_1a_, port_z_2a_, port_z_1b_, port_z_2b_;
 
@@ -73,10 +71,6 @@ namespace nexus {
 
   inline void Next100Ics::SetELtoSapphireWDWdistance(G4double distance){
     gate_sapphire_wdw_dist_ = distance;
-  }
-
-  inline void Next100Ics::SetFieldCageLength(G4double length){
-    field_cage_length_ = length;
   }
 
 } // end namespace nexus

--- a/source/geometries/Next100Ics.h
+++ b/source/geometries/Next100Ics.h
@@ -18,9 +18,7 @@ class G4GenericMessenger;
 
 namespace nexus {
 
-  class CylinderPointSampler;
-  class SpherePointSampler;
-  class BoxPointSampler;
+  class CylinderPointSampler2020;
 
   class Next100Ics: public GeometryBase
   {
@@ -65,8 +63,7 @@ namespace nexus {
     G4bool visibility_;
 
     // Vertex generators
-    CylinderPointSampler* body_gen_;
-    BoxPointSampler* plug_gen_;
+    CylinderPointSampler2020* ics_gen_;
 
     // Geometry Navigator
     G4Navigator* geom_navigator_;

--- a/source/geometries/Next100Ics.h
+++ b/source/geometries/Next100Ics.h
@@ -32,7 +32,8 @@ namespace nexus {
     /// Sets the Logical Volume where ICS will be placed
     void SetLogicalVolume(G4LogicalVolume* mother_logic);
 
-    void SetELtoTPdistance(G4double z);
+    void SetELtoTPdistance(G4double);
+    void SetELtoSapphireWDWdistance(G4double);
     void SetFieldCageLength(G4double length);
     void SetPortZpositions(G4double port_positions[]);
 
@@ -47,7 +48,8 @@ namespace nexus {
     G4LogicalVolume* mother_logic_;
 
     // Dimensions
-    G4double gate_tp_distance_, field_cage_length_;
+    G4double gate_tp_distance_, gate_sapphire_wdw_dist_;
+    G4double field_cage_length_;
     G4double in_rad_, length_, thickness_;
     G4double port_z_1a_, port_z_2a_, port_z_1b_, port_z_2b_;
 
@@ -65,13 +67,17 @@ namespace nexus {
 
   };
 
-  inline void Next100Ics::SetELtoTPdistance(G4double z){
-    gate_tp_distance_ = z;
-  };
+  inline void Next100Ics::SetELtoTPdistance(G4double distance){
+    gate_tp_distance_ = distance;
+  }
+
+  inline void Next100Ics::SetELtoSapphireWDWdistance(G4double distance){
+    gate_sapphire_wdw_dist_ = distance;
+  }
 
   inline void Next100Ics::SetFieldCageLength(G4double length){
     field_cage_length_ = length;
-  };
+  }
 
 } // end namespace nexus
 

--- a/source/geometries/Next100Ics.h
+++ b/source/geometries/Next100Ics.h
@@ -36,6 +36,7 @@ namespace nexus {
 
     void SetELtoTPdistance(G4double z);
     void SetFieldCageLength(G4double length);
+    void SetPortZpositions(G4double port_positions[]);
 
     /// Generate a vertex within a given region of the geometry
     G4ThreeVector GenerateVertex(const G4String& region) const;
@@ -54,6 +55,7 @@ namespace nexus {
     G4double gate_tp_distance_, field_cage_length_;
     G4double in_rad_, length_, thickness_;
     G4double tracking_length_;
+    G4double port_z_1a_, port_z_2a_, port_z_1b_, port_z_2b_;
     G4double plug_x_, plug_y_, plug_z_, plug_posz_;
     G4double DB_columns_, num_DBs_;
 

--- a/source/geometries/Next100Ics.h
+++ b/source/geometries/Next100Ics.h
@@ -26,11 +26,7 @@ namespace nexus {
   {
   public:
     /// Constructor
-    Next100Ics(const G4double nozzle_ext_diam,
-	       const G4double up_nozzle_ypos,
-	       const G4double central_nozzle_ypos,
-	       const G4double down_nozzle_ypos,
-	       const G4double bottom_nozzle_ypos);
+    Next100Ics();
 
     /// Destructor
     ~Next100Ics();
@@ -57,12 +53,7 @@ namespace nexus {
     G4double plug_x_, plug_y_, plug_z_, plug_posz_;
     G4double DB_columns_, num_DBs_;
 
-    // Dimensions coming from outside
-    G4double nozzle_ext_diam_, up_nozzle_ypos_, central_nozzle_ypos_;
-    G4double down_nozzle_ypos_, bottom_nozzle_ypos_;
-
     std::vector<G4ThreeVector> DB_positions_;
-
 
     // Visibility of the shielding
     G4bool visibility_;

--- a/source/geometries/Next100Ics.h
+++ b/source/geometries/Next100Ics.h
@@ -50,7 +50,7 @@ namespace nexus {
     // Dimensions
     G4double gate_tp_distance_, gate_sapphire_wdw_dist_;
     G4double field_cage_length_;
-    G4double in_rad_, length_, thickness_;
+    G4double in_rad_, thickness_;
     G4double port_z_1a_, port_z_2a_, port_z_1b_, port_z_2b_;
 
     // Visibility of the shielding

--- a/source/geometries/Next100Ics.h
+++ b/source/geometries/Next100Ics.h
@@ -43,26 +43,18 @@ namespace nexus {
     void Construct();
 
   private:
-    void GenerateDBPositions();
-
-
-  private:
     // Mother Logical Volume of the ICS
     G4LogicalVolume* mother_logic_;
 
+    // Dimensions
     G4double gate_tp_distance_, field_cage_length_;
     G4double in_rad_, length_, thickness_;
-    G4double tracking_length_;
     G4double port_z_1a_, port_z_2a_, port_z_1b_, port_z_2b_;
-    G4double plug_x_, plug_y_, plug_z_, plug_posz_;
-    G4double DB_columns_, num_DBs_;
-
-    std::vector<G4ThreeVector> DB_positions_;
 
     // Visibility of the shielding
     G4bool visibility_;
 
-    // Vertex generators
+    // Vertex generator
     CylinderPointSampler2020* ics_gen_;
 
     // Geometry Navigator

--- a/source/geometries/Next100Ics.h
+++ b/source/geometries/Next100Ics.h
@@ -53,11 +53,9 @@ namespace nexus {
     G4LogicalVolume* mother_logic_;
     // Dimensions
     G4double body_in_rad_, body_length_, body_thickness_;
-    G4double tracking_orad_, tracking_length_;
+    G4double tracking_length_;
     G4double plug_x_, plug_y_, plug_z_, plug_posz_;
     G4double DB_columns_, num_DBs_;
-    //    G4double tracking_cone_height_, tracking_irad_;
-    G4double energy_theta_, energy_orad_, energy_thickness_, energy_sph_zpos_, energy_cyl_length_;
 
     // Dimensions coming from outside
     G4double nozzle_ext_diam_, up_nozzle_ypos_, central_nozzle_ypos_;

--- a/source/geometries/Next100Ics.h
+++ b/source/geometries/Next100Ics.h
@@ -34,6 +34,9 @@ namespace nexus {
     /// Sets the Logical Volume where ICS will be placed
     void SetLogicalVolume(G4LogicalVolume* mother_logic);
 
+    void SetELtoTPdistance(G4double z);
+    void SetFieldCageLength(G4double length);
+
     /// Generate a vertex within a given region of the geometry
     G4ThreeVector GenerateVertex(const G4String& region) const;
 
@@ -47,8 +50,9 @@ namespace nexus {
   private:
     // Mother Logical Volume of the ICS
     G4LogicalVolume* mother_logic_;
-    // Dimensions
-    G4double body_in_rad_, body_length_, body_thickness_;
+
+    G4double gate_tp_distance_, field_cage_length_;
+    G4double in_rad_, length_, thickness_;
     G4double tracking_length_;
     G4double plug_x_, plug_y_, plug_z_, plug_posz_;
     G4double DB_columns_, num_DBs_;
@@ -60,12 +64,7 @@ namespace nexus {
 
     // Vertex generators
     CylinderPointSampler* body_gen_;
-    CylinderPointSampler* tracking_gen_;
-    CylinderPointSampler* energy_cyl_gen_;
-    SpherePointSampler*   energy_sph_gen_;
     BoxPointSampler* plug_gen_;
-
-    G4double perc_body_vol_, perc_tracking_vol_, perc_energy_cyl_vol_;
 
     // Geometry Navigator
     G4Navigator* geom_navigator_;
@@ -73,6 +72,14 @@ namespace nexus {
     // Messenger for the definition of control commands
     G4GenericMessenger* msg_;
 
+  };
+
+  inline void Next100Ics::SetELtoTPdistance(G4double z){
+    gate_tp_distance_ = z;
+  };
+
+  inline void Next100Ics::SetFieldCageLength(G4double length){
+    field_cage_length_ = length;
   };
 
 } // end namespace nexus

--- a/source/geometries/Next100InnerElements.cc
+++ b/source/geometries/Next100InnerElements.cc
@@ -30,9 +30,6 @@ namespace nexus {
     mother_logic_(nullptr),
     mother_phys_ (nullptr),
     gas_(nullptr),
-    field_cage_    (new Next100FieldCage()),
-    energy_plane_  (new Next100EnergyPlane()),
-    tracking_plane_(new Next100TrackingPlane(gate_tracking_plane_distance_)),
     msg_(nullptr)
   {
     // Messenger
@@ -55,6 +52,11 @@ namespace nexus {
 
   void Next100InnerElements::Construct()
   {
+
+    field_cage_     = new Next100FieldCage();
+    energy_plane_   = new Next100EnergyPlane();
+    tracking_plane_ = new Next100TrackingPlane(gate_tracking_plane_distance_);
+
     // Position in Z of the beginning of the drift region
     G4double gate_zpos = GetELzCoord();
     // Reading mother material
@@ -66,6 +68,7 @@ namespace nexus {
     field_cage_->SetMotherLogicalVolume(mother_logic_);
     field_cage_->SetMotherPhysicalVolume(mother_phys_);
     field_cage_->SetELzCoord(gate_zpos);
+    field_cage_->SetELtoSapphireWDWdistance(gate_sapphire_wdw_distance_);
     field_cage_->Construct();
 
     // Energy Plane

--- a/source/geometries/Next100InnerElements.cc
+++ b/source/geometries/Next100InnerElements.cc
@@ -27,8 +27,6 @@ namespace nexus {
 
   Next100InnerElements::Next100InnerElements():
     GeometryBase(),
-    gate_sapphire_wdw_distance_  (1460.5 * mm), // active length + cathode thickness + buffer length
-    gate_tracking_plane_distance_(35. * mm), //to be confirmed
     mother_logic_(nullptr),
     mother_phys_ (nullptr),
     gas_(nullptr),

--- a/source/geometries/Next100InnerElements.cc
+++ b/source/geometries/Next100InnerElements.cc
@@ -30,6 +30,9 @@ namespace nexus {
     mother_logic_(nullptr),
     mother_phys_ (nullptr),
     gas_(nullptr),
+    field_cage_    (new Next100FieldCage()),
+    energy_plane_  (new Next100EnergyPlane()),
+    tracking_plane_(new Next100TrackingPlane()),
     msg_(nullptr)
   {
     // Messenger
@@ -52,11 +55,6 @@ namespace nexus {
 
   void Next100InnerElements::Construct()
   {
-
-    field_cage_     = new Next100FieldCage();
-    energy_plane_   = new Next100EnergyPlane();
-    tracking_plane_ = new Next100TrackingPlane(gate_tracking_plane_distance_);
-
     // Position in Z of the beginning of the drift region
     G4double gate_zpos = GetELzCoord();
     // Reading mother material
@@ -80,6 +78,7 @@ namespace nexus {
     // Tracking plane
     tracking_plane_->SetMotherPhysicalVolume(mother_phys_);
     tracking_plane_->SetELzCoord(gate_zpos);
+    tracking_plane_->SetELtoTPdistance(gate_tracking_plane_distance_);
     tracking_plane_->Construct();
   }
 

--- a/source/geometries/Next100InnerElements.h
+++ b/source/geometries/Next100InnerElements.h
@@ -39,6 +39,8 @@ namespace nexus {
     /// Set the logical and physical volume that encloses the entire geometry
     void SetLogicalVolume(G4LogicalVolume*);
     void SetPhysicalVolume(G4VPhysicalVolume*);
+    void SetELtoTPdistance(G4double);
+    void SetELtoSapphireWDWdistance(G4double);
 
     /// Return the relative position respect to the rest of NEXT100 geometry
     G4ThreeVector GetPosition() const;
@@ -52,8 +54,8 @@ namespace nexus {
 
   private:
 
-    const G4double gate_sapphire_wdw_distance_;
-    const G4double gate_tracking_plane_distance_;
+    G4double gate_sapphire_wdw_distance_;
+    G4double gate_tracking_plane_distance_;
 
 
     G4LogicalVolume* mother_logic_;
@@ -72,6 +74,14 @@ namespace nexus {
     G4GenericMessenger* msg_;
 
   };
+
+  inline void Next100InnerElements::SetELtoTPdistance(G4double distance){
+    gate_tracking_plane_distance_ = distance;
+  }
+
+  inline void Next100InnerElements::SetELtoSapphireWDWdistance(G4double distance){
+    gate_sapphire_wdw_distance_ = distance;
+  }
 
 } // end namespace nexus
 

--- a/source/geometries/Next100OpticalGeometry.cc
+++ b/source/geometries/Next100OpticalGeometry.cc
@@ -33,6 +33,9 @@ namespace nexus {
   REGISTER_CLASS(Next100OpticalGeometry, GeometryBase)
 
   Next100OpticalGeometry::Next100OpticalGeometry(): GeometryBase(),
+                // common used variables in geomety components
+                gate_tracking_plane_distance_(35. * mm), // to be confirmed
+                gate_sapphire_wdw_distance_  (1460.5 * mm),
 						    pressure_(15. * bar),
 						    temperature_ (300 * kelvin),
 						    sc_yield_(25510. * 1/MeV),
@@ -137,6 +140,8 @@ namespace nexus {
   inner_elements_->SetLogicalVolume(gas_logic);
   inner_elements_->SetPhysicalVolume(gas_phys);
   inner_elements_->SetELzCoord(gate_zpos_in_gas_);
+  inner_elements_->SetELtoSapphireWDWdistance(gate_sapphire_wdw_distance_);
+  inner_elements_->SetELtoTPdistance         (gate_tracking_plane_distance_);
   inner_elements_->Construct();
 
   // Visibilities

--- a/source/geometries/Next100OpticalGeometry.h
+++ b/source/geometries/Next100OpticalGeometry.h
@@ -42,6 +42,7 @@ namespace nexus {
     // Messenger for the definition of control commands
     G4GenericMessenger* msg_;
 
+    G4double gate_tracking_plane_distance_, gate_sapphire_wdw_distance_;
     G4double pressure_;
     G4double temperature_;
     G4double sc_yield_;

--- a/source/geometries/Next100TrackingPlane.cc
+++ b/source/geometries/Next100TrackingPlane.cc
@@ -23,9 +23,8 @@
 using namespace nexus;
 
 
-Next100TrackingPlane::Next100TrackingPlane(G4double origin_z_coord):
+Next100TrackingPlane::Next100TrackingPlane():
   GeometryBase(),
-  z0_(origin_z_coord), // Distance between gate and inner face of copper plate
   copper_plate_diameter_  (1340.*mm),
   copper_plate_thickness_ ( 120.*mm),
   distance_board_board_   (   1.*mm),
@@ -72,7 +71,7 @@ void Next100TrackingPlane::Construct()
                         G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"),
                         copper_plate_name);
 
-  G4double zpos = GetELzCoord() - z0_ - copper_plate_thickness_/2.;
+  G4double zpos = GetELzCoord() - gate_tp_dist_ - copper_plate_thickness_/2.;
 
   G4VPhysicalVolume* copper_plate_phys_vol =
     new G4PVPlacement(nullptr, G4ThreeVector(0.,0.,zpos),
@@ -87,7 +86,7 @@ void Next100TrackingPlane::Construct()
   sipm_board_geom_->Construct();
   G4LogicalVolume* sipm_board_logic_vol = sipm_board_geom_->GetLogicalVolume();
 
-  zpos = GetELzCoord() - z0_ + sipm_board_geom_->GetThickness()/2.;
+  zpos = GetELzCoord() - gate_tp_dist_ + sipm_board_geom_->GetThickness()/2.;
 
   // SiPM boards are positioned bottom (negative Y) to top (positive Y)
   // and left (negative X) to right (positive X).

--- a/source/geometries/Next100TrackingPlane.h
+++ b/source/geometries/Next100TrackingPlane.h
@@ -27,11 +27,12 @@ namespace nexus {
   {
   public:
     // Constructor
-    Next100TrackingPlane(G4double origin_z_coord=0.);
+    Next100TrackingPlane();
     // Destructor
     ~Next100TrackingPlane();
     //
     void SetMotherPhysicalVolume(G4VPhysicalVolume*);
+    void SetELtoTPdistance(G4double);
     //
     void Construct() override;
     //
@@ -43,7 +44,7 @@ namespace nexus {
     void PlaceSiPMBoardColumns(G4int, G4double, G4double, G4int&, G4LogicalVolume*);
 
   private:
-    const G4double z0_; // Z position of origin of coordinates
+    G4double gate_tp_dist_;
     const G4double copper_plate_diameter_, copper_plate_thickness_;
     const G4double distance_board_board_;
 
@@ -62,6 +63,10 @@ namespace nexus {
 
   inline void Next100TrackingPlane::SetMotherPhysicalVolume(G4VPhysicalVolume* p)
   { mpv_ = p; }
+
+  inline void Next100TrackingPlane::SetELtoTPdistance(G4double distance){
+    gate_tp_dist_ = distance;
+  }
 
 } // namespace nexus
 

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -56,17 +56,13 @@ namespace nexus {
     endcap_in_z_width_   (15.6   * cm),
     endcap_gate_distance_(48.62  * cm),
 
-    // Ports (values set on Construct())
+    // Ports
     port_base_height_(37. * mm),
-    port_tube_height_(port_base_height_), // preliminar
+    port_tube_height_(154.* mm),
     // They are defined global because are needed at the vertex generation
     port_x_ ((vessel_in_rad_ + port_base_height_ - port_tube_height_/2.)/sqrt(2.)), // inner port pos
     port_y_ (port_x_),
     source_height_ (5. * mm), // preliminar
-    port_z_1a_ (0.), // defined in the Construct()
-    port_z_1b_ (0.),
-    port_z_2a_ (0.),
-    port_z_2b_ (0.),
 
     // // Nozzle dimensions
     // large_nozzle_length_ (250.0 * cm),
@@ -494,6 +490,11 @@ namespace nexus {
     }
 
     return vertex;
+  }
+
+  G4double* Next100Vessel::GetPortZpositions(){
+    static G4double port_positions[]{port_z_1a_, port_z_2a_, port_z_1b_, port_z_2b_};
+    return port_positions;
   }
 
 } //end namespace nexus

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -42,6 +42,9 @@ namespace nexus {
     G4LogicalVolume* GetInternalLogicalVolume();
     G4VPhysicalVolume* GetInternalPhysicalVolume();
 
+    // get Z position of calibration ports
+    G4double* GetPortZpositions();
+
     /// Builder
     void Construct();
 


### PR DESCRIPTION
This PR review the Next-100 ICS. The ICS was almost completely rewritted, since the current designs are different from what was implemented before. As usual, the dimensions in the code are obtained from 2D if possible, if not they are meassured in the 3D drawings. 2D drawings provided by Jordi can be found below.
[copper_bars.pdf](https://github.com/next-exp/nexus/files/7115666/01-00.DRAWINGS.OF.COPPER.BARS.1.TO.7.pdf)
[dimensions.png](https://user-images.githubusercontent.com/35993868/132211404-7317d6cb-e3d6-4e80-b297-c40e528ff56c.png)

The changes are substantial in the ICS implementation:
- Delete copper plate from the energy and tracking planes and corresponding nozzle holes. The copper plates are already included in its respective classes.
- Remove dice board plugs. These will be likely included in the tracking plane PR.
- Implement ICS holes in calibration ports and feedthroughts. Also extend the calibration ports inside the copper plate througout the hole (see vessel PR slides).
- Implement vertex generator for the new ICS.

Importantly since it overlaps with PR #118: `gate_tp_distance_` variable and field-cage length are needed to built the ICS. The first variable is set as global in `Next100.cc` and setted (`SetELtoTPdistance`) in `ics_` instance. The same should be made for `inner_elements_` to be consistent. For the field-cage-length a getter would be required from `inner_elements_`, its value is preeliminary hardcoded.