### PR TITLE
Use C++-17 in nexus and avoid warnings.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -183,7 +183,7 @@ vars.AddVariables(
 
     ('CXXFLAGS',
      'c++ compiler options.',
-     ['-std=c++11']),
+     ['-std=c++17']),
 
     ('CPPPATH',
      'List of directories where the include headers are located.',
@@ -280,6 +280,11 @@ if not env['LIBPATH']:
 #    if not conf.CheckLib(library='GSL', language='CXX', autoadd=0):
 #        Abort('GSL library not found.')
 ## ##################################################################
+
+    ## Force nexus to use C++17 standard
+    if '-std=c++11' in env['CXXFLAGS']:
+        env['CXXFLAGS'].remove('-std=c++11')
+
     env = conf.Finish()
 
 vars.Save(BUILDVARS_FILE, env)

--- a/source/generators/Decay0Interface.cc
+++ b/source/generators/Decay0Interface.cc
@@ -199,7 +199,7 @@ void Decay0Interface::ProcessHeader()
 {
   G4String line;
 
-  while (!line.contains("First event")) getline(file_, line);
+  while (!G4StrUtil::contains(line, "First event")) getline(file_, line);
 
   getline(file_, line);
   getline(file_, line);

--- a/source/sensdet/SensorSD.cc
+++ b/source/sensdet/SensorSD.cc
@@ -22,8 +22,7 @@ namespace nexus {
 
   SensorSD::SensorSD(G4String sdname):
     G4VSensitiveDetector(sdname),
-    naming_order_(0), sensor_depth_(0), mother_depth_(0),
-    boundary_(0)
+    naming_order_(0), sensor_depth_(0), mother_depth_(0)
   {
     // Register the name of the collection of hits
     collectionName.insert(GetCollectionUniqueName());

--- a/source/sensdet/SensorSD.h
+++ b/source/sensdet/SensorSD.h
@@ -74,8 +74,6 @@ namespace nexus {
 
     G4double timebinning_; ///< Time bin width
 
-    G4OpBoundaryProcess* boundary_; ///< Pointer to the optical boundary process
-
     SensorHitsCollection* HC_; ///< Pointer to the collection of hits
   };
 


### PR DESCRIPTION
This PR modifies the SConstruct file to use the 17 standard of C++. This way, a lot of warnings coming from C++14 and C++17 extensions used in GEANT4 are removed.