### PR TITLE
Fix segmentation fault due to G4 bug by setting G4MaterialPropertiesTable

### DIFF
--- a/source/geometries/GenericPhotosensor.cc
+++ b/source/geometries/GenericPhotosensor.cc
@@ -83,6 +83,7 @@ void GenericPhotosensor::DefineMaterials()
 {
   // Case /////
   case_mat_ = materials::FR4();
+  case_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   // Window /////
   // The optical properties of a given material, is common for the whole geometry so,
@@ -119,6 +120,7 @@ void GenericPhotosensor::DefineMaterials()
 
   // Sensitive /////
   sensitive_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Si");
+  sensitive_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   // WLS coating /////
   wls_mat_ = materials::TPB();

--- a/source/geometries/Next1EL.cc
+++ b/source/geometries/Next1EL.cc
@@ -255,19 +255,25 @@ void Next1EL::DefineMaterials()
 {
   // AIR
   air_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+  air_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
   // GASEOUS XENON
   gxe_ = materials::GXe(pressure_, 303);
   gxe_->SetMaterialPropertiesTable(opticalprops::GXe(pressure_, 303, sc_yield_, e_lifetime_));
   // PTFE (TEFLON)
   teflon_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+  teflon_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
   // STAINLESS STEEL
   steel_ = materials::Steel();
+  steel_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
   // ALUMINUM
   aluminum_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Al");
+  aluminum_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
   //LEAD
   lead_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Pb");
+  lead_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
   //PLASTIC
   plastic_ = materials::PS();
+  plastic_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
   //TPB
   tpb_ = materials::TPB();
   tpb_->SetMaterialPropertiesTable(opticalprops::TPB());
@@ -352,6 +358,7 @@ void Next1EL::BuildExtScintillator()
     new G4Tubs("SOURCE", 0., source_diam/2., source_thick/2., 0., twopi);
   G4Material* sodium22_mat =
     G4NistManager::Instance()->FindOrBuildMaterial("G4_Na");
+  sodium22_mat->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
   G4LogicalVolume* source_logic =
     new G4LogicalVolume(source_solid, sodium22_mat, "SOURCE");
 
@@ -400,6 +407,7 @@ void Next1EL::BuildExtScintillator()
   G4Tubs* sc_solid = new G4Tubs("NaI", 0., radius, length/2., 0., twopi);
   G4Material* mat =
     G4NistManager::Instance()->FindOrBuildMaterial("G4_SODIUM_IODIDE");
+  mat->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
   G4LogicalVolume* sc_logic = new G4LogicalVolume(sc_solid, mat, "NaI");
   sc_logic->SetUserLimits(new G4UserLimits(1.*mm));
 
@@ -955,8 +963,11 @@ void Next1EL::BuildFieldCage()
     new G4UnionSolid("SUPPORT_BAR", bar_base, addon, 0,
 		     G4ThreeVector(bar_thickn_, 0., (bar_length - bar_addon_length_)/2.));
 
+  G4Material* peek_mat_ = materials::PEEK();
+  peek_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
   G4LogicalVolume* bar_logic =
-    new G4LogicalVolume(bar_solid, materials::PEEK(), "SUPPORT_BAR");
+    new G4LogicalVolume(bar_solid, peek_mat_, "SUPPORT_BAR");
 
 
   G4double pos_rad = ring_diam_/2. + ring_thickn_ + bar_thickn_/2.;

--- a/source/geometries/Next1EL.cc
+++ b/source/geometries/Next1EL.cc
@@ -963,11 +963,11 @@ void Next1EL::BuildFieldCage()
     new G4UnionSolid("SUPPORT_BAR", bar_base, addon, 0,
 		     G4ThreeVector(bar_thickn_, 0., (bar_length - bar_addon_length_)/2.));
 
-  G4Material* peek_mat_ = materials::PEEK();
-  peek_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+  G4Material* peek_mat = materials::PEEK();
+  peek_mat->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   G4LogicalVolume* bar_logic =
-    new G4LogicalVolume(bar_solid, peek_mat_, "SUPPORT_BAR");
+    new G4LogicalVolume(bar_solid, peek_mat, "SUPPORT_BAR");
 
 
   G4double pos_rad = ring_diam_/2. + ring_thickn_ + bar_thickn_/2.;

--- a/source/geometries/Next1ELDBO.cc
+++ b/source/geometries/Next1ELDBO.cc
@@ -65,6 +65,7 @@ namespace nexus {
 
     G4Material* teflon =
       G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+    teflon->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4LogicalVolume* board_logic =
       new G4LogicalVolume(board_solid, teflon, "DBO");

--- a/source/geometries/NextDemo.cc
+++ b/source/geometries/NextDemo.cc
@@ -75,9 +75,14 @@ void NextDemo::ConstructLab()
   G4Box* lab_solid_vol =
     new G4Box(lab_name, lab_size_/2., lab_size_/2., lab_size_/2.);
 
+  G4Material* air_mat_ = 
+    G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+
+  air_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
   G4LogicalVolume* lab_logic_vol =
     new G4LogicalVolume(lab_solid_vol,
-                        G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"),
+                        air_mat_,
                         lab_name);
 
   // Make the volume invisible in the visualization

--- a/source/geometries/NextDemo.cc
+++ b/source/geometries/NextDemo.cc
@@ -75,14 +75,14 @@ void NextDemo::ConstructLab()
   G4Box* lab_solid_vol =
     new G4Box(lab_name, lab_size_/2., lab_size_/2., lab_size_/2.);
 
-  G4Material* air_mat_ = 
+  G4Material* air_mat = 
     G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
 
-  air_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+  air_mat->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   G4LogicalVolume* lab_logic_vol =
     new G4LogicalVolume(lab_solid_vol,
-                        air_mat_,
+                        air_mat,
                         lab_name);
 
   // Make the volume invisible in the visualization

--- a/source/geometries/NextDemoEnergyPlane.cc
+++ b/source/geometries/NextDemoEnergyPlane.cc
@@ -120,9 +120,12 @@ namespace nexus {
                                pmt_positions_[i]);
     }
 
+    G4Material* aluminum_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Al");
+    aluminum_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
     G4LogicalVolume* carrier_plate_logic =
       new G4LogicalVolume(carrier_plate_solid,
-                          G4NistManager::Instance()->FindOrBuildMaterial("G4_Al"),
+                          aluminum_,
                           "EP_PLATE");
     G4double carrier_plate_posz =
       GetELzCoord() + gate_support_surface_dist_ + carrier_plate_thickness_/2.;
@@ -139,6 +142,7 @@ namespace nexus {
     sapphire->SetMaterialPropertiesTable(opticalprops::Sapphire());
 
     G4Material* copper = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
+    copper->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4Material* vacuum =
       G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic");
@@ -247,9 +251,13 @@ namespace nexus {
     G4Tubs* pmt_base_solid =
       new G4Tubs("PMT_BASE", 0., pmt_base_diam_/2., pmt_base_thickness_,
                  0.,twopi);
+
+    G4Material* kapton_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON");
+    kapton_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
     G4LogicalVolume* pmt_base_logic =
       new G4LogicalVolume(pmt_base_solid,
-                          G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON"),
+                          kapton_,
 			  "PMT_BASE");
     G4double pmt_base_pos = pmt_hole_length_/2. - pmt_base_thickness_;
     new G4PVPlacement(0, G4ThreeVector(0.,0., pmt_base_pos),

--- a/source/geometries/NextDemoEnergyPlane.cc
+++ b/source/geometries/NextDemoEnergyPlane.cc
@@ -120,12 +120,12 @@ namespace nexus {
                                pmt_positions_[i]);
     }
 
-    G4Material* aluminum_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Al");
-    aluminum_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+    G4Material* aluminum = G4NistManager::Instance()->FindOrBuildMaterial("G4_Al");
+    aluminum->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4LogicalVolume* carrier_plate_logic =
       new G4LogicalVolume(carrier_plate_solid,
-                          aluminum_,
+                          aluminum,
                           "EP_PLATE");
     G4double carrier_plate_posz =
       GetELzCoord() + gate_support_surface_dist_ + carrier_plate_thickness_/2.;
@@ -252,12 +252,12 @@ namespace nexus {
       new G4Tubs("PMT_BASE", 0., pmt_base_diam_/2., pmt_base_thickness_,
                  0.,twopi);
 
-    G4Material* kapton_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON");
-    kapton_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+    G4Material* kapton = G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON");
+    kapton->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4LogicalVolume* pmt_base_logic =
       new G4LogicalVolume(pmt_base_solid,
-                          kapton_,
+                          kapton,
 			  "PMT_BASE");
     G4double pmt_base_pos = pmt_hole_length_/2. - pmt_base_thickness_;
     new G4PVPlacement(0, G4ThreeVector(0.,0., pmt_base_pos),

--- a/source/geometries/NextDemoFieldCage.cc
+++ b/source/geometries/NextDemoFieldCage.cc
@@ -225,10 +225,12 @@ namespace nexus {
     temperature_ = gas_->GetTemperature();
 
     aluminum_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Al");
+    aluminum_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     /// Teflon for the light tube
     teflon_ =
       G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+    teflon_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     /// Quartz
     quartz_ =  materials::FusedSilica();

--- a/source/geometries/NextDemoSiPMBoard.cc
+++ b/source/geometries/NextDemoSiPMBoard.cc
@@ -179,9 +179,12 @@ void NextDemoSiPMBoard::Construct()
   G4Box* kapton_solid = new G4Box(kapton_name, board_size_x/2.,
                                   board_size_y/2., kapton_thickn_/2.);
 
+  G4Material* kapton_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON");
+  kapton_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
   G4LogicalVolume* kapton_logic =
     new G4LogicalVolume(kapton_solid,
-                        G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON"),
+                        kapton_mat_,
                         kapton_name);
 
   new G4PVPlacement(nullptr, G4ThreeVector(0., 0., kapton_posz), kapton_logic,
@@ -196,8 +199,11 @@ void NextDemoSiPMBoard::Construct()
   G4Box* mask_solid = new G4Box(mask_name, board_size_x/2.,
                                 board_size_y/2., mask_thickn_/2.);
 
+  G4Material* teflon_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+  teflon_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
   G4LogicalVolume* mask_logic =
-    new G4LogicalVolume(mask_solid, G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON"),
+    new G4LogicalVolume(mask_solid, teflon_,
                         mask_name);
 
   // Adding the optical surface

--- a/source/geometries/NextDemoSiPMBoard.cc
+++ b/source/geometries/NextDemoSiPMBoard.cc
@@ -179,12 +179,12 @@ void NextDemoSiPMBoard::Construct()
   G4Box* kapton_solid = new G4Box(kapton_name, board_size_x/2.,
                                   board_size_y/2., kapton_thickn_/2.);
 
-  G4Material* kapton_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON");
-  kapton_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+  G4Material* kapton_mat = G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON");
+  kapton_mat->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   G4LogicalVolume* kapton_logic =
     new G4LogicalVolume(kapton_solid,
-                        kapton_mat_,
+                        kapton_mat,
                         kapton_name);
 
   new G4PVPlacement(nullptr, G4ThreeVector(0., 0., kapton_posz), kapton_logic,
@@ -199,11 +199,11 @@ void NextDemoSiPMBoard::Construct()
   G4Box* mask_solid = new G4Box(mask_name, board_size_x/2.,
                                 board_size_y/2., mask_thickn_/2.);
 
-  G4Material* teflon_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
-  teflon_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+  G4Material* teflon = G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+  teflon->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   G4LogicalVolume* mask_logic =
-    new G4LogicalVolume(mask_solid, teflon_,
+    new G4LogicalVolume(mask_solid, teflon,
                         mask_name);
 
   // Adding the optical surface

--- a/source/geometries/NextElDB.cc
+++ b/source/geometries/NextElDB.cc
@@ -67,6 +67,8 @@ namespace nexus {
     G4Material* teflon =
       G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
 
+    teflon->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
     G4LogicalVolume* board_logic =
       new G4LogicalVolume(board_solid, teflon, "DICE_BOARD");
 

--- a/source/geometries/NextFlex.cc
+++ b/source/geometries/NextFlex.cc
@@ -142,9 +142,11 @@ void NextFlex::DefineMaterials()
 {
   // Copper
   copper_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
+  copper_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   // Air
   air_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+  air_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   // Defining the gas xenon
   if (gas_name_ == "naturalXe")

--- a/source/geometries/NextFlexEnergyPlane.cc
+++ b/source/geometries/NextFlexEnergyPlane.cc
@@ -143,9 +143,11 @@ void NextFlexEnergyPlane::DefineMaterials()
 
   // Copper
   copper_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
+  copper_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   // Teflon
   teflon_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+  teflon_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   // Sapphire
   sapphire_mat_ = materials::Sapphire();

--- a/source/geometries/NextFlexFieldCage.cc
+++ b/source/geometries/NextFlexFieldCage.cc
@@ -292,6 +292,7 @@ void NextFlexFieldCage::DefineMaterials()
 
   // Teflon
   teflon_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+  teflon_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   // UV shifting material
   if (wls_mat_name_ == "NONE") {

--- a/source/geometries/NextFlexTrackingPlane.cc
+++ b/source/geometries/NextFlexTrackingPlane.cc
@@ -200,9 +200,11 @@ void NextFlexTrackingPlane::DefineMaterials()
 
   // Copper
   copper_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
+  copper_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   // Teflon
   teflon_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+  teflon_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   // UV shifting material
   if (wls_mat_name_ == "NONE") {

--- a/source/geometries/NextNew.cc
+++ b/source/geometries/NextNew.cc
@@ -179,13 +179,17 @@ namespace nexus {
 				   hallA_length, hallA_length);
       G4Material *vacuum =
 	G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic");
+      vacuum->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
       lab_logic_ = new G4LogicalVolume(lab_solid, vacuum, "LAB");
       this->SetSpan(2 * hallA_length);
     } else {
       G4Box* lab_solid =
 	new G4Box("LAB", lab_size_/2., lab_size_/2., lab_size_/2.);
 
-      lab_logic_ = new G4LogicalVolume(lab_solid, G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"), "LAB");
+      G4Material* air_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+      air_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+      lab_logic_ = new G4LogicalVolume(lab_solid, air_mat_, "LAB");
     }
     lab_logic_->SetVisAttributes(G4VisAttributes::GetInvisible());
 

--- a/source/geometries/NextNew.cc
+++ b/source/geometries/NextNew.cc
@@ -187,9 +187,9 @@ namespace nexus {
       G4Box* lab_solid =
 	new G4Box("LAB", lab_size_/2., lab_size_/2., lab_size_/2.);
 
-      G4Material* air_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
-      air_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
-      lab_logic_ = new G4LogicalVolume(lab_solid, air_mat_, "LAB");
+      G4Material* air_mat = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+      air_mat->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+      lab_logic_ = new G4LogicalVolume(lab_solid, air_mat, "LAB");
     }
     lab_logic_->SetVisAttributes(G4VisAttributes::GetInvisible());
 

--- a/source/geometries/NextNewEnergyPlane.cc
+++ b/source/geometries/NextNewEnergyPlane.cc
@@ -138,10 +138,12 @@ namespace nexus {
       new G4SubtractionSolid("CARRIER_PLATE", carrier_plate_solid, axial_port_hole_solid,
 			     0, G4ThreeVector(0., 0., - carrier_plate_front_buffer_thickness_ - axial_port_thickn_));
 
+    G4Material* copper_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
+    copper_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4LogicalVolume* carrier_plate_logic =
       new G4LogicalVolume(carrier_plate_solid,
-			  G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"),
+			  copper_mat_,
 			  "CARRIER_PLATE");
 
 

--- a/source/geometries/NextNewEnergyPlane.cc
+++ b/source/geometries/NextNewEnergyPlane.cc
@@ -138,12 +138,12 @@ namespace nexus {
       new G4SubtractionSolid("CARRIER_PLATE", carrier_plate_solid, axial_port_hole_solid,
 			     0, G4ThreeVector(0., 0., - carrier_plate_front_buffer_thickness_ - axial_port_thickn_));
 
-    G4Material* copper_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
-    copper_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+    G4Material* copper_mat = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
+    copper_mat->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4LogicalVolume* carrier_plate_logic =
       new G4LogicalVolume(carrier_plate_solid,
-			  copper_mat_,
+			  copper_mat,
 			  "CARRIER_PLATE");
 
 

--- a/source/geometries/NextNewFieldCage.cc
+++ b/source/geometries/NextNewFieldCage.cc
@@ -281,9 +281,11 @@ namespace nexus {
 
     // Copper for field rings
     copper_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
+    copper_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
     // Teflon for the light tube
     teflon_ =
       G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+    teflon_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
     // TPB coating
     tpb_ = materials::TPB();
     tpb_->SetMaterialPropertiesTable(opticalprops::TPB());

--- a/source/geometries/NextNewIcs.cc
+++ b/source/geometries/NextNewIcs.cc
@@ -125,10 +125,11 @@ namespace nexus {
     ics_solid = new G4SubtractionSolid("ICS", ics_solid, up_big_nozzle_hole_solid, rotx,
 				                               G4ThreeVector( 0., up_nozzle_y_pos_, center_nozzle_z_pos_ +up_nozzle_z_pos_));
 
+    G4Material* copper_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
+    copper_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4LogicalVolume* ics_logic =
-      new G4LogicalVolume(ics_solid,
-     						          G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"), "ICS");
+      new G4LogicalVolume(ics_solid, copper_mat_, "ICS");
 
     new G4PVPlacement(0, G4ThreeVector(0.,0.,-body_zpos_), ics_logic, "ICS", mother_logic_, false, 0, false);
 

--- a/source/geometries/NextNewIcs.cc
+++ b/source/geometries/NextNewIcs.cc
@@ -125,11 +125,11 @@ namespace nexus {
     ics_solid = new G4SubtractionSolid("ICS", ics_solid, up_big_nozzle_hole_solid, rotx,
 				                               G4ThreeVector( 0., up_nozzle_y_pos_, center_nozzle_z_pos_ +up_nozzle_z_pos_));
 
-    G4Material* copper_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
-    copper_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+    G4Material* copper_mat = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
+    copper_mat->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4LogicalVolume* ics_logic =
-      new G4LogicalVolume(ics_solid, copper_mat_, "ICS");
+      new G4LogicalVolume(ics_solid, copper_mat, "ICS");
 
     new G4PVPlacement(0, G4ThreeVector(0.,0.,-body_zpos_), ics_logic, "ICS", mother_logic_, false, 0, false);
 

--- a/source/geometries/NextNewKDB.cc
+++ b/source/geometries/NextNewKDB.cc
@@ -111,6 +111,7 @@ namespace nexus {
 
     G4Material* kapton =
       G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON");
+    kapton->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4LogicalVolume* board_logic =
       new G4LogicalVolume(board_solid, kapton, "DICE_BOARD");
@@ -125,6 +126,7 @@ namespace nexus {
 
     G4Material* teflon =
       G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
+    teflon->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4LogicalVolume* mask_logic =
       new G4LogicalVolume(mask_solid, teflon, "DICE_MASK");

--- a/source/geometries/NextNewMiniCastle.cc
+++ b/source/geometries/NextNewMiniCastle.cc
@@ -116,11 +116,11 @@ namespace nexus {
       new G4UnionSolid("MINI_CASTLE", castle_solid, z_wall_solid_sipms, 0,
      		       G4ThreeVector(0., -y_/2.+thickness_/2., z_/2.-thickness_/2.));
 
-    G4Material* lead_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Pb");
-    lead_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+    G4Material* lead = G4NistManager::Instance()->FindOrBuildMaterial("G4_Pb");
+    lead->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4LogicalVolume* castle_logic =
-      new G4LogicalVolume (castle_solid, lead_, "CASTLE");
+      new G4LogicalVolume (castle_solid, lead, "CASTLE");
 
     G4double y_pos = pedestal_surf_y_ + y_ -thickness_/2.;
     new G4PVPlacement(0, G4ThreeVector(0., y_pos, 0.), castle_logic,
@@ -160,11 +160,11 @@ namespace nexus {
       new G4UnionSolid("MINI_CASTLE_STEEL", steel_solid, z_steel_solid_sipms, 0,
       		       G4ThreeVector(0., -steel_y/2.+steel_thickn_/2., steel_z/2.-steel_thickn_/2.));
 
-    G4Material* steel_ = materials::Steel();
-    steel_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+    G4Material* steel = materials::Steel();
+    steel->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4LogicalVolume* steel_logic =
-      new G4LogicalVolume (steel_solid, steel_, "MINI_CASTLE_STEEL");
+      new G4LogicalVolume (steel_solid, steel, "MINI_CASTLE_STEEL");
 
     y_pos = pedestal_surf_y_ + y_ -thickness_ - steel_thickn_/2.;
     new G4PVPlacement(0, G4ThreeVector(0., y_pos, 0.), steel_logic,

--- a/source/geometries/NextNewMiniCastle.cc
+++ b/source/geometries/NextNewMiniCastle.cc
@@ -116,9 +116,11 @@ namespace nexus {
       new G4UnionSolid("MINI_CASTLE", castle_solid, z_wall_solid_sipms, 0,
      		       G4ThreeVector(0., -y_/2.+thickness_/2., z_/2.-thickness_/2.));
 
+    G4Material* lead_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Pb");
+    lead_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
     G4LogicalVolume* castle_logic =
-      new G4LogicalVolume (castle_solid,
-			   G4NistManager::Instance()->FindOrBuildMaterial("G4_Pb"),"CASTLE");
+      new G4LogicalVolume (castle_solid, lead_, "CASTLE");
 
     G4double y_pos = pedestal_surf_y_ + y_ -thickness_/2.;
     new G4PVPlacement(0, G4ThreeVector(0., y_pos, 0.), castle_logic,
@@ -158,8 +160,11 @@ namespace nexus {
       new G4UnionSolid("MINI_CASTLE_STEEL", steel_solid, z_steel_solid_sipms, 0,
       		       G4ThreeVector(0., -steel_y/2.+steel_thickn_/2., steel_z/2.-steel_thickn_/2.));
 
+    G4Material* steel_ = materials::Steel();
+    steel_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
     G4LogicalVolume* steel_logic =
-      new G4LogicalVolume (steel_solid, materials::Steel(), "MINI_CASTLE_STEEL");
+      new G4LogicalVolume (steel_solid, steel_, "MINI_CASTLE_STEEL");
 
     y_pos = pedestal_surf_y_ + y_ -thickness_ - steel_thickn_/2.;
     new G4PVPlacement(0, G4ThreeVector(0., y_pos, 0.), steel_logic,

--- a/source/geometries/NextNewPedestal.cc
+++ b/source/geometries/NextNewPedestal.cc
@@ -54,11 +54,11 @@ namespace nexus {
     G4Box* table_solid =
       new G4Box("TABLE", table_x_/2., table_y_/2., table_z_/2.);
 
-    G4Material* steel_316_Ti_ = materials::Steel316Ti();
-    steel_316_Ti_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+    G4Material* steel_316_Ti = materials::Steel316Ti();
+    steel_316_Ti->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4LogicalVolume* table_logic = new G4LogicalVolume(table_solid,
-						       steel_316_Ti_,
+						       steel_316_Ti,
 						       "TABLE");
     new G4PVPlacement(0, G4ThreeVector(0.,y_pos_,0.), table_logic, "TABLE", mother_logic_, false, 0,false);
 

--- a/source/geometries/NextNewPedestal.cc
+++ b/source/geometries/NextNewPedestal.cc
@@ -10,6 +10,7 @@
 #include "MaterialsList.h"
 #include "Visibilities.h"
 
+#include <G4Material.hh>
 #include <G4GenericMessenger.hh>
 #include <G4LogicalVolume.hh>
 #include <G4PVPlacement.hh>

--- a/source/geometries/NextNewPedestal.cc
+++ b/source/geometries/NextNewPedestal.cc
@@ -53,8 +53,11 @@ namespace nexus {
     G4Box* table_solid =
       new G4Box("TABLE", table_x_/2., table_y_/2., table_z_/2.);
 
+    G4Material* steel_316_Ti_ = materials::Steel316Ti();
+    steel_316_Ti_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
     G4LogicalVolume* table_logic = new G4LogicalVolume(table_solid,
-						       materials::Steel316Ti(),
+						       steel_316_Ti_,
 						       "TABLE");
     new G4PVPlacement(0, G4ThreeVector(0.,y_pos_,0.), table_logic, "TABLE", mother_logic_, false, 0,false);
 

--- a/source/geometries/NextNewPmtEnclosure.cc
+++ b/source/geometries/NextNewPmtEnclosure.cc
@@ -104,7 +104,7 @@ namespace nexus{
     G4UnionSolid* enclosure_solid =
       new G4UnionSolid("ENCLOSURE_SOLID", enclosure_body, enclosure_endcap, nullptr, transl);
 
-    G4Material* copper = G4NistManager::Instance()->FindOrBuidlMaterial("G4_Cu");
+    G4Material* copper = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
     copper->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4LogicalVolume* enclosure_logic =

--- a/source/geometries/NextNewPmtEnclosure.cc
+++ b/source/geometries/NextNewPmtEnclosure.cc
@@ -104,9 +104,12 @@ namespace nexus{
     G4UnionSolid* enclosure_solid =
       new G4UnionSolid("ENCLOSURE_SOLID", enclosure_body, enclosure_endcap, nullptr, transl);
 
+    G4Material* copper = G4NistManager::Instance()->FindOrBuidlMaterial("G4_Cu");
+    copper->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
     G4LogicalVolume* enclosure_logic =
       new G4LogicalVolume(enclosure_solid,
-                          G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"),
+                          copper,
                           "ENCLOSURE");
     GeometryBase::SetLogicalVolume(enclosure_logic);
 
@@ -198,9 +201,13 @@ namespace nexus{
     // Adding the PMT base
     G4Tubs* pmt_base_solid =
       new G4Tubs("PMT_BASE", 0., pmt_base_diam_/2., pmt_base_thickness_, 0.,twopi);
+    
+    G4Material* kapton = G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON");
+    kapton->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
     G4LogicalVolume* pmt_base_logic =
       new G4LogicalVolume(pmt_base_solid,
-                          G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON"),
+                          kapton,
                           "PMT_BASE");
     new G4PVPlacement(nullptr, G4ThreeVector(0.,0., -pmt_base_z_),
                       pmt_base_logic, "PMT_BASE", enclosure_gas_logic, false, 0, false);

--- a/source/geometries/NextNewTrackingPlane.cc
+++ b/source/geometries/NextNewTrackingPlane.cc
@@ -111,11 +111,11 @@ namespace nexus {
      						   support_plate_cable_hole_solid, 0, pos);
     }
 
-    G4Material* copper_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
-    copper_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+    G4Material* copper_mat = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
+    copper_mat->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4LogicalVolume* support_plate_logic = new G4LogicalVolume(support_plate_solid,
-							       copper_mat_,
+							       copper_mat,
 							       "SUPPORT_PLATE");
 
     ///// Support Plate placement
@@ -146,10 +146,10 @@ namespace nexus {
     //PIGGY TAIL PLUG/////////////////////////////////////////////////////
     G4Box* plug_solid = new G4Box("DB_CONNECTOR", plug_x_/2., plug_y_/2., plug_z_/2.);
 
-    G4Material* peek_mat_ = materials::PEEK();
-    peek_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+    G4Material* peek_mat = materials::PEEK();
+    peek_mat->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
-    G4LogicalVolume* plug_logic = new G4LogicalVolume(plug_solid,  peek_mat_, "DB_PLUG");
+    G4LogicalVolume* plug_logic = new G4LogicalVolume(plug_solid,  peek_mat, "DB_PLUG");
     //G4PVPlacement * plug_physi;
     G4ThreeVector positn;
     for (int i=0; i<num_DBs_; i++) {

--- a/source/geometries/NextNewTrackingPlane.cc
+++ b/source/geometries/NextNewTrackingPlane.cc
@@ -111,8 +111,11 @@ namespace nexus {
      						   support_plate_cable_hole_solid, 0, pos);
     }
 
+    G4Material* copper_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
+    copper_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
     G4LogicalVolume* support_plate_logic = new G4LogicalVolume(support_plate_solid,
-							       G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"),
+							       copper_mat_,
 							       "SUPPORT_PLATE");
 
     ///// Support Plate placement
@@ -142,7 +145,11 @@ namespace nexus {
 
     //PIGGY TAIL PLUG/////////////////////////////////////////////////////
     G4Box* plug_solid = new G4Box("DB_CONNECTOR", plug_x_/2., plug_y_/2., plug_z_/2.);
-    G4LogicalVolume* plug_logic = new G4LogicalVolume(plug_solid,  materials::PEEK(), "DB_PLUG");
+
+    G4Material* peek_mat_ = materials::PEEK();
+    peek_mat->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
+    G4LogicalVolume* plug_logic = new G4LogicalVolume(plug_solid,  peek_mat_, "DB_PLUG");
     //G4PVPlacement * plug_physi;
     G4ThreeVector positn;
     for (int i=0; i<num_DBs_; i++) {

--- a/source/geometries/NextNewTrackingPlane.cc
+++ b/source/geometries/NextNewTrackingPlane.cc
@@ -147,7 +147,7 @@ namespace nexus {
     G4Box* plug_solid = new G4Box("DB_CONNECTOR", plug_x_/2., plug_y_/2., plug_z_/2.);
 
     G4Material* peek_mat_ = materials::PEEK();
-    peek_mat->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+    peek_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4LogicalVolume* plug_logic = new G4LogicalVolume(plug_solid,  peek_mat_, "DB_PLUG");
     //G4PVPlacement * plug_physi;

--- a/source/geometries/NextNewVessel.cc
+++ b/source/geometries/NextNewVessel.cc
@@ -378,11 +378,11 @@ void NextNewVessel::Construct()
       new G4Tubs("LATERAL_PORT_AIR_EXT", 0., port_tube_diam_/2.,
     		 (lat_nozzle_flange_high_ + lat_port_tube_out_)/2., 0., twopi);
     
-    G4Material* air_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
-    air_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+    G4Material* air_mat = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+    air_mat->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
     
     G4LogicalVolume* lateral_port_hole_logic =
-      new G4LogicalVolume(lateral_port_hole_solid, air_mat_,
+      new G4LogicalVolume(lateral_port_hole_solid, air_mat,
 			  "LATERAL_PORT_AIR_EXT");
     new G4PVPlacement(G4Transform3D(*rot_lat, G4ThreeVector(vessel_in_diam_/2.+lat_nozzle_high_+(lat_nozzle_flange_high_+lat_port_tube_out_)/2., 0., lat_nozzle_z_pos_)),
 		      lateral_port_hole_logic, "LATERAL_PORT_AIR_EXT", vessel_logic, false, 0, false);
@@ -392,7 +392,7 @@ void NextNewVessel::Construct()
       new G4Tubs("UP_PORT_AIR_EXT", 0., port_tube_diam_/2.,
     		 (up_nozzle_flange_high_ + up_port_tube_out_)/2., 0., twopi);
     G4LogicalVolume* upper_port_hole_logic =
-      new G4LogicalVolume(upper_port_hole_solid, air_mat_,
+      new G4LogicalVolume(upper_port_hole_solid, air_mat,
 			  "UP_PORT_AIR_EXT");
     new G4PVPlacement(G4Transform3D(*rot_up, G4ThreeVector(0., vessel_in_diam_/2.+ up_nozzle_high_ + (up_nozzle_flange_high_ + up_port_tube_out_)/2. , 0.)), upper_port_hole_logic,
     		      "UP_PORT_AIR_EXT", vessel_logic, false, 0, false);
@@ -401,7 +401,7 @@ void NextNewVessel::Construct()
       new G4Tubs("AXIAL_PORT_AIR_EXT", 0., port_tube_diam_/2.,
     		 (endcap_nozzle_flange_high_ + axial_port_tube_ext)/2., 0., twopi);
     G4LogicalVolume* axial_port_hole_logic =
-      new G4LogicalVolume(axial_port_hole_solid, air_mat_,
+      new G4LogicalVolume(axial_port_hole_solid, air_mat,
 			  "AXIAL_PORT_AIR_EXT");
     // new G4PVPlacement(G4Transform3D(*rot_endcap, G4ThreeVector(0., 0.,  endcap_nozzle_z_pos_ + endcap_nozzle_high_ + (endcap_nozzle_flange_high_)/2.)), axial_port_hole_logic,
     new G4PVPlacement(G4Transform3D(*rot_endcap, G4ThreeVector(0., 0.,  -endcap_nozzle_z_pos_ - endcap_nozzle_high_ - (endcap_nozzle_flange_high_ + axial_port_tube_ext)/2.)), axial_port_hole_logic,
@@ -466,7 +466,7 @@ void NextNewVessel::Construct()
 
   G4LogicalVolume* lateral_port_tube_air_logic =
     new G4LogicalVolume(lateral_port_tube_air_solid,
-			air_mat_, "LATERAL_PORT_AIR");
+			air_mat, "LATERAL_PORT_AIR");
 
   new G4PVPlacement(0,G4ThreeVector(0.,0., -port_tube_window_thickn_/2.),
 		    lateral_port_tube_air_logic, "LATERAL_PORT_AIR",
@@ -557,7 +557,7 @@ void NextNewVessel::Construct()
 
   G4LogicalVolume* upper_port_tube_air_logic =
     new G4LogicalVolume(upper_port_tube_air_solid,
-			air_mat_, "UPPER_PORT_AIR");
+			air_mat, "UPPER_PORT_AIR");
 
   new G4PVPlacement(0,G4ThreeVector(0.,0.,-port_tube_window_thickn_/2.),
 		    upper_port_tube_air_logic, "UPPER_PORT_AIR",
@@ -652,7 +652,7 @@ void NextNewVessel::Construct()
 
   G4LogicalVolume* axial_port_tube_air_logic =
     new G4LogicalVolume(axial_port_tube_air_solid,
-			air_mat_, "AXIAL_PORT_AIR");
+			air_mat, "AXIAL_PORT_AIR");
 
   new G4PVPlacement(0,G4ThreeVector(0.,0., -port_tube_window_thickn_/2.),
 		    axial_port_tube_air_logic, "AXIAL_PORT_AIR",

--- a/source/geometries/NextNewVessel.cc
+++ b/source/geometries/NextNewVessel.cc
@@ -365,16 +365,24 @@ void NextNewVessel::Construct()
 
 
     //// LOGICS //////
+    
+    G4Material* steel_316_Ti = materials::Steel316Ti();
+    steel_316_Ti->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
     G4LogicalVolume* vessel_logic =
-      new G4LogicalVolume(vessel_solid,	materials::Steel316Ti(), "VESSEL");
+      new G4LogicalVolume(vessel_solid,	steel_316_Ti, "VESSEL");
     this->SetLogicalVolume(vessel_logic);
 
     // Place the port air inside the flanges end external tubes for lateral and upper
     G4Tubs* lateral_port_hole_solid =
       new G4Tubs("LATERAL_PORT_AIR_EXT", 0., port_tube_diam_/2.,
     		 (lat_nozzle_flange_high_ + lat_port_tube_out_)/2., 0., twopi);
+    
+    G4Material* air_mat_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+    air_mat_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+    
     G4LogicalVolume* lateral_port_hole_logic =
-      new G4LogicalVolume(lateral_port_hole_solid, G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"),
+      new G4LogicalVolume(lateral_port_hole_solid, air_mat_,
 			  "LATERAL_PORT_AIR_EXT");
     new G4PVPlacement(G4Transform3D(*rot_lat, G4ThreeVector(vessel_in_diam_/2.+lat_nozzle_high_+(lat_nozzle_flange_high_+lat_port_tube_out_)/2., 0., lat_nozzle_z_pos_)),
 		      lateral_port_hole_logic, "LATERAL_PORT_AIR_EXT", vessel_logic, false, 0, false);
@@ -384,7 +392,7 @@ void NextNewVessel::Construct()
       new G4Tubs("UP_PORT_AIR_EXT", 0., port_tube_diam_/2.,
     		 (up_nozzle_flange_high_ + up_port_tube_out_)/2., 0., twopi);
     G4LogicalVolume* upper_port_hole_logic =
-      new G4LogicalVolume(upper_port_hole_solid, G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"),
+      new G4LogicalVolume(upper_port_hole_solid, air_mat_,
 			  "UP_PORT_AIR_EXT");
     new G4PVPlacement(G4Transform3D(*rot_up, G4ThreeVector(0., vessel_in_diam_/2.+ up_nozzle_high_ + (up_nozzle_flange_high_ + up_port_tube_out_)/2. , 0.)), upper_port_hole_logic,
     		      "UP_PORT_AIR_EXT", vessel_logic, false, 0, false);
@@ -393,7 +401,7 @@ void NextNewVessel::Construct()
       new G4Tubs("AXIAL_PORT_AIR_EXT", 0., port_tube_diam_/2.,
     		 (endcap_nozzle_flange_high_ + axial_port_tube_ext)/2., 0., twopi);
     G4LogicalVolume* axial_port_hole_logic =
-      new G4LogicalVolume(axial_port_hole_solid, G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"),
+      new G4LogicalVolume(axial_port_hole_solid, air_mat_,
 			  "AXIAL_PORT_AIR_EXT");
     // new G4PVPlacement(G4Transform3D(*rot_endcap, G4ThreeVector(0., 0.,  endcap_nozzle_z_pos_ + endcap_nozzle_high_ + (endcap_nozzle_flange_high_)/2.)), axial_port_hole_logic,
     new G4PVPlacement(G4Transform3D(*rot_endcap, G4ThreeVector(0., 0.,  -endcap_nozzle_z_pos_ - endcap_nozzle_high_ - (endcap_nozzle_flange_high_ + axial_port_tube_ext)/2.)), axial_port_hole_logic,
@@ -443,7 +451,7 @@ void NextNewVessel::Construct()
 						 simulated_length_lat/2., 0, twopi);
 
     G4LogicalVolume* lateral_port_tube_logic =
-    new G4LogicalVolume(lateral_port_tube_solid, materials::Steel316Ti(), "LATERAL_PORT");
+    new G4LogicalVolume(lateral_port_tube_solid, steel_316_Ti, "LATERAL_PORT");
 
     // G4ThreeVector pos_lateral_port(lat_nozzle_x_pos_  + lat_nozzle_high_/2. - simulated_length_lat/2.,  0., lat_nozzle_z_pos_);
     G4ThreeVector pos_lateral_port(vessel_in_diam_/2.  + lat_nozzle_high_ - simulated_length_lat/2.,  0., lat_nozzle_z_pos_);
@@ -458,7 +466,7 @@ void NextNewVessel::Construct()
 
   G4LogicalVolume* lateral_port_tube_air_logic =
     new G4LogicalVolume(lateral_port_tube_air_solid,
-			G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"), "LATERAL_PORT_AIR");
+			air_mat_, "LATERAL_PORT_AIR");
 
   new G4PVPlacement(0,G4ThreeVector(0.,0., -port_tube_window_thickn_/2.),
 		    lateral_port_tube_air_logic, "LATERAL_PORT_AIR",
@@ -535,7 +543,7 @@ void NextNewVessel::Construct()
   G4Tubs* upper_port_tube_solid = new G4Tubs("UPPER_PORT", 0., port_tube_diam_/2.+port_tube_thickness_,
 					     simulated_length_up/2., 0, twopi);
   G4LogicalVolume* upper_port_tube_logic =
-    new G4LogicalVolume(upper_port_tube_solid, materials::Steel316Ti(), "UPPER_PORT");
+    new G4LogicalVolume(upper_port_tube_solid, steel_316_Ti, "UPPER_PORT");
 
   G4ThreeVector pos_upper_port(0., vessel_in_diam_/2. + up_nozzle_high_ - simulated_length_up/2., 0.);
 
@@ -549,7 +557,7 @@ void NextNewVessel::Construct()
 
   G4LogicalVolume* upper_port_tube_air_logic =
     new G4LogicalVolume(upper_port_tube_air_solid,
-			G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"), "UPPER_PORT_AIR");
+			air_mat_, "UPPER_PORT_AIR");
 
   new G4PVPlacement(0,G4ThreeVector(0.,0.,-port_tube_window_thickn_/2.),
 		    upper_port_tube_air_logic, "UPPER_PORT_AIR",
@@ -629,7 +637,7 @@ void NextNewVessel::Construct()
     new G4Tubs("AXIAL_PORT", 0., port_tube_diam_/2.+port_tube_thickness_,
 	       simulated_length/2., 0, twopi);
   G4LogicalVolume* axial_port_tube_logic =
-    new G4LogicalVolume(axial_port_tube_solid, materials::Steel316Ti(), "AXIAL_PORT");
+    new G4LogicalVolume(axial_port_tube_solid, steel_316_Ti, "AXIAL_PORT");
 
   G4ThreeVector pos_axial_port(0.,0.,  - endcap_nozzle_z_pos_ - endcap_nozzle_high_ +  simulated_length/2.);
 
@@ -644,7 +652,7 @@ void NextNewVessel::Construct()
 
   G4LogicalVolume* axial_port_tube_air_logic =
     new G4LogicalVolume(axial_port_tube_air_solid,
-			G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"), "AXIAL_PORT_AIR");
+			air_mat_, "AXIAL_PORT_AIR");
 
   new G4PVPlacement(0,G4ThreeVector(0.,0., -port_tube_window_thickn_/2.),
 		    axial_port_tube_air_logic, "AXIAL_PORT_AIR",

--- a/source/geometries/NextTonScale.cc
+++ b/source/geometries/NextTonScale.cc
@@ -86,6 +86,8 @@ void NextTonScale::Construct()
   G4Material* lab_material =
     G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
 
+  lab_material->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
+
   G4Box* lab_solid_vol = new G4Box(lab_name, lab_size/2., lab_size/2., lab_size/2.);
   G4LogicalVolume* lab_logic_vol = new G4LogicalVolume(lab_solid_vol, lab_material, lab_name);
   lab_logic_vol->SetVisAttributes(G4VisAttributes::GetInvisible());
@@ -113,6 +115,7 @@ G4LogicalVolume* NextTonScale::ConstructWaterTank(G4LogicalVolume* mother_logic_
   G4String tank_name = "TANK";
   G4Material* tank_material =
     G4NistManager::Instance()->FindOrBuildMaterial("G4_STAINLESS-STEEL");
+  tank_material->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   G4Tubs* tank_solid_vol =
     new G4Tubs(tank_name, 0., tank_size_/2., tank_size_/2., 0., 360.*deg);
@@ -136,6 +139,7 @@ G4LogicalVolume* NextTonScale::ConstructWaterTank(G4LogicalVolume* mother_logic_
   G4double water_size = tank_size_ - 2.*tank_thickn_;
   G4Material* water_material =
     G4NistManager::Instance()->FindOrBuildMaterial("G4_WATER");
+  water_material->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   G4Tubs* water_solid_vol =
     new G4Tubs(water_name, 0., water_size/2., water_size/2., 0., 360.*deg);
@@ -174,6 +178,7 @@ G4LogicalVolume* NextTonScale::ConstructVesselAndICS(G4LogicalVolume* mother_log
   G4String vessel_name = "VESSEL";
   G4Material* vessel_material =
     G4NistManager::Instance()->FindOrBuildMaterial("G4_STAINLESS-STEEL");
+  vessel_material->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   G4Tubs* vessel_solid_vol =
     new G4Tubs(vessel_name, 0., detector_diam_/2., detector_length_/2., 0., 360.*deg);
@@ -223,6 +228,7 @@ G4LogicalVolume* NextTonScale::ConstructVesselAndICS(G4LogicalVolume* mother_log
   G4double ics_diam = gas_diam;
   G4double ics_length = gas_length - 2.*endcap_hollow_;
   G4Material* ics_material = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
+  ics_material->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   G4Tubs* ics_full_solid_vol =
     new G4Tubs("ICS_FULL", 0., ics_diam/2., ics_length/2., 0., 360.*deg);
@@ -272,6 +278,7 @@ G4LogicalVolume* NextTonScale::ConstructFieldCageAndReadout(G4LogicalVolume* mot
   G4double fcage_length = active_length_;
   G4Material* fcage_material =
     G4NistManager::Instance()->FindOrBuildMaterial("G4_POLYETHYLENE");
+  fcage_material->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   G4Tubs* fcage_solid_vol = new G4Tubs(fcage_name, active_diam_/2., fcage_diam/2.,
                                        fcage_length/2., 0., 360.*deg);
@@ -315,6 +322,7 @@ G4LogicalVolume* NextTonScale::ConstructFieldCageAndReadout(G4LogicalVolume* mot
 
   G4Material* cathode_mat =
     G4NistManager::Instance()->FindOrBuildMaterial("G4_STAINLESS-STEEL");
+  cathode_mat->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   G4Tubs* cathode_solid_vol =
     new G4Tubs(cathode_name, 0., cathode_diam/2., cathode_thickn_/2., 0., 360.*deg);
@@ -360,6 +368,7 @@ G4LogicalVolume* NextTonScale::ConstructFieldCageAndReadout(G4LogicalVolume* mot
 
   G4Material* readout_material =
     G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON");
+  readout_material->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
   G4Tubs* readout_solid_vol =
     new G4Tubs(readout_name, 0., readout_diam/2., readout_thickn/2., 0., 360.*deg);

--- a/source/geometries/PmtR11410.cc
+++ b/source/geometries/PmtR11410.cc
@@ -83,6 +83,7 @@ namespace nexus {
 
 
     G4Material* Kovar = materials::Kovar();
+    Kovar->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4LogicalVolume* pmt_logic =
       new G4LogicalVolume(pmt_solid, Kovar, "PMT_R11410");
@@ -108,6 +109,7 @@ namespace nexus {
 						   rear_body_gas_solid, 0, gas_transl);
 
     G4Material* pmt_gas_mat = G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic");
+    pmt_gas_mat->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
     G4LogicalVolume* pmt_gas_logic = new G4LogicalVolume(pmt_gas_solid, pmt_gas_mat, "PMT_GAS");
 
     G4double pmt_gas_posz = body_thickness_/2.;
@@ -137,6 +139,7 @@ namespace nexus {
 		 0., twopi);
 
     G4Material* aluminum = G4NistManager::Instance()->FindOrBuildMaterial("G4_Al");
+    aluminum->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
     G4LogicalVolume* photocathode_logic =
       new G4LogicalVolume(photocathode_solid, aluminum, "PMT_PHOTOCATHODE");
 


### PR DESCRIPTION
Similar to #141 and #148, this PR adds an empty G4MaterialPropertiesTable to materials that lack it (e.g. copper, teflon, steel, etc). The implementation is for all the geometries not covered by the previous two PRs (i.e. all except NEXT100). 