### PR TITLE
Move function definitions where the smart pointer is complete

### DIFF
--- a/source/base/DetectorConstruction.cc
+++ b/source/base/DetectorConstruction.cc
@@ -73,3 +73,14 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
 
   return world_physi;
 }
+
+
+void DetectorConstruction::SetGeometry(std::unique_ptr<GeometryBase> g)
+{
+  geometry_ = std::move(g);
+}
+
+const GeometryBase* DetectorConstruction::GetGeometry() const
+{
+  return geometry_.get();
+}

--- a/source/base/DetectorConstruction.h
+++ b/source/base/DetectorConstruction.h
@@ -39,14 +39,6 @@ namespace nexus {
   };
 
 
-  // INLINE DEFINITIONS /////////////////////////////////////////////
-
-  inline void DetectorConstruction::SetGeometry(std::unique_ptr<GeometryBase> g)
-  { geometry_ = std::move(g); }
-
-  inline const GeometryBase* DetectorConstruction::GetGeometry() const
-  { return geometry_.get(); }
-
 } // end namespace nexus
 
 #endif


### PR DESCRIPTION
I've noticed that a compilation error is prompted when nexus is used as a third party library by an external software. The reason of the error is that we use a forward declaration of the smart pointer in `DetectorConstruction.h` and we use the move assignment operator in an inline function in the same header file. However, when the move assignment operator is used, the smart pointer needs to be complete, which is not the case in DetectorConstruction.h, because of forward declaration.
Therefore, this PR moves the definitions of the functions to the `.cc` file.