### PR TITLE
Solves G4 photon simulation issue

### DIFF
--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -256,6 +256,9 @@ void Next100FieldCage::DefineMaterials()
 
   /// Teflon for the light tube
   teflon_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+  // teflon is the material used in the light-tube, and is covered by a G4LogicalSkinSurface
+  // In Geant4 11.0.0, a bug in treating the OpBoundaryProcess produced in the surface makes the code fail.
+  // This is avoided by setting an empty G4MaterialPropertiesTable of the G4Material.
   teflon_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   /// TPB coating

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -255,8 +255,8 @@ void Next100FieldCage::DefineMaterials()
   copper_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
 
   /// Teflon for the light tube
-  teflon_ =
-  G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+  teflon_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+  teflon_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   /// TPB coating
   tpb_ = materials::TPB();

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -516,18 +516,6 @@ void Next100FieldCage::BuildELRegion()
                     anode_logic, "ANODE_RING", mother_logic_,
                     false, 0, false);
 
-  ///Gas under ANODE.
-  G4Tubs* anode_gas_solid =
-    new G4Tubs("ANODE_GAS", 0, gate_int_diam_/2.,
-              (gate_ring_thickn_-grid_thickn_)/2., 0, twopi);
-
-  G4LogicalVolume* anode_gas_logic =
-    new G4LogicalVolume(anode_gas_solid, gas_, "ANODE_GAS");
-
-  new G4PVPlacement(0, G4ThreeVector(0., 0., anode_grid_zpos_-gate_ring_thickn_/2.),
-                    anode_gas_logic, "ANODE_GAS", mother_logic_,
-                    false, 0, false);
-
   if (elfield_) {
     /// Define EL electric field
     UniformElectricDriftField* el_field = new UniformElectricDriftField();

--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -105,10 +105,11 @@ void Next100SiPMBoard::Construct()
   G4Box* mask_solid_vol =
     new G4Box(mask_name, size_/2., size_/2., mask_thickness_/2.);
 
+  G4Material* teflon = G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+  teflon->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
   G4LogicalVolume* mask_logic_vol =
-      new G4LogicalVolume(mask_solid_vol,
-                          G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON"),
-                          mask_name);
+      new G4LogicalVolume(mask_solid_vol, teflon, mask_name);
 
   new G4PVPlacement(nullptr, G4ThreeVector(0., 0., mask_zpos),
                     mask_logic_vol, mask_name, board_logic_vol, false, 0, false);

--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -106,6 +106,9 @@ void Next100SiPMBoard::Construct()
     new G4Box(mask_name, size_/2., size_/2., mask_thickness_/2.);
 
   G4Material* teflon = G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+  // teflon is the material used in the sipm-board masks which are covered by a G4LogicalSkinSurface
+  // In Geant4 11.0.0, a bug in treating the OpBoundaryProcess produced in the surface makes the code fail.
+  // This is avoided by setting an empty G4MaterialPropertiesTable of the G4Material.
   teflon->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   G4LogicalVolume* mask_logic_vol =


### PR DESCRIPTION
In this PR:
- Remove ANODE-GAS volume, since the G4LogicalBorderSurface is the interface between the mother-gas (vessel-gas) and the tpb of the boards.
- Add an empty G4MaterialPropertiesTable to the teflon G4Material to avoid segmentation fault bug in G4, which is reported in [bugzilla-geant4-2471](https://bugzilla-geant4.kek.jp/show_bug.cgi?id=2471)