### PR TITLE
Fix angles in MuonGenerator

### DIFF
--- a/source/actions/MuonsEventAction.cc
+++ b/source/actions/MuonsEventAction.cc
@@ -49,7 +49,7 @@ REGISTER_CLASS(MuonsEventAction, G4UserEventAction)
 
     // Muons Control plots
     hist1_ = new TH1D ("Edepo","Energy_deposited",100,-1.0,3.4);
-    hist2_ = new TH1D ("Theta","Theta generated",100,-pi,pi);
+    hist2_ = new TH1D ("Theta","Theta generated",100,0.,pi);
     hist3_ = new TH1D ("Phi","Phi generated",100,0.,twopi);
     tree_  = new TTree("Tree nexus","Flat tree with some nexus info");
     tree_->Branch("tree_theta", &tree_theta_, "tree_theta/D");

--- a/source/generators/MuonGenerator.cc
+++ b/source/generators/MuonGenerator.cc
@@ -110,6 +110,8 @@ void MuonGenerator::GeneratePrimaryVertex(G4Event* event)
   // If user provides a momentum direction, this one is used
   if (fixed_momentum) {
     p_dir = momentum_.unit();
+    phi   = p_dir.getPhi() + pi; // change phi interval to be between 0, twopi
+    theta = p_dir.getTheta();
   }
 
   G4ThreeVector p = pmod * p_dir;


### PR DESCRIPTION
The user can set the muon's momentum direction in the MuonGenerator to a fixed value.
However if the momentum is set by the user, the histograms provided by MuonEventAction (theta and phi angles) result in the default angle distributions of MuonGenerator class, instead of the fixed values provided by the user.
This comes from the fact that the momentum angles are not computed when it is set by the user.