### PR TITLE
Add source info for sapphire optical properties.

### DIFF
--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -350,6 +350,10 @@ namespace opticalprops {
   /// Sapphire ///
   G4MaterialPropertiesTable* Sapphire()
   {
+    // Input data: Sellmeier equation coeficients extracted from:
+    // https://refractiveindex.info/?shelf=3d&book=crystals&page=sapphire
+    //C[i] coeficients at line 362 are squared.
+
     G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
 
     // REFRACTIVE INDEX


### PR DESCRIPTION
This PR adds the link where the refractive index info of sapphire was extracted from.