### PR TITLE
Change type of event ID to int64 to avoid overflow

### DIFF
--- a/source/persistency/HDF5Writer.cc
+++ b/source/persistency/HDF5Writer.cc
@@ -89,7 +89,7 @@ void HDF5Writer::WriteRunInfo(const char* param_key, const char* param_value)
 }
 
 
-void HDF5Writer::WriteSensorDataInfo(int evt_number, unsigned int sensor_id, unsigned int time_bin, unsigned int charge)
+void HDF5Writer::WriteSensorDataInfo(int64_t evt_number, unsigned int sensor_id, unsigned int time_bin, unsigned int charge)
 {
   sns_data_t snsData;
   snsData.event_id = evt_number;
@@ -101,7 +101,7 @@ void HDF5Writer::WriteSensorDataInfo(int evt_number, unsigned int sensor_id, uns
   ismp_++;
 }
 
-void HDF5Writer::WriteHitInfo(int evt_number, int particle_indx, int hit_indx, float hit_position_x, float hit_position_y, float hit_position_z, float hit_time, float hit_energy, const char* label)
+void HDF5Writer::WriteHitInfo(int64_t evt_number, int particle_indx, int hit_indx, float hit_position_x, float hit_position_y, float hit_position_z, float hit_time, float hit_energy, const char* label)
 {
   hit_info_t trueInfo;
   trueInfo.event_id = evt_number;
@@ -119,7 +119,7 @@ void HDF5Writer::WriteHitInfo(int evt_number, int particle_indx, int hit_indx, f
   ihit_++;
 }
 
-void HDF5Writer::WriteParticleInfo(int evt_number, int particle_indx, const char* particle_name, char primary, int mother_id, float initial_vertex_x, float initial_vertex_y, float initial_vertex_z, float initial_vertex_t, float final_vertex_x, float final_vertex_y, float final_vertex_z, float final_vertex_t, const char* initial_volume, const char* final_volume, float ini_momentum_x, float ini_momentum_y, float ini_momentum_z, float final_momentum_x, float final_momentum_y, float final_momentum_z, float kin_energy, float length, const char* creator_proc, const char* final_proc)
+void HDF5Writer::WriteParticleInfo(int64_t evt_number, int particle_indx, const char* particle_name, char primary, int mother_id, float initial_vertex_x, float initial_vertex_y, float initial_vertex_z, float initial_vertex_t, float final_vertex_x, float final_vertex_y, float final_vertex_z, float final_vertex_t, const char* initial_volume, const char* final_volume, float ini_momentum_x, float ini_momentum_y, float ini_momentum_z, float final_momentum_x, float final_momentum_y, float final_momentum_z, float kin_energy, float length, const char* creator_proc, const char* final_proc)
 {
   particle_info_t trueInfo;
   trueInfo.event_id = evt_number;
@@ -171,7 +171,7 @@ void HDF5Writer::WriteSensorPosInfo(unsigned int sensor_id, const char* sensor_n
   ipos_++;
 }
 
-void HDF5Writer::WriteStep(int evt_number,
+void HDF5Writer::WriteStep(int64_t evt_number,
                            int particle_id, const char* particle_name,
                            int step_id,
                            const char* initial_volume,

--- a/source/persistency/HDF5Writer.h
+++ b/source/persistency/HDF5Writer.h
@@ -31,11 +31,11 @@ namespace nexus {
     void Close();
 
     void WriteRunInfo(const char* param_key, const char* param_value);
-    void WriteSensorDataInfo(int evt_number, unsigned int sensor_id, unsigned int time_bin, unsigned int charge);
-    void WriteHitInfo(int evt_number, int particle_indx, int hit_indx, float hit_position_x, float hit_position_y, float hit_position_z, float hit_time, float hit_energy, const char* label);
-    void WriteParticleInfo(int evt_number, int particle_indx, const char* particle_name, char primary, int mother_id, float initial_vertex_x, float initial_vertex_y, float initial_vertex_z, float initial_vertex_t, float final_vertex_x, float final_vertex_y, float final_vertex_z, float final_vertex_t, const char* initial_volume, const char* final_volume, float ini_momentum_x, float ini_momentum_y, float ini_momentum_z, float final_momentum_x, float final_momentum_y, float final_momentum_z, float kin_energy, float length, const char* creator_proc, const char* final_proc);
+    void WriteSensorDataInfo(int64_t evt_number, unsigned int sensor_id, unsigned int time_bin, unsigned int charge);
+    void WriteHitInfo(int64_t evt_number, int particle_indx, int hit_indx, float hit_position_x, float hit_position_y, float hit_position_z, float hit_time, float hit_energy, const char* label);
+    void WriteParticleInfo(int64_t evt_number, int particle_indx, const char* particle_name, char primary, int mother_id, float initial_vertex_x, float initial_vertex_y, float initial_vertex_z, float initial_vertex_t, float final_vertex_x, float final_vertex_y, float final_vertex_z, float final_vertex_t, const char* initial_volume, const char* final_volume, float ini_momentum_x, float ini_momentum_y, float ini_momentum_z, float final_momentum_x, float final_momentum_y, float final_momentum_z, float kin_energy, float length, const char* creator_proc, const char* final_proc);
     void WriteSensorPosInfo(unsigned int sensor_id, const char* sensor_name, float x, float y, float z);
-    void WriteStep(int evt_number,
+    void WriteStep(int64_t evt_number,
                    int particle_id, const char* particle_name,
                    int step_id,
                    const char* initial_volume,

--- a/source/persistency/PersistencyManager.h
+++ b/source/persistency/PersistencyManager.h
@@ -86,12 +86,12 @@ namespace nexus {
 
     G4String event_type_; ///< event type: bb0nu, bb2nu, background or not set
 
-    G4int saved_evts_; ///< number of events to be saved
-    G4int interacting_evts_; ///< number of events interacting in ACTIVE
+    int64_t saved_evts_; ///< number of events to be saved
+    int64_t interacting_evts_; ///< number of events interacting in ACTIVE
     G4double pmt_bin_size_, sipm_bin_size_; ///< bin width of sensors
 
-    G4int nevt_; ///< Event ID
-    G4int start_id_; ///< ID for the first event in file
+    int64_t nevt_; ///< Event ID
+    int64_t start_id_; ///< ID for the first event in file
     G4bool first_evt_; ///< true only for the first event of the run
 
     HDF5Writer* h5writer_;  ///< Event writer to hdf5 file

--- a/source/persistency/hdf5_functions.cc
+++ b/source/persistency/hdf5_functions.cc
@@ -25,7 +25,7 @@ hsize_t createSensorDataType()
 {
   //Create compound datatype for the table
   hsize_t memtype = H5Tcreate (H5T_COMPOUND, sizeof (sns_data_t));
-  H5Tinsert (memtype, "event_id", HOFFSET (sns_data_t, event_id), H5T_NATIVE_INT32);
+  H5Tinsert (memtype, "event_id", HOFFSET (sns_data_t, event_id), H5T_NATIVE_INT64);
   H5Tinsert (memtype, "sensor_id", HOFFSET (sns_data_t, sensor_id), H5T_NATIVE_UINT);
   H5Tinsert (memtype, "time_bin", HOFFSET (sns_data_t, time_bin), H5T_NATIVE_UINT64);
   H5Tinsert (memtype, "charge", HOFFSET (sns_data_t, charge), H5T_NATIVE_UINT);
@@ -40,7 +40,7 @@ hsize_t createHitInfoType()
 
   //Create compound datatype for the table
   hsize_t memtype = H5Tcreate (H5T_COMPOUND, sizeof (hit_info_t));
-  H5Tinsert (memtype, "event_id", HOFFSET (hit_info_t, event_id), H5T_NATIVE_INT32);
+  H5Tinsert (memtype, "event_id", HOFFSET (hit_info_t, event_id), H5T_NATIVE_INT64);
   H5Tinsert (memtype, "x", HOFFSET (hit_info_t, x), H5T_NATIVE_FLOAT);
   H5Tinsert (memtype, "y", HOFFSET (hit_info_t, y), H5T_NATIVE_FLOAT);
   H5Tinsert (memtype, "z", HOFFSET (hit_info_t, z), H5T_NATIVE_FLOAT);
@@ -63,7 +63,7 @@ hsize_t createParticleInfoType()
 
   //Create compound datatype for the table
   hsize_t memtype = H5Tcreate (H5T_COMPOUND, sizeof (particle_info_t));
-  H5Tinsert (memtype, "event_id", HOFFSET (particle_info_t, event_id), H5T_NATIVE_INT32);
+  H5Tinsert (memtype, "event_id", HOFFSET (particle_info_t, event_id), H5T_NATIVE_INT64);
   H5Tinsert (memtype, "particle_id", HOFFSET (particle_info_t, particle_id), H5T_NATIVE_INT);
   H5Tinsert (memtype, "particle_name", HOFFSET (particle_info_t, particle_name),strtype);
   H5Tinsert (memtype, "primary", HOFFSET (particle_info_t, primary), H5T_NATIVE_CHAR);
@@ -118,7 +118,7 @@ hsize_t createStepType()
 
   //Create compound datatype for the table
   hsize_t memtype = H5Tcreate (H5T_COMPOUND, sizeof(step_info_t));
-  H5Tinsert (memtype, "event_id"      , HOFFSET(step_info_t, event_id      ), H5T_NATIVE_INT32);
+  H5Tinsert (memtype, "event_id"      , HOFFSET(step_info_t, event_id      ), H5T_NATIVE_INT64);
   H5Tinsert (memtype, "particle_id"   , HOFFSET(step_info_t, particle_id   ), H5T_NATIVE_INT  );
   H5Tinsert (memtype, "particle_name" , HOFFSET(step_info_t, particle_name ), strtype         );
   H5Tinsert (memtype, "step_id"       , HOFFSET(step_info_t, step_id       ), H5T_NATIVE_INT  );

--- a/source/persistency/hdf5_functions.h
+++ b/source/persistency/hdf5_functions.h
@@ -21,14 +21,14 @@
    } run_info_t;
 
   typedef struct{
-    int32_t event_id;
+    uint64_t event_id;
     unsigned int sensor_id;
-    uint64_t time_bin;
+    int64_t time_bin;
     unsigned int charge;
   } sns_data_t;
 
   typedef struct{
-        int32_t event_id;
+        int64_t event_id;
 	float x;
 	float y;
 	float z;
@@ -40,7 +40,7 @@
   } hit_info_t;
 
   typedef struct{
-        int32_t event_id;
+        int64_t event_id;
 	int particle_id;
 	char particle_name[STRLEN];
         char primary;
@@ -76,7 +76,7 @@
   } sns_pos_t;
 
   typedef struct{
-    int32_t event_id;
+    int64_t event_id;
     int32_t particle_id;
     char    particle_name[STRLEN];
     int     step_id;


### PR DESCRIPTION
This PR changes the type of the event ID in all the h5 tables, to avoid problems of overflow during big productions such as the background model.