### PR TITLE
Add empty properties table

### DIFF
--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -196,9 +196,13 @@ namespace nexus {
 
     }
 
+    G4Material* copper = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
+    // In Geant4 11.0.0, a bug in treating the OpBoundaryProcess produced in the surface makes the code fail.
+    // This is avoided by setting an empty G4MaterialPropertiesTable of the G4Material.
+    copper->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+    
     G4LogicalVolume* copper_plate_logic =
-      new G4LogicalVolume(copper_plate_solid,
-                          G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"), "EP_COPPER_PLATE");
+      new G4LogicalVolume(copper_plate_solid, copper, "EP_COPPER_PLATE");
 
     G4double stand_out_length =
       sapphire_window_thickn_ + tpb_thickn_ + optical_pad_thickn_ + pmt_stand_out_;

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -267,6 +267,9 @@ void Next100FieldCage::DefineMaterials()
 
   /// Steel
   steel_ = materials::Steel316Ti();
+  // In Geant4 11.0.0, a bug in treating the OpBoundaryProcess produced in the surface makes the code fail.
+  // This is avoided by setting an empty G4MaterialPropertiesTable of the G4Material.
+  steel_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 }
 
 

--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -89,10 +89,14 @@ void Next100SiPMBoard::Construct()
   G4Box* board_solid_vol =
     new G4Box(board_name, size_/2., size_/2., (board_thickness_ + mask_thickness_)/2.);
 
+
+  G4Material* kapton = G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON");
+  // In Geant4 11.0.0, a bug in treating the OpBoundaryProcess produced in the surface makes the code fail.
+  // This is avoided by setting an empty G4MaterialPropertiesTable of the G4Material.
+  kapton->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
   G4LogicalVolume* board_logic_vol =
-    new G4LogicalVolume(board_solid_vol,
-                        G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON"),
-                        board_name);
+    new G4LogicalVolume(board_solid_vol, kapton, board_name);
 
   GeometryBase::SetLogicalVolume(board_logic_vol);
 

--- a/source/geometries/Next100TrackingPlane.cc
+++ b/source/geometries/Next100TrackingPlane.cc
@@ -71,9 +71,13 @@ void Next100TrackingPlane::Construct()
                                           copper_plate_thickness_/2.,
                                           0., 360.*deg);
 
+  G4Material* copper = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
+  // In Geant4 11.0.0, a bug in treating the OpBoundaryProcess produced in the surface makes the code fail.
+  // This is avoided by setting an empty G4MaterialPropertiesTable of the G4Material.
+  copper->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+  
   G4LogicalVolume* copper_plate_logic =
-    new G4LogicalVolume(copper_plate_solid,
-                        G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"), copper_plate_name);
+    new G4LogicalVolume(copper_plate_solid, copper, copper_plate_name);
 
   G4double copper_plate_zpos = GetELzCoord() - gate_tp_dist_ - copper_plate_thickness_/2.;
 


### PR DESCRIPTION
Same as #141. It adds an empty material properties table to kapton and steel in order to avoid Geant4 bug in optical boundary process.