### PR TITLE
Change variable name to eliminate compilation warnings

### DIFF
--- a/source/actions/DefaultEventAction.cc
+++ b/source/actions/DefaultEventAction.cc
@@ -94,8 +94,8 @@ REGISTER_CLASS(DefaultEventAction, G4UserEventAction)
                       "DefaultTrackingAction is required when using DefaultEventAction");
         }
         for (unsigned int i=0; i<tc->size(); ++i) {
-          Trajectory* trj = dynamic_cast<Trajectory*>((*tc)[i]);
-          edep += trj->GetEnergyDeposit();
+          Trajectory* tr = dynamic_cast<Trajectory*>((*tc)[i]);
+          edep += tr->GetEnergyDeposit();
         }
       }
       else {

--- a/source/base/DetectorConstruction.cc
+++ b/source/base/DetectorConstruction.cc
@@ -75,9 +75,9 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
 }
 
 
-void DetectorConstruction::SetGeometry(std::unique_ptr<GeometryBase> g)
+void DetectorConstruction::SetGeometry(std::unique_ptr<GeometryBase> geo)
 {
-  geometry_ = std::move(g);
+  geometry_ = std::move(geo);
 }
 
 const GeometryBase* DetectorConstruction::GetGeometry() const

--- a/source/base/Trajectory.h
+++ b/source/base/Trajectory.h
@@ -184,8 +184,8 @@ inline G4int nexus::Trajectory::GetParentID() const
 inline G4ThreeVector nexus::Trajectory::GetFinalMomentum() const
 { return final_momentum_; }
 
-inline void nexus::Trajectory::SetFinalMomentum(const G4ThreeVector& m)
-{ final_momentum_ = m; }
+inline void nexus::Trajectory::SetFinalMomentum(const G4ThreeVector& fm)
+{ final_momentum_ = fm; }
 
 inline G4ThreeVector nexus::Trajectory::GetInitialPosition() const
 { return initial_position_; }


### PR DESCRIPTION
This is a very simple PR, which eliminates the compilation warnings due to a clash of variable names between `nexus` and `CLHEP`. 