### PR TITLE
Fix test code following latest changes in xenon properties

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -323,7 +323,8 @@ WriteNexusConfig(w_prefix_dir)
 env.Execute(Chmod(w_prefix_dir+'/bin/nexus-config', 0o755))
 nexus = env.Program('bin/nexus', ['source/nexus.cc']+src)
 
-TSTDIR = ['utils',
+TSTDIR = ['materials',
+          'utils',
           'example']
 TSTDIR = ['source/tests/' + dir for dir in TSTDIR]
 

--- a/source/tests/materials/XenonGasPropertiesTests.cc
+++ b/source/tests/materials/XenonGasPropertiesTests.cc
@@ -6,39 +6,37 @@
 
 
 TEST_CASE("XenonProperties::MakeDataTable"){
-  auto props = nexus::XenonProperties();
-  REQUIRE_NOTHROW(props.MakeDataTable());
+  std::vector<std::vector<G4double>> data;
+  REQUIRE_NOTHROW(MakeXeDensityDataTable(data));
 }
 
 TEST_CASE("XenonProperties::Density") {
   // These tests check that the XenonProperties class correctly finds
   // the density of xenon given a temperature and pressure.
 
-  auto props = nexus::XenonProperties();
-
   SECTION ("Density Calculation"){
     Approx target = Approx(87.836).epsilon(0.01);
-    G4double density = props.GetGasDensity(15 * bar, 295 * kelvin);
+    G4double density = GetGasDensity(15 * bar, 295 * kelvin);
     REQUIRE (density/(kg/m3) == target);
   }
 
   SECTION ("Pressure is too big") {
-    REQUIRE_THROWS (props.GetGasDensity(51 * bar, 295 * kelvin),
+    REQUIRE_THROWS (GetGasDensity(51 * bar, 295 * kelvin),
                     "Unknown xenon density for this pressure");
   }
 
   SECTION ("Pressure is too small") {
-    REQUIRE_THROWS (props.GetGasDensity(-15 * bar, 295 * kelvin),
+    REQUIRE_THROWS (GetGasDensity(-15 * bar, 295 * kelvin),
                     "Unknown xenon density for this pressure");
   }
 
   SECTION ("Temperature is too big"){
-    REQUIRE_THROWS (props.GetGasDensity(15 * bar, 410 * kelvin),
+    REQUIRE_THROWS (GetGasDensity(15 * bar, 410 * kelvin),
                     "Unknown xenon density for this temperature");
   }
 
   SECTION ("Temperature is too small"){
-    REQUIRE_THROWS (props.GetGasDensity(15 * bar, -295 * kelvin),
+    REQUIRE_THROWS (GetGasDensity(15 * bar, -295 * kelvin),
                     "Unknown xenon density for this temperature");
   }
 


### PR DESCRIPTION
This PR fixes a problem with the code of a test, which had not been adapted to the latest changes in the material-related classes. The issue had gone unnoticed so far because that test was not included in the `scons` compilation. This PR also fixes the compilation.