### PR TITLE
Force the diagnostic flag to work always

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -174,7 +174,7 @@ vars.AddVariables(
 
     ('CPPFLAGS',
      'User-specified preprocessor options.',
-     ['-g', '-fdiagnostics-color']),
+     ['-g', '-fdiagnostics-color=always']),
 
     ('CXXFLAGS',
      'c++ compiler options.',


### PR DESCRIPTION
This PR sets the flag that controls the color in diagnostic to work in any case. Before, the behaviour depended on the default of the specific compiler.