### PR TITLE
Fix hit ids

### DIFF
--- a/source/persistency/PersistencyManager.cc
+++ b/source/persistency/PersistencyManager.cc
@@ -146,6 +146,7 @@ G4bool PersistencyManager::Store(const G4Event* event)
 
   // Store ionization hits and sensor hits
   ihits_ = nullptr;
+  hit_map_.clear();
   StoreHits(event->GetHCofThisEvent());
 
   nevt_++;
@@ -252,8 +253,6 @@ void PersistencyManager::StoreIonizationHits(G4VHitsCollection* hc)
   IonizationHitsCollection* hits =
     dynamic_cast<IonizationHitsCollection*>(hc);
   if (!hits) return;
-
-  hit_map_.clear();
 
   double evt_energy = 0.;
   std::string sdname = hits->GetSDname();

--- a/source/persistency/PersistencyManager.cc
+++ b/source/persistency/PersistencyManager.cc
@@ -145,6 +145,7 @@ G4bool PersistencyManager::Store(const G4Event* event)
   StoreTrajectories(event->GetTrajectoryContainer());
 
   // Store ionization hits and sensor hits
+  ihits_ = nullptr;
   StoreHits(event->GetHCofThisEvent());
 
   nevt_++;
@@ -264,19 +265,19 @@ void PersistencyManager::StoreIonizationHits(G4VHitsCollection* hc)
 
     G4int trackid = hit->GetTrackID();
 
-    std::vector<G4int>* ihits = nullptr;
+
     std::map<G4int, std::vector<G4int>* >::iterator it = hit_map_.find(trackid);
     if (it != hit_map_.end()) {
-      ihits = it->second;
+      ihits_ = it->second;
     } else {
-       ihits = new std::vector<G4int>;
-      hit_map_[trackid] = ihits;
+      ihits_ = new std::vector<G4int>;
+      hit_map_[trackid] = ihits_;
     }
 
-    ihits->push_back(1);
+    ihits_->push_back(1);
 
     G4ThreeVector xyz = hit->GetPosition();
-    h5writer_->WriteHitInfo(nevt_, trackid,  ihits->size() - 1,
+    h5writer_->WriteHitInfo(nevt_, trackid,  ihits_->size() - 1,
 			    xyz[0], xyz[1], xyz[2],
 			    hit->GetTime(), hit->GetEnergyDeposit(),
 			    sdname.c_str());

--- a/source/persistency/PersistencyManager.h
+++ b/source/persistency/PersistencyManager.h
@@ -96,6 +96,7 @@ namespace nexus {
 
     HDF5Writer* h5writer_;  ///< Event writer to hdf5 file
 
+    std::vector<G4int>* ihits_;
     std::map<G4int, std::vector<G4int>* > hit_map_;
     std::vector<G4int> sns_posvec_;
 


### PR DESCRIPTION
When a particle crossed two different `ionization` sensitive detectors and deposited energy in both of them, the hit IDs of the hits were repeated, starting from 0 in each sensitive detector.
This PR fixes this bug, and now the hits of a given particle have increasing  hit ID, no matter which sensitive detector has registered them.