### PR TITLE
Protect against failed cast

### DIFF
--- a/source/actions/DefaultEventAction.cc
+++ b/source/actions/DefaultEventAction.cc
@@ -86,10 +86,21 @@ REGISTER_CLASS(DefaultEventAction, G4UserEventAction)
 
       G4TrajectoryContainer* tc = event->GetTrajectoryContainer();
       if (tc) {
+        // in interactive mode, a G4TrajectoryContainer would exist
+        // but the trajectories will not cast to Trajectory
+        Trajectory* trj = dynamic_cast<Trajectory*>((*tc)[0]);
+        if (trj == nullptr){
+          G4Exception("[DefaultEventAction]", "EndOfEventAction()", FatalException,
+                      "DefaultTrackingAction is required when using DefaultEventAction");
+        }
         for (unsigned int i=0; i<tc->size(); ++i) {
           Trajectory* trj = dynamic_cast<Trajectory*>((*tc)[i]);
           edep += trj->GetEnergyDeposit();
         }
+      }
+      else {
+        G4Exception("[DefaultEventAction]", "EndOfEventAction()", FatalException,
+                    "DefaultTrackingAction is required when using DefaultEventAction");
       }
 
       PersistencyManager* pm = dynamic_cast<PersistencyManager*>


### PR DESCRIPTION
  In interactive mode, you might want to use **DefaultEventAction** without **DefaultTrackingAction**. Since you are in interactive mode, Geant4 will provide a not empty `G4TrajectoryContainer`, which is a vector of `G4VTrajectory`. The dowcast fails since `Trajectory` is a nexus class.