### PR TITLE
Fix Trajectory visualization bug

### DIFF
--- a/source/base/Trajectory.cc
+++ b/source/base/Trajectory.cc
@@ -43,6 +43,10 @@ Trajectory::Trajectory(const G4Track* track):
   initial_volume_ = track->GetVolume()->GetName();
 
   trjpoints_ = new TrajectoryPointContainer();
+  TrajectoryPoint* first_trj_point = 
+                new TrajectoryPoint(track->GetPosition(), 
+                                    track->GetGlobalTime());
+  trjpoints_->push_back(first_trj_point);
 
   // Add this trajectory in the map, but only if no other
   // trajectory for this track id has been registered yet


### PR DESCRIPTION
As pointed out by issue #9, the trajectories of photons and geantinos cannot be visualized from the very beginning.
With this commit, the creation of the first trajectory point within Trajectory class constructor is added, thus resolving the incompleteness of the visualized trajectories, which actually affected every trajectory regardless its track.

Resolves: #9

Find below the effects of this change on the configuration given by macros/nexus_example1.init.mac , after executing run/beamOn 100

Before this commit:
![image](https://user-images.githubusercontent.com/78102932/164268997-4a2bd004-e4b2-42fc-ac26-bdc635d4e712.png)

After this commit:
![image](https://user-images.githubusercontent.com/78102932/164269217-088f274f-eb52-4c23-9946-b6685f931e6f.png)

