### PR TITLE
Change default NEXT-100 visibilities

### DIFF
--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -351,6 +351,7 @@ namespace nexus {
     //////////////////////
 
     vacuum_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
+    pmt_base_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
     if (visibility_) {
       G4VisAttributes copper_col = CopperBrownAlpha();
       copper_col.SetForceSolid(true);
@@ -364,18 +365,12 @@ namespace nexus {
       G4VisAttributes tpb_col = nexus::LightBlueAlpha();
       tpb_col.SetForceSolid(true);
       tpb_logic->SetVisAttributes(tpb_col);
-      G4VisAttributes pmt_base_col = YellowAlpha();
-      pmt_base_col.SetForceSolid(true);
-      pmt_base_logic->SetVisAttributes(pmt_base_col);
-      G4VisAttributes vacuum_col = WhiteAlpha();
-      vacuum_logic->SetVisAttributes(vacuum_col);
+      
     } else {
       copper_plate_logic   ->SetVisAttributes(G4VisAttributes::GetInvisible());
       sapphire_window_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
       optical_pad_logic    ->SetVisAttributes(G4VisAttributes::GetInvisible());
       tpb_logic            ->SetVisAttributes(G4VisAttributes::GetInvisible());
-      pmt_base_logic       ->SetVisAttributes(G4VisAttributes::GetInvisible());
-      vacuum_logic         ->SetVisAttributes(G4VisAttributes::GetInvisible());
     }
 
     //////////////////////////

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -352,22 +352,22 @@ namespace nexus {
 
     vacuum_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
     if (visibility_) {
-      G4VisAttributes copper_col = CopperBrown();
+      G4VisAttributes copper_col = CopperBrownAlpha();
       copper_col.SetForceSolid(true);
       copper_plate_logic->SetVisAttributes(copper_col);
-      G4VisAttributes sapphire_col = nexus::Lilla();
+      G4VisAttributes sapphire_col = nexus::LillaAlpha();
       sapphire_col.SetForceSolid(true);
       sapphire_window_logic->SetVisAttributes(sapphire_col);
-      G4VisAttributes pad_col = nexus::LightGreen();
+      G4VisAttributes pad_col = nexus::LightGreenAlpha();
       pad_col.SetForceSolid(true);
       optical_pad_logic->SetVisAttributes(pad_col);
-      G4VisAttributes tpb_col = nexus::LightBlue();
+      G4VisAttributes tpb_col = nexus::LightBlueAlpha();
       tpb_col.SetForceSolid(true);
       tpb_logic->SetVisAttributes(tpb_col);
-      G4VisAttributes pmt_base_col = Yellow();
+      G4VisAttributes pmt_base_col = YellowAlpha();
       pmt_base_col.SetForceSolid(true);
       pmt_base_logic->SetVisAttributes(pmt_base_col);
-      G4VisAttributes vacuum_col = White();
+      G4VisAttributes vacuum_col = WhiteAlpha();
       vacuum_logic->SetVisAttributes(vacuum_col);
     } else {
       copper_plate_logic   ->SetVisAttributes(G4VisAttributes::GetInvisible());

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -343,14 +343,8 @@ void Next100FieldCage::BuildActive()
 
 
   /// Visibilities
-  if (visibility_) {
-    G4VisAttributes active_col = nexus::Yellow();
-    active_logic->SetVisAttributes(active_col);
-  } else {
-    active_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
-  }
-
-
+  active_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
+  
   /// Verbosity
   if (verbosity_) {
     G4cout << "Active starts in " << (active_zpos_ - active_length_/2.)/mm
@@ -397,9 +391,10 @@ void Next100FieldCage::BuildCathode()
   /// Visibilities
   if (visibility_) {
     G4VisAttributes grey = nexus::LightGrey();
-    G4VisAttributes copper_col = nexus::CopperBrown();
+    G4VisAttributes cathode_col = nexus::DarkGrey();
+    cathode_col.SetForceSolid(true);
     diel_grid_logic->SetVisAttributes(grey);
-    cathode_logic->SetVisAttributes(copper_col);
+    cathode_logic->SetVisAttributes(cathode_col);
   } else {
     diel_grid_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
     cathode_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
@@ -471,12 +466,7 @@ void Next100FieldCage::BuildBuffer()
                                             G4ThreeVector(0., 0., xenon_zpos));
 
   /// Visibilities
-  if (visibility_) {
-    G4VisAttributes buffer_col = nexus::LightGreen();
-    buffer_logic->SetVisAttributes(buffer_col);
-  } else {
-    buffer_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
-  }
+  buffer_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
 
   /// Verbosity
   if (verbosity_) {
@@ -585,12 +575,13 @@ void Next100FieldCage::BuildELRegion()
 
   /// Visibilities
   if (visibility_) {
-    G4VisAttributes grey = nexus::LightGrey();
+    G4VisAttributes grey = nexus::DarkGrey();
+    grey.SetForceSolid(true);
     gate_logic->SetVisAttributes(grey);
     G4VisAttributes light_blue = nexus::LightBlue();
     el_gap_logic->SetVisAttributes(light_blue);
     anode_logic->SetVisAttributes(grey);
-    diel_grid_logic->SetVisAttributes(grey);
+    diel_grid_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
   } else {
     gate_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
     el_gap_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
@@ -706,14 +697,12 @@ void Next100FieldCage::BuildLightTube()
 
   // Visibilities
   if (visibility_) {
-    G4VisAttributes light_green = nexus::LightGreen();
-    G4VisAttributes green = nexus::DarkGreen();
-    light_green.SetForceSolid(true);
-    teflon_drift_logic->SetVisAttributes(light_green);
-    teflon_buffer_logic->SetVisAttributes(green);
-    G4VisAttributes red = nexus::Red();
-    tpb_drift_logic->SetVisAttributes(red);
-    tpb_buffer_logic->SetVisAttributes(red);
+    G4VisAttributes light_yellow = nexus::YellowAlpha();
+    light_yellow.SetForceSolid(true);
+    teflon_drift_logic->SetVisAttributes(light_yellow);
+    teflon_buffer_logic->SetVisAttributes(light_yellow);
+    tpb_drift_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
+    tpb_buffer_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
   }
   else {
     teflon_drift_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
@@ -905,10 +894,13 @@ void Next100FieldCage::BuildFieldCage()
   /// Visibilities
   if (visibility_) {
     G4VisAttributes ring_col = nexus::CopperBrown();
+    ring_col.SetForceSolid(true);
     ring_logic->SetVisAttributes(ring_col);
-    G4VisAttributes hdpe_col = nexus::White();
+    G4VisAttributes hdpe_col =nexus::WhiteAlpha();
+    hdpe_col.SetForceSolid(true);
     hdpe_tube_logic->SetVisAttributes(hdpe_col);
     G4VisAttributes hold_col = nexus::LightGrey();
+    hold_col.SetForceSolid(true);
     act_holder_logic->SetVisAttributes(hold_col);
     buff_holder_logic->SetVisAttributes(hold_col);
     cathode_holder_logic->SetVisAttributes(hold_col);

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -396,8 +396,10 @@ void Next100FieldCage::BuildCathode()
     diel_grid_logic->SetVisAttributes(grey);
     cathode_logic->SetVisAttributes(cathode_col);
   } else {
+    G4VisAttributes cathode_col = nexus::DarkGrey();
+    cathode_col.SetForceSolid(true);
     diel_grid_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
-    cathode_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
+    cathode_logic->SetVisAttributes(cathode_col);
   }
 
 
@@ -575,19 +577,17 @@ void Next100FieldCage::BuildELRegion()
 
   /// Visibilities
   if (visibility_) {
-    G4VisAttributes grey = nexus::DarkGrey();
-    grey.SetForceSolid(true);
-    gate_logic->SetVisAttributes(grey);
     G4VisAttributes light_blue = nexus::LightBlue();
     el_gap_logic->SetVisAttributes(light_blue);
-    anode_logic->SetVisAttributes(grey);
     diel_grid_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
   } else {
-    gate_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
     el_gap_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
-    anode_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
     diel_grid_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
   }
+  G4VisAttributes grey = nexus::DarkGrey();
+  grey.SetForceSolid(true);
+  gate_logic->SetVisAttributes(grey);
+  anode_logic->SetVisAttributes(grey);
 
   /// Verbosity
   if (verbosity_) {

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -150,7 +150,8 @@ namespace nexus {
 
     // SETTING VISIBILITIES   //////////
     if (visibility_) {
-      G4VisAttributes copper_col = nexus::CopperBrown();
+      G4VisAttributes copper_col = nexus::CopperBrownAlpha();
+      copper_col.SetForceSolid(true);
       ics_logic->SetVisAttributes(copper_col);
     }
     else {

--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -277,19 +277,17 @@ void Next100SiPMBoard::Construct()
 
   // VISIBILITIES ////////////////////////////////////////////////////
   if (visibility_) {
-    G4VisAttributes blue       = Blue();
     G4VisAttributes light_blue = LightBlue();
-    board_logic_vol ->SetVisAttributes(blue);
     mask_logic_vol  ->SetVisAttributes(light_blue);
   }
   else{
-    board_logic_vol ->SetVisAttributes(G4VisAttributes::GetInvisible());
     mask_logic_vol  ->SetVisAttributes(G4VisAttributes::GetInvisible());
   }
   mask_hole_logic_vol    ->SetVisAttributes(G4VisAttributes::GetInvisible());
   mask_wls_logic_vol     ->SetVisAttributes(G4VisAttributes::GetInvisible());
   mask_wls_hole_logic_vol->SetVisAttributes(G4VisAttributes::GetInvisible());
   wall_wls_logic_vol     ->SetVisAttributes(G4VisAttributes::GetInvisible());
+  board_logic_vol ->SetVisAttributes(G4VisAttributes::GetInvisible());
 }
 
 

--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -289,6 +289,7 @@ void Next100SiPMBoard::Construct()
   mask_hole_logic_vol    ->SetVisAttributes(G4VisAttributes::GetInvisible());
   mask_wls_logic_vol     ->SetVisAttributes(G4VisAttributes::GetInvisible());
   mask_wls_hole_logic_vol->SetVisAttributes(G4VisAttributes::GetInvisible());
+  wall_wls_logic_vol     ->SetVisAttributes(G4VisAttributes::GetInvisible());
 }
 
 

--- a/source/geometries/Next100TrackingPlane.cc
+++ b/source/geometries/Next100TrackingPlane.cc
@@ -146,6 +146,7 @@ void Next100TrackingPlane::Construct()
 
 
   // VISIBILITIES //////////////////////////////////////////
+  plug_logic        ->SetVisAttributes(G4VisAttributes::GetInvisible());
   if (visibility_) {
     G4VisAttributes copper_brown = CopperBrownAlpha();
     copper_brown.SetForceSolid(true);
@@ -153,7 +154,6 @@ void Next100TrackingPlane::Construct()
   } else {
     copper_plate_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
     sipm_board_logic  ->SetVisAttributes(G4VisAttributes::GetInvisible());
-    plug_logic        ->SetVisAttributes(G4VisAttributes::GetInvisible());
   }
 
 }

--- a/source/geometries/Next100TrackingPlane.cc
+++ b/source/geometries/Next100TrackingPlane.cc
@@ -147,7 +147,8 @@ void Next100TrackingPlane::Construct()
 
   // VISIBILITIES //////////////////////////////////////////
   if (visibility_) {
-    G4VisAttributes copper_brown = CopperBrown();
+    G4VisAttributes copper_brown = CopperBrownAlpha();
+    copper_brown.SetForceSolid(true);
     copper_plate_logic->SetVisAttributes(copper_brown);
   } else {
     copper_plate_logic->SetVisAttributes(G4VisAttributes::GetInvisible());

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -298,12 +298,12 @@ namespace nexus {
 
     // SETTING VISIBILITIES   //////////
     if (visibility_) {
-      G4VisAttributes grey = DarkGrey();
+      G4VisAttributes grey = nexus::TitaniumGreyAlpha();
       G4VisAttributes yellow = nexus::Yellow();
       grey  .SetForceSolid(true);
       yellow.SetForceSolid(true);
       vessel_logic       ->SetVisAttributes(grey);
-      vessel_gas_logic   ->SetVisAttributes(grey);
+      vessel_gas_logic   ->SetVisAttributes(G4VisAttributes::GetInvisible());
       port_tube_logic    ->SetVisAttributes(grey);
       port_tube_gas_logic->SetVisAttributes(yellow);
     }

--- a/source/geometries/PmtR11410.cc
+++ b/source/geometries/PmtR11410.cc
@@ -163,7 +163,7 @@ namespace nexus {
     pmt_gas_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
     window_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
     if (visibility_) {
-      G4VisAttributes pmt_col = nexus::LightGreyAlpha();
+      G4VisAttributes pmt_col = nexus::LightGrey();
       pmt_col.SetForceSolid(true);
       pmt_logic->SetVisAttributes(pmt_col);
       G4VisAttributes phot_col = nexus::Brown();

--- a/source/geometries/PmtR11410.cc
+++ b/source/geometries/PmtR11410.cc
@@ -163,7 +163,7 @@ namespace nexus {
     pmt_gas_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
     window_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
     if (visibility_) {
-      G4VisAttributes pmt_col = nexus::LightGrey();
+      G4VisAttributes pmt_col = nexus::LightGreyAlpha();
       pmt_col.SetForceSolid(true);
       pmt_logic->SetVisAttributes(pmt_col);
       G4VisAttributes phot_col = nexus::Brown();

--- a/source/utils/Visibilities.h
+++ b/source/utils/Visibilities.h
@@ -29,6 +29,24 @@ namespace nexus {
   inline G4VisAttributes DarkGrey()     { return { { .3 ,  .3 ,  .3 } }; }
   inline G4VisAttributes LightGrey()    { return { { .7 ,  .7 ,  .7 } }; }
   inline G4VisAttributes TitaniumGrey() { return { { .71,  .69,  .66} }; }
+  
+  // Set colours with alpha for transparency
+  inline G4VisAttributes YellowAlpha()       { return { {1.0 , 1.0 ,  0.0, .5} }; }
+  inline G4VisAttributes WhiteAlpha()        { return { {1.0 , 1.0 ,  1.0, .3} }; }
+  inline G4VisAttributes RedAlpha()          { return { { 1. ,  .0 ,  .0 , .5} }; }
+  inline G4VisAttributes DarkRedAlpha()      { return { { .88,  .87,  .86, .5} }; }
+  inline G4VisAttributes BloodRedAlpha()     { return { { .55,  .09,  .09, .5} }; }
+  inline G4VisAttributes DarkGreenAlpha()    { return { { .0 ,  .6 ,  .0 , .5} }; }
+  inline G4VisAttributes LightGreenAlpha()   { return { { .6 ,  .9 ,  .2 , .3} }; }
+  inline G4VisAttributes DirtyWhiteAlpha()   { return { {1   , 1   ,  .8 , .5} }; }
+  inline G4VisAttributes CopperBrownAlpha()  { return { { .72,  .45,  .20, .2} }; }
+  inline G4VisAttributes BrownAlpha()        { return { { .93,  .87,  .80, .5} }; }
+  inline G4VisAttributes BlueAlpha()         { return { { .0 ,  .0 , 1   , .5} }; }
+  inline G4VisAttributes LightBlueAlpha()    { return { { .6 ,  .8 ,  .79, .5} }; }
+  inline G4VisAttributes LillaAlpha()        { return { { .5 ,  .5 ,  .7 , .5} }; }
+  inline G4VisAttributes DarkGreyAlpha()     { return { { .3 ,  .3 ,  .3 , .5} }; }
+  inline G4VisAttributes LightGreyAlpha()    { return { { .7 ,  .7 ,  .7 , .5} }; }
+  inline G4VisAttributes TitaniumGreyAlpha() { return { { .71,  .69,  .66, .5} }; }
 
 }  // end namespace nexus
 


### PR DESCRIPTION
This PR addresses issue #137 where the TPB coating on the teflon mask walls were being drawn and slowing down the NEXT-100 visualisation rendering. In addition, the default settings of the NEXT-100 visibilities have been changed so that the inner parts of the detector are more clear. I have added colours in the Visibility.hh file with an alpha setting to select colours with a level of transparency. 

Image below shows the NEXT-100 geometry with the following settings switched on:
/Geometry/Next100/tracking_plane_vis true
/Geometry/Next100/energy_plane_vis true
/Geometry/Next100/field_cage_vis true
/Geometry/Next100/sipm_board_vis true
/Geometry/Next100/sipm_vis true
/Geometry/PmtR11410/visibility true
/Geometry/Next100/vessel_vis true
/Geometry/Next100/ics_vis true
<img width="530" alt="image" src="https://user-images.githubusercontent.com/32701127/161153345-78ede7dc-4bf0-4c18-a2be-c3e6ceaa8758.png">

The inner field cage looks like this:
<img width="560" alt="image" src="https://user-images.githubusercontent.com/32701127/161152853-77f923ed-a3eb-41ed-a3de-72bcaca9d01d.png">

