### PR TITLE
Fix wrong distances in NEXT100 sipm boards

### DIFF
--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -33,7 +33,7 @@ using namespace nexus;
 
 Next100SiPMBoard::Next100SiPMBoard():
   GeometryBase     (),
-  size_            (122.40  * mm),
+  size_            (123.40  * mm),
   pitch_           ( 15.55  * mm),
   margin_          (  7.275 * mm),
   board_thickness_ (  0.2   * mm),

--- a/source/geometries/Next100TrackingPlane.cc
+++ b/source/geometries/Next100TrackingPlane.cc
@@ -32,7 +32,7 @@ Next100TrackingPlane::Next100TrackingPlane():
   GeometryBase(),
   copper_plate_diameter_  (1340.*mm),
   copper_plate_thickness_ ( 145.*mm),
-  distance_board_board_   (   2.*mm),
+  distance_board_board_   (   1.*mm),
 
   visibility_(true),
   sipm_board_geom_(new Next100SiPMBoard),
@@ -80,7 +80,7 @@ void Next100TrackingPlane::Construct()
   // In Geant4 11.0.0, a bug in treating the OpBoundaryProcess produced in the surface makes the code fail.
   // This is avoided by setting an empty G4MaterialPropertiesTable of the G4Material.
   copper->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
-  
+
   G4LogicalVolume* copper_plate_logic =
     new G4LogicalVolume(copper_plate_solid, copper, copper_plate_name);
 


### PR DESCRIPTION
NEXT100 sipm-board size is 1 mm larger and distance between boards is 1 mm instead 2 mm (see attached drawings)

[masks.pdf](https://github.com/next-exp/nexus/files/8768911/03-03.pdf)
[tracking_plane.pdf](https://github.com/next-exp/nexus/files/8768919/00-03-00.Tracking.Plane.Shielding.pdf)

