### PR TITLE
Automatic build and test using docker

### DIFF
--- a/.github/workflows/install-via-docker-and-test.yml
+++ b/.github/workflows/install-via-docker-and-test.yml
@@ -1,0 +1,17 @@
+name: Install via docker and Test
+on:
+  pull_request:
+  push:
+jobs:
+  build-and-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Compile software
+        run: docker build -t nexus .
+      - name: Run tests
+        run: docker run nexus /nexus/docker/run_tests.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM registry.cern.ch/next/nexus-base:2022-07-13
+
+COPY . /nexus
+WORKDIR /nexus
+
+RUN bash /nexus/docker/compile_docker.sh

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:jammy
+
+RUN apt-get update -y && \
+    apt-get install -y cmake g++ libexpat1-dev libgsl27 libgsl-dev &&\ 
+    apt-get autoremove -y && \
+    apt-get clean -y && \
+    rm -rf /var/cache/apt/archives/* && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=registry.cern.ch/next/geant4:11.0.2           /opt/geant4       /opt/geant4
+COPY --from=registry.cern.ch/next/root:6.26.04            /opt/root/install /opt/root/install
+COPY --from=registry.cern.ch/next/python-nexus:2022-07-13 /opt/conda        /opt/conda

--- a/docker/compile_docker.sh
+++ b/docker/compile_docker.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source /nexus/docker/env.sh
+
+cmake -DGSL_ROOT_DIR=/usr/include/gsl -DHDF5_ROOT=/opt/conda/envs/tests/ -DCMAKE_INSTALL_PREFIX=$NEXUSDIR -S . -B /nexus-build
+cmake --build /nexus-build --target install -j`nproc`

--- a/docker/env.sh
+++ b/docker/env.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#ROOT
+export PATH=/opt/root/install/bin/:$PATH
+export LD_LIBRARY_PATH=/opt/root/install/lib/:$LD_LIBRARY_PATH
+
+#Geant4
+export G4INSTALL=/opt/geant4/install/
+export PATH=$G4INSTALL/bin:$PATH
+export LD_LIBRARY_PATH=$G4INSTALL/lib:$LD_LIBRARY_PATH
+
+export G4LEVELGAMMADATA=/opt/geant4/data/PhotonEvaporation5.7
+export G4LEDATA=/opt/geant4/data/G4EMLOW8.0
+export G4RADIOACTIVEDATA=/opt/geant4/data/RadioactiveDecay5.6
+export G4ENSDFSTATEDATA=/opt/geant4/data/G4ENSDFSTATE2.3
+export G4SAIDXSDATA=/opt/geant4/data/G4SAIDDATA2.0
+export G4PARTICLEXSDATA=/opt/geant4/data/G4PARTICLEXS4.0
+export G4NEUTRONHPDATA=/opt/geant4/data/G4NDL4.6
+export G4INCLDATA=/opt/geant4/data/G4INCL1.0
+
+export NEXUSDIR=/nexus
+#export HDF5_DISABLE_VERSION_CHECK=1 # find out why is needed 

--- a/docker/geant4/Dockerfile
+++ b/docker/geant4/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:jammy
+
+ENV G4_VERSION v11.0.2
+
+RUN apt-get update -y && \
+    apt-get install -y cmake curl g++ libexpat1-dev
+RUN mkdir -p /opt/geant4/src && \
+    mkdir -p /opt/geant4/build && \
+    mkdir -p /opt/geant4/install && \
+    mkdir -p /opt/geant4/data && \
+    curl -L -o /geant4.tar.gz https://geant4-data.web.cern.ch/releases/geant4-${G4_VERSION}.tar.gz && \
+    tar xzf /geant4.tar.gz -C /opt/geant4/src && \
+    cd /opt/geant4/build && \
+    cmake -DCMAKE_INSTALL_PREFIX=/opt/geant4/install \
+          -DGEANT4_BUILD_MULTITHREADED=ON \
+          -DGEANT4_INSTALL_EXAMPLES=OFF \
+          ../src/geant4-${G4_VERSION} && \
+    make -j`nproc` && \
+    make install  && \
+    rm -r /opt/geant4/src /opt/geant4/build
+
+COPY /download_dataset.sh /download_dataset.sh
+RUN bash /download_dataset.sh /opt/geant4/data

--- a/docker/geant4/download_dataset.sh
+++ b/docker/geant4/download_dataset.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+DATASETDIR=$1
+DATASETDIR=${DATASETDIR:=data}
+
+DATASETS="
+G4NDL.4.6.tar.gz
+G4EMLOW.8.0.tar.gz
+G4PhotonEvaporation.5.7.tar.gz
+G4RadioactiveDecay.5.6.tar.gz
+G4PARTICLEXS.4.0.tar.gz
+G4PII.1.3.tar.gz
+G4RealSurface.2.2.tar.gz
+G4SAIDDATA.2.0.tar.gz
+G4ABLA.3.1.tar.gz
+G4INCL.1.0.tar.gz
+G4ENSDFSTATE.2.3.tar.gz
+"
+
+mkdir -p $DATASETDIR
+for DATASET in $DATASETS; do
+    curl -o $DATASETDIR/$DATASET https://geant4-data.web.cern.ch/geant4-data/datasets/$DATASET
+    tar zxf $DATASETDIR/$DATASET -C $DATASETDIR
+    rm $DATASETDIR/$DATASET
+done
+
+echo "#########################################################"
+echo " Data set dir: $DATASETDIR"
+echo "#########################################################"

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -1,0 +1,6 @@
+FROM continuumio/miniconda
+
+COPY env.yml .
+
+RUN conda env create -f env.yml && \
+  conda clean -afy

--- a/docker/python/env.yml
+++ b/docker/python/env.yml
@@ -1,0 +1,11 @@
+name: tests
+dependencies:
+  - python=3.8.5
+  - numpy=1.19.1
+  - pandas=1.1.3
+  - pytables=3.6.1
+  - pytest=6.1.1
+  - hypothesis=5.37.4
+  - pip=20.2.4
+  - pip:
+    - pytest-order==0.9.2

--- a/docker/root/Dockerfile
+++ b/docker/root/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:jammy
+
+ENV ROOT_VERSION 6.26.04
+
+# if x11 add: libx11-dev libxpm4 libxpm-dev libxft2 libxft-dev libxext6 libxext-dev
+RUN apt-get update -y && \
+    apt-get install -y cmake curl g++ libexpat1-dev git python3 zlib1g zlib1g-dev libssl-dev && \
+    apt-get autoremove -y && \
+    apt-get clean -y && \
+    rm -rf /var/cache/apt/archives/* && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/root/src && \
+    mkdir -p /opt/root/build && \
+    mkdir -p /opt/root/install && \
+    curl -o /root.tar.gz https://root.cern/download/root_v${ROOT_VERSION}.source.tar.gz && \
+    tar xf /root.tar.gz -C /opt/root/src && \
+    cd /opt/root/build && \
+    cmake -Druntime_cxxmodules=OFF -Dxrootd=OFF -Dbuiltin_xrootd=OFF -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=/opt/root/install -Dx11=OFF ../src/root-${ROOT_VERSION} && \
+    make -j`nproc` && \
+    make install && \
+    rm -r /opt/root/src /opt/root/build /root.tar.gz

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+source /nexus/docker/env.sh
+
+source /opt/conda/etc/profile.d/conda.sh
+conda activate tests
+
+/nexus/bin/nexus-test && pytest -v


### PR DESCRIPTION
This PR adds a new mechanism for continuous integration using docker. The total size of the image including `Geant4`, `Root` and the `conda` environment is ~3.8GB.

It is built in several steps, the `docker` folder contains the definitions for several images:

- Geant4 11.0.2
- Root 6.26.04
- Miniconda with the corresponding environment
- A `nexus-base` image with all the compiled dependencies. 

The new github action included builds `nexus` and run the tests. An example can be seen [here](https://github.com/jmbenlloch/nexus/runs/7327955513?check_suite_focus=true).

When an update is needed, the corresponding `Dockerfile` will need to be updated, as well as the image in the registry. Now we are using https://registry.cern.ch, which offers no limitations in terms of pulling images.

The docker image could be used directly in several HPC clusters. In those not supporting docker, singularity is usually an option and singularity can build an image from a docker container.

The next step would be to modify the github action, so on every merge to master, a new docker image gets compiled and pushed to the registry automatically. In that way, we would have a pre-compiled version for every status of the master branch. That could be pulled from any production machine.

The size of the new images will be small since only the last layer would be updated (this repo and the compiled version of nexus).