### PR TITLE
Modify SIPM_BOARD vertex.

### DIFF
--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -272,8 +272,8 @@ void Next100SiPMBoard::Construct()
 
   // VERTEX GENERATOR ////////////////////////////////////////////////
 
-  vtxgen_ = new BoxPointSampler(size_, size_, board_thickness_, 0.,
-                                G4ThreeVector(0., 0., -mask_thickness_/2.));
+  vtxgen_ = new BoxPointSampler(size_, size_, board_thickness_+mask_thickness_, 0.,
+                                G4ThreeVector(0., 0., 0));
 
   // VISIBILITIES ////////////////////////////////////////////////////
   if (visibility_) {

--- a/source/geometries/Next100TrackingPlane.h
+++ b/source/geometries/Next100TrackingPlane.h
@@ -15,6 +15,7 @@
 
 class G4VPhysicalVolume;
 class G4GenericMessenger;
+class G4Navigator;
 
 namespace nexus {
 
@@ -62,6 +63,8 @@ namespace nexus {
     G4VPhysicalVolume* mpv_; // Pointer to mother's physical volume
 
     G4GenericMessenger* msg_;
+    // Geometry Navigator
+    G4Navigator* geom_navigator_;
   };
 
   inline void Next100TrackingPlane::SetMotherPhysicalVolume(G4VPhysicalVolume* p)


### PR DESCRIPTION
This PR modifies the SIPM_BOARD vertex to include the volumes of the mask, wls and SiPMs in the same region as the kapton board. Listed here are all the volumes included:
```
SIPM_BOARD_MASK
SIPM_BOARD
SIPM_S13372
SIPM_S13372_WINDOW
SIPM_S13372_SENSAREA
SIPM_BOARD_MASK_WLS
SIPM_BOARD_MASK_WALL_WLS
SIPM_S13372_WLS
```