### PR TITLE
Next100 cleanup and fixes

### DIFF
--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -41,13 +41,6 @@ namespace nexus {
     gate_tracking_plane_distance_(30. * mm), // to be confirmed
     gate_sapphire_wdw_distance_  (1460.5 * mm),
 
-    // Nozzles external diam and y positions
-    nozzle_ext_diam_ (9. * cm),
-    up_nozzle_ypos_ (20. * cm),
-    central_nozzle_ypos_ (0. * cm),
-    down_nozzle_ypos_ (-20. * cm),
-    bottom_nozzle_ypos_(-53. * cm),
-
     specific_vertex_{},
     lab_walls_(false)
   {
@@ -70,8 +63,7 @@ namespace nexus {
   hallA_walls_ = new LSCHallA();
 
   // Vessel
-  vessel_ = new Next100Vessel(nozzle_ext_diam_, up_nozzle_ypos_, central_nozzle_ypos_,
-			      down_nozzle_ypos_, bottom_nozzle_ypos_);
+  vessel_ = new Next100Vessel();
 
   // Internal copper shielding
   ics_ = new Next100Ics();

--- a/source/geometries/Next100.h
+++ b/source/geometries/Next100.h
@@ -49,10 +49,6 @@ namespace nexus {
     const G4double lab_size_;          /// Size of the air box containing the detector
     const G4double gate_tracking_plane_distance_, gate_sapphire_wdw_distance_;
 
-    // External diameter of nozzles and y positions
-    const G4double nozzle_ext_diam_;
-    const G4double up_nozzle_ypos_, central_nozzle_ypos_, down_nozzle_ypos_, bottom_nozzle_ypos_;
-
     // Pointers to logical volumes
     G4LogicalVolume* lab_logic_;
     G4LogicalVolume* buffer_gas_logic_;

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -241,8 +241,8 @@ void Next100FieldCage::DefineMaterials()
   /// High density polyethylene for the field cage
   hdpe_ = materials::HDPE();
 
-  /// PE1000 for the holders
-  pe1000_ = materials::PE1000();
+  /// PE500 for the holders
+  pe500_ = materials::PE500();
 
   /// Copper for field rings
   copper_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
@@ -794,7 +794,7 @@ void Next100FieldCage::BuildFieldCage()
     }
 
   G4LogicalVolume* act_holder_logic =
-    new G4LogicalVolume(act_holder_solid,pe1000_,"ACT_HOLDER");
+    new G4LogicalVolume(act_holder_solid, pe500_, "ACT_HOLDER");
   G4int numbering=0;
   for (G4int i=10; i<360; i +=20){
     G4RotationMatrix* rot = new G4RotationMatrix();
@@ -837,7 +837,7 @@ void Next100FieldCage::BuildFieldCage()
                                      teflon_buffer_length_/2. - buffer_last_z/2.));
 
     G4LogicalVolume* buff_holder_logic =
-      new G4LogicalVolume(buff_holder_solid,pe1000_, "BUFF_HOLDER");
+      new G4LogicalVolume(buff_holder_solid, pe500_, "BUFF_HOLDER");
 
     numbering=0;
     for (G4int i=10; i<360; i +=20){
@@ -869,7 +869,7 @@ void Next100FieldCage::BuildFieldCage()
                                       -(cathode_long_z/2.-cathode_short_z/2.)));
 
     G4LogicalVolume* cathode_holder_logic =
-      new G4LogicalVolume(cathode_holder_solid,pe1000_, "CATHODE_HOLDER");
+      new G4LogicalVolume(cathode_holder_solid, pe500_, "CATHODE_HOLDER");
 
     numbering=0;
     G4double cathode_holder_r = (active_diam_+2*teflon_thickn_+ 2*holder_long_y_+

--- a/source/geometries/Next100FieldCage.h
+++ b/source/geometries/Next100FieldCage.h
@@ -114,7 +114,7 @@ namespace nexus {
 
     // Pointers to materials definition
     G4Material* hdpe_;
-    G4Material* pe1000_;
+    G4Material* pe500_;
     G4Material* tpb_;
     G4Material* teflon_;
     G4Material* copper_;

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -97,24 +97,28 @@ namespace nexus {
 
     /// Upper holes
     // z distances measured with respect to TP plate, ie the start of ICS
-    G4double upp_hole_rad = 31.  * mm;
+    G4double upp_hole_1_rad = 31. * mm;
+    G4double upp_hole_2_rad = 71. * mm;
     G4double upp_hole_1_z = 313. * mm;
-    G4double upp_hole_2_z = 313. * mm + 919. * mm;
+    G4double upp_hole_2_z = upp_hole_1_z + 906.5 * mm;
 
     G4RotationMatrix* port_upp_Rot = new G4RotationMatrix;
     port_upp_Rot->rotateX( 90. * deg);
 
-    G4Tubs* upp_hole_solid = new G4Tubs("UPP_HOLE", 0., upp_hole_rad,
+    G4Tubs* upp_hole_solid_1 = new G4Tubs("UPP_HOLE", 0., upp_hole_1_rad,
                                         (thickness_ + offset)/2., 0.*deg, 360.*deg);
 
-    ics_solid = new G4SubtractionSolid("ICS", ics_solid, upp_hole_solid,
+    ics_solid = new G4SubtractionSolid("ICS", ics_solid, upp_hole_solid_1,
                 port_upp_Rot, G4ThreeVector(0, (in_rad_ + thickness_/2.), upp_hole_1_z-length/2.));
 
-    ics_solid = new G4SubtractionSolid("ICS", ics_solid, upp_hole_solid,
+    G4Tubs* upp_hole_solid_2 = new G4Tubs("UPP_HOLE", 0., upp_hole_2_rad,
+                                        (thickness_ + offset)/2., 0.*deg, 360.*deg);
+
+    ics_solid = new G4SubtractionSolid("ICS", ics_solid, upp_hole_solid_2,
                 port_upp_Rot, G4ThreeVector(0, (in_rad_ + thickness_/2.), upp_hole_2_z-length/2.));
 
     /// Lateral holes
-    G4double lat_hole_rad = upp_hole_rad;
+    G4double lat_hole_rad = upp_hole_1_rad;
     G4double lat_hole_z   = 58.1 * mm;
 
     G4Tubs* lat_hole_solid = new G4Tubs("LAT_HOLE", 0., lat_hole_rad,

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -35,11 +35,7 @@ namespace nexus {
 
   using namespace CLHEP;
 
-  Next100Vessel::Next100Vessel(const G4double nozzle_ext_diam,
-			       const G4double up_nozzle_ypos,
-			       const G4double central_nozzle_ypos,
-			       const G4double down_nozzle_ypos,
-			       const G4double bottom_nozzle_ypos):
+  Next100Vessel::Next100Vessel():
     GeometryBase(),
 
     // general vessel dimensions
@@ -65,10 +61,6 @@ namespace nexus {
     port_y_ (port_x_),
     source_height_ (5. * mm), // preliminar
 
-    // // Nozzle dimensions
-    // large_nozzle_length_ (250.0 * cm),
-    // small_nozzle_length_ (240.0 * cm),
-
     // Vessel gas
     sc_yield_(16670. * 1/MeV),
     e_lifetime_(1000. * ms),
@@ -80,13 +72,6 @@ namespace nexus {
     helium_mass_num_(4),
     xe_perc_(100.)
   {
-
-    /// Needed External variables
-    nozzle_ext_diam_ = nozzle_ext_diam;
-    up_nozzle_ypos_ = up_nozzle_ypos;
-    central_nozzle_ypos_ = central_nozzle_ypos;
-    down_nozzle_ypos_ = down_nozzle_ypos;
-    bottom_nozzle_ypos_ = bottom_nozzle_ypos;
 
     // Initializing the geometry navigator (used in vertex generation)
     geom_navigator_ = G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking();
@@ -184,20 +169,6 @@ namespace nexus {
     G4Tubs* port_tube_gas_solid = new G4Tubs("PORT_TUBE_GAS", 0., port_tube_rad,
                                              port_tube_height_/2., 0.*deg, 360.*deg);
 
-    // // Nozzle solids
-    // G4Tubs* large_nozzle_solid = new G4Tubs("LARGE_NOZZLE", 0.*cm, nozzle_ext_diam_/2.,
-		// 			    large_nozzle_length_/2., 0.*deg, 360.*deg);
-    //
-    // G4Tubs* small_nozzle_solid = new G4Tubs("SMALL_NOZZLE", 0.*cm, nozzle_ext_diam_/2.,
-		// 			    small_nozzle_length_/2., 0.*deg, 360.*deg);
-    //
-    // G4Tubs* large_nozzle_gas_solid = new G4Tubs("LARGE_NOZZLE_GAS", 0.*cm, (nozzle_ext_diam_/2. - vessel_thickness_),
-		// 				large_nozzle_length_/2., 0.*deg, 360.*deg);
-    //
-    // G4Tubs* small_nozzle_gas_solid = new G4Tubs("SMALL_NOZZLE_GAS", 0.*cm, (nozzle_ext_diam_/2. - vessel_thickness_),
-		// 				small_nozzle_length_/2., 0.*deg, 360.*deg);
-
-
     //// Unions
     G4double endcap_z_pos = (body_length_ / 2.) + endcap_in_z_width_ - endcap_in_rad_;
     G4ThreeVector energy_endcap_pos  (0, 0,  endcap_z_pos);
@@ -253,17 +224,6 @@ namespace nexus {
     vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, port_solid,
                                     port_b_Rot, G4ThreeVector(-port_nozzle_x, port_nozzle_y, port_z_2b_));
 
-    // // Adding nozzles
-    // vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, small_nozzle_solid,
-		// 		    0, G4ThreeVector(0., up_nozzle_ypos_, 0.) );
-    // vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, large_nozzle_solid,
-		// 		    0, G4ThreeVector(0., central_nozzle_ypos_, 0.) );
-    // vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, large_nozzle_solid,
-		// 		    0, G4ThreeVector(0., down_nozzle_ypos_, 0.) );
-    // vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, small_nozzle_solid,
-		// 		    0, G4ThreeVector(0., bottom_nozzle_ypos_, 0.) );
-
-
     // Body gas + Energy endcap gas
     G4UnionSolid* vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_body_solid,
 						      vessel_gas_endcap_solid, 0, energy_endcap_pos);
@@ -284,16 +244,6 @@ namespace nexus {
                                         port_b_Rot, G4ThreeVector(-port_gas_x, port_gas_y, port_z_1b_));
     vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, port_gas_solid,
                                         port_b_Rot, G4ThreeVector(-port_gas_x, port_gas_y, port_z_2b_));
-    // // Adding nozzles
-    // vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, small_nozzle_gas_solid,
-		// 			0, G4ThreeVector(0., up_nozzle_ypos_, 0.) );
-    // vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, large_nozzle_gas_solid,
-		// 			0, G4ThreeVector(0., central_nozzle_ypos_, 0.) );
-    // vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, large_nozzle_gas_solid,
-		// 			0, G4ThreeVector(0., down_nozzle_ypos_, 0.) );
-    // vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, small_nozzle_gas_solid,
-		// 			0, G4ThreeVector(0., bottom_nozzle_ypos_, 0.) );
-
 
     //// The logics
     // vessel and vessel gas

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -76,7 +76,7 @@ namespace nexus {
     temperature_ (303 * kelvin),
     // Visibility
     visibility_(0),
-    gas_("naturalXe"),
+    gas_("enrichedXe"),
     helium_mass_num_(4),
     xe_perc_(100.)
   {

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -26,11 +26,7 @@ namespace nexus {
   {
   public:
     /// Constructor
-    Next100Vessel(const G4double nozzle_ext_diam,
-		  const G4double up_nozzle_ypos,
-		  const G4double central_nozzle_ypos,
-		  const G4double down_nozzle_ypos,
-		  const G4double bottom_nozzle_ypos);
+    Next100Vessel();
 
     /// Destructor
     ~Next100Vessel();
@@ -49,16 +45,12 @@ namespace nexus {
     /// Builder
     void Construct();
 
-
-
   private:
     // Dimensions
     G4double vessel_in_rad_, vessel_thickness_;
     G4double body_length_;
     G4double endcap_in_rad_, endcap_in_body_, endcap_theta_, endcap_in_z_width_;
     G4double endcap_tp_distance_, gate_tp_distance_;
-    // G4double flange_out_rad_, flange_length_, flange_z_pos_;
-    // G4double large_nozzle_length_, small_nozzle_length_;
     G4double port_base_height_, port_tube_height_, port_tube_tip_;
     G4double port_x_, port_y_, source_height_, port_z_1a_, port_z_1b_, port_z_2a_, port_z_2b_;
     G4double sc_yield_, e_lifetime_;
@@ -66,10 +58,6 @@ namespace nexus {
 
     // Visibility of the shielding
     G4bool visibility_;
-
-    // Dimensions coming from outside
-    G4double nozzle_ext_diam_, up_nozzle_ypos_, central_nozzle_ypos_;
-    G4double down_nozzle_ypos_, bottom_nozzle_ypos_;
 
     // Internal logical and physical volumes
     G4LogicalVolume* internal_logic_vol_;

--- a/source/materials/MaterialsList.cc
+++ b/source/materials/MaterialsList.cc
@@ -594,26 +594,49 @@ namespace materials {
   }
 
 
-G4Material* PE1000()
-{
-  G4String name = "PE1000";
+  G4Material* PE1000()
+  {
+    G4String name = "PE1000";
 
-  G4Material* mat = G4Material::GetMaterial(name, false);
+    G4Material* mat = G4Material::GetMaterial(name, false);
 
-  if (mat == 0) {
-    G4NistManager* nist = G4NistManager::Instance();
+    if (mat == 0) {
+      G4NistManager* nist = G4NistManager::Instance();
 
-    G4Element* H = nist->FindOrBuildElement("H");
-    G4Element* C = nist->FindOrBuildElement("C");
+      G4Element* H = nist->FindOrBuildElement("H");
+      G4Element* C = nist->FindOrBuildElement("C");
 
-    mat = new G4Material(name, .93*g/cm3, 2, kStateSolid);
-    mat->AddElement(H, 4);
-    mat->AddElement(C, 2);
+      mat = new G4Material(name, .93*g/cm3, 2, kStateSolid);
+      mat->AddElement(H, 4);
+      mat->AddElement(C, 2);
+    }
+
+    return mat;
+
   }
 
-  return mat;
 
-}
+  G4Material* PE500()
+  {
+    G4String name = "PE500";
+
+    G4Material* mat = G4Material::GetMaterial(name, false);
+
+    if (mat == 0) {
+      G4NistManager* nist = G4NistManager::Instance();
+
+      G4Element* H = nist->FindOrBuildElement("H");
+      G4Element* C = nist->FindOrBuildElement("C");
+
+      mat = new G4Material(name, .96*g/cm3, 2, kStateSolid);
+      mat->AddElement(H, 4);
+      mat->AddElement(C, 2);
+    }
+
+    return mat;
+
+  }
+
 
   G4Material* OpticalSilicone()
   {

--- a/source/materials/MaterialsList.h
+++ b/source/materials/MaterialsList.h
@@ -105,6 +105,8 @@ namespace materials {
   /// PE1000 (PE UHMW, ultra-high molecular weight polyethylene)
   G4Material* PE1000();
 
+  /// PE500 (PE HD, high density)
+  G4Material* PE500();
 
   /// Selenium Hexafluoride
     G4Material* SeF6(G4double pressure=STP_Pressure,


### PR DESCRIPTION
This PR solves simple TO-DOs in the Next100 geometry:

- Set enriched-Xe as the default gas.
- Remove deprecated vessel nozzles.
- Add PE500 and set it as the buffer-holder material. The fact that buffer-holders are now made of PE500 (instead of PE1000 as in Next-White) was comunicated privately by engineers. The material density is taken from [PE500-Ficha-Tecnica](https://www.elaplas.es/wp-content/uploads/Ficha-Tecnica-Polietileno-HD-5002.pdf)