### PR TITLE
Eliminate hadronic physics verbosity, to clean up automatic tests

### DIFF
--- a/macros/NEXT100.Neutron.config.mac
+++ b/macros/NEXT100.Neutron.config.mac
@@ -13,7 +13,7 @@
 /tracking/verbose 0
 
 /process/em/verbose 0
-#/process/had/verbose 0
+/process/had/verbose 0
 
 ##### JOB CONTROL #####
 /nexus/random_seed -1

--- a/macros/NEXT100.singleMuon_200GeV.config.mac
+++ b/macros/NEXT100.singleMuon_200GeV.config.mac
@@ -14,7 +14,7 @@
 /tracking/verbose 0
 
 /process/em/verbose 0
-#/process/had/verbose 0
+/process/had/verbose 0
 
 ### JOB CONTROL
 /nexus/random_seed -2

--- a/macros/NEXT100.singleNeutron_2MeV.config.mac
+++ b/macros/NEXT100.singleNeutron_2MeV.config.mac
@@ -14,7 +14,7 @@
 /tracking/verbose 0
 
 /process/em/verbose 0
-#/process/had/verbose 0
+/process/had/verbose 0
 
 ### JOB CONTROL
 /nexus/random_seed 12345

--- a/macros/NEXT100_muons_hallA.config.mac
+++ b/macros/NEXT100_muons_hallA.config.mac
@@ -14,7 +14,7 @@
 /tracking/verbose 0
 
 /process/em/verbose 0
-#/process/had/verbose 0
+/process/had/verbose 0
 
 ### JOB CONTROL
 /nexus/random_seed 17392

--- a/macros/NEXT100_muons_lsc.config.mac
+++ b/macros/NEXT100_muons_lsc.config.mac
@@ -14,7 +14,7 @@
 /tracking/verbose 0
 
 /process/em/verbose 0
-#/process/had/verbose 0
+/process/had/verbose 0
 
 ### JOB CONTROL
 /nexus/random_seed 17392

--- a/macros/NextTonScale.config.mac
+++ b/macros/NextTonScale.config.mac
@@ -14,6 +14,7 @@
 /tracking/verbose 0
 
 /process/em/verbose 0
+/process/had/verbose 0
 
 ### JOB CONTROL
 /nexus/random_seed 1


### PR DESCRIPTION
This PR sets the verbosity of the hadronic physics to zero in the example macros, to avoid having a lot of output in the automatic tests, which makes difficult to understand the error when they fail. The electromagnetic verbosity was already set to zero, but in previous versions of Geant4 the hadronic one didn't work properly (that's why the command was commented in the examples). Starting from geant4.11 the command works fine and it has been introduced in all the macros that use hadronic physics lists.