### PR TITLE
Fix el-grid transparency and p-T defaults

### DIFF
--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -88,8 +88,8 @@ Next100FieldCage::Next100FieldCage():
   // EL electric field
   elfield_ (0),
   ELelectric_field_ (34.5*kilovolt/cm),
-  cath_grid_transparency_ (.95),
-  el_grid_transparency_ (cath_grid_transparency_), // to check
+  cath_grid_transparency_(.95),
+  el_grid_transparency_  (.90),
   max_step_size_ (1. * mm),
   visibility_ (0),
   verbosity_(0),

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -64,8 +64,8 @@ namespace nexus {
     // Vessel gas
     sc_yield_(16670. * 1/MeV),
     e_lifetime_(1000. * ms),
-    pressure_(15 * bar),
-    temperature_ (303 * kelvin),
+    pressure_   (13.5 * bar),
+    temperature_(300  * kelvin),
     // Visibility
     visibility_(0),
     gas_("enrichedXe"),


### PR DESCRIPTION
This PR corrects the transparency for the EL-grid and the default values of pressure and temperature for NEXT100.