### PR TITLE
Add missing variable for Scons compilation

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -215,6 +215,7 @@ env = Environment(variables=vars)
 ## Load the PATH variable of the user environment,
 ## to look for third-party library paths
 env.PrependENVPath('PATH', os.environ['PATH'])
+env.PrependENVPath('LD_LIBRARY_PATH', os.environ['LD_LIBRARY_PATH'])
 
 ## If the LIBPATH buildvar (for instance) is not defined, the configure
 ## step has not been run yet

--- a/SConstruct
+++ b/SConstruct
@@ -208,8 +208,7 @@ vars.AddVariables(
 ## ###################################################################
 ## CONFIGURE BUILD
 
-## Create a construction environment adding the build vars and
-## propagating the user's external environment
+## Create a construction environment adding the build vars
 env = Environment(variables=vars)
 
 ## Load the PATH variable of the user environment,

--- a/SConstruct
+++ b/SConstruct
@@ -214,6 +214,9 @@ env = Environment(variables=vars)
 ## Load the PATH variable of the user environment,
 ## to look for third-party library paths
 env.PrependENVPath('PATH', os.environ['PATH'])
+
+## Temporary: this line appears to be necessary in some Linux machines
+## and will not be needed anymore with patch Geant4.11.0.1
 env.PrependENVPath('LD_LIBRARY_PATH', os.environ['LD_LIBRARY_PATH'])
 
 ## If the LIBPATH buildvar (for instance) is not defined, the configure


### PR DESCRIPTION
In some Linux systems not loading the full environment of the user makes the building fail, with errors related to the inability of locating some libraries. This PR fixes this issue by loading  the `LD_LIBRARY_PATH` explicitly.