### PR TITLE
Add Polished Aluminium material

### DIFF
--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -740,14 +740,6 @@ namespace opticalprops {
   {
     G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
 
-    // REFLECTIVITY
-    // std::vector<G4double> ENERGIES = {
-    //   optPhotMinE_, optPhotMaxE_
-    // };
-    // std::vector<G4double> REFLECTIVITY = {
-    //   1., 1.
-    // };
-
     std::vector<G4double> ENERGIES = {
        h_Planck * c_light / (2456.42541 * nm), h_Planck * c_light / (2396.60266 * nm),
        h_Planck * c_light / (2276.95716 * nm), h_Planck * c_light / (2159.52733 * nm),

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -735,6 +735,76 @@ namespace opticalprops {
     return mpt;
   }
 
+  /// PolishedAl ///
+  G4MaterialPropertiesTable* PolishedAl()
+  {
+    G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
+
+    // REFLECTIVITY
+    // std::vector<G4double> ENERGIES = {
+    //   optPhotMinE_, optPhotMaxE_
+    // };
+    // std::vector<G4double> REFLECTIVITY = {
+    //   1., 1.
+    // };
+
+    std::vector<G4double> ENERGIES = {
+       h_Planck * c_light / (2456.42541 * nm), h_Planck * c_light / (2396.60266 * nm),
+       h_Planck * c_light / (2276.95716 * nm), h_Planck * c_light / (2159.52733 * nm),
+       h_Planck * c_light / (2037.66617 * nm), h_Planck * c_light / (1918.02068 * nm),
+       h_Planck * c_light / (1798.37518 * nm), h_Planck * c_light / (1676.51403 * nm),
+       h_Planck * c_light / (1559.08419 * nm), h_Planck * c_light / (1437.22304 * nm),
+       h_Planck * c_light / (1319.79321 * nm), h_Planck * c_light / (1197.93205 * nm),
+       h_Planck * c_light / (1078.28656 * nm), h_Planck * c_light / (956.42541 * nm),
+       h_Planck * c_light / (838.99557 * nm), h_Planck * c_light / (717.13442 * nm),
+       h_Planck * c_light / (597.48892 * nm), h_Planck * c_light / (477.84343 * nm),
+       h_Planck * c_light / (418.02068 * nm), h_Planck * c_light / (358.19793 * nm),
+       h_Planck * c_light / (293.94387 * nm)
+    };
+    std::vector<G4double> REFLECTIVITY = {
+      .99088, .99082, .98925, .98623, .98611,
+      .98163, .98006, .97849, .97401, .97098,
+      .96941, .96784, .96481, .96033, .96167,
+      .96301, .96289, .96278, .96126, .95830,
+      .94224
+    };
+    mpt->AddProperty("REFLECTIVITY", ENERGIES, REFLECTIVITY);
+
+    // REFLEXION BEHAVIOR
+    std::vector<G4double> ENERGIES_2    = {optPhotMinE_, optPhotMaxE_};
+    std::vector<G4double> ENERGIES_3    = {
+      0.005 * eV, 0.19581 * eV, 0.43227 * eV,
+      0.84211 * eV, 1.2254 * eV, 1.4477 * eV,
+      1.7831 * eV, 2.8203 * eV, 3.6216 * eV,
+      5.0548 * eV, 7.0554 * eV, 9.4450 * eV,
+      12.645 * eV, 14.939 * eV, 16.238 * eV,
+      18.4 * eV, 20. * eV
+    };
+    // Specular reflection about the normal to a microfacet.
+    // Such a vector is chosen according to a gaussian distribution with
+    // sigma = SigmaAlhpa (in rad) and centered in the average normal.
+    std::vector<G4double> specularlobe  = {0., 0.};
+    // specular reflection about the average normal
+    std::vector<G4double> specularspike = {0., 0.};
+    // 180 degrees reflection.
+    std::vector<G4double> backscatter   = {0., 0.};
+    // 1 - the sum of these three last parameters is the percentage of Lambertian reflection
+
+    mpt->AddProperty("SPECULARLOBECONSTANT", ENERGIES_2, specularlobe);
+    mpt->AddProperty("SPECULARSPIKECONSTANT",ENERGIES_2, specularspike);
+    mpt->AddProperty("BACKSCATTERCONSTANT",  ENERGIES_2, backscatter);
+
+    // REFRACTIVE INDEX
+    // std::vector<G4double> rIndex = {1.41, 1.41};
+    std::vector<G4double> rIndex = {
+      473.49, 12.843, 3.8841, 1.437, 1.4821, 2.4465, 1.6203, 0.58336, 0.32634, 0.1686,
+      0.089866, 0.051461, 0.039232, 0.11588, 0.39013, 0.58276, 0.66415
+    };
+    // from https://refractiveindex.info/?shelf=3d&book=metals&page=aluminium
+    mpt->AddProperty("RINDEX", ENERGIES_3, rIndex);
+
+    return mpt;
+  }
 
   /// TPB (tetraphenyl butadiene) ///
   G4MaterialPropertiesTable* TPB()

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -768,18 +768,11 @@ namespace opticalprops {
       .96301, .96289, .96278, .96126, .95830,
       .94224
     };
+    // DOI:10.4236/ampc.2015.511046
     mpt->AddProperty("REFLECTIVITY", ENERGIES, REFLECTIVITY);
 
     // REFLEXION BEHAVIOR
     std::vector<G4double> ENERGIES_2    = {optPhotMinE_, optPhotMaxE_};
-    std::vector<G4double> ENERGIES_3    = {
-      0.005 * eV, 0.19581 * eV, 0.43227 * eV,
-      0.84211 * eV, 1.2254 * eV, 1.4477 * eV,
-      1.7831 * eV, 2.8203 * eV, 3.6216 * eV,
-      5.0548 * eV, 7.0554 * eV, 9.4450 * eV,
-      12.645 * eV, 14.939 * eV, 16.238 * eV,
-      18.4 * eV, 20. * eV
-    };
     // Specular reflection about the normal to a microfacet.
     // Such a vector is chosen according to a gaussian distribution with
     // sigma = SigmaAlhpa (in rad) and centered in the average normal.
@@ -795,7 +788,14 @@ namespace opticalprops {
     mpt->AddProperty("BACKSCATTERCONSTANT",  ENERGIES_2, backscatter);
 
     // REFRACTIVE INDEX
-    // std::vector<G4double> rIndex = {1.41, 1.41};
+    std::vector<G4double> ENERGIES_3    = {
+      0.005 * eV, 0.19581 * eV, 0.43227 * eV,
+      0.84211 * eV, 1.2254 * eV, 1.4477 * eV,
+      1.7831 * eV, 2.8203 * eV, 3.6216 * eV,
+      5.0548 * eV, 7.0554 * eV, 9.4450 * eV,
+      12.645 * eV, 14.939 * eV, 16.238 * eV,
+      18.4 * eV, 20. * eV
+    };
     std::vector<G4double> rIndex = {
       473.49, 12.843, 3.8841, 1.437, 1.4821, 2.4465, 1.6203, 0.58336, 0.32634, 0.1686,
       0.089866, 0.051461, 0.039232, 0.11588, 0.39013, 0.58276, 0.66415

--- a/source/materials/OpticalMaterialProperties.h
+++ b/source/materials/OpticalMaterialProperties.h
@@ -65,6 +65,8 @@ namespace opticalprops {
 
   G4MaterialPropertiesTable* PTFE();
 
+  G4MaterialPropertiesTable* PolishedAl();
+
   G4MaterialPropertiesTable* EJ280();
 
   G4MaterialPropertiesTable* EJ286();


### PR DESCRIPTION
This PR adds Polished Aluminum material to Optical Material Properties because, by placing an Aluminum disk at one end of the fibers, the number of photons collected by the sensor at the other end is  higher. This way there's no need to work with 2 photosensors, one at each end of the fibers.

The values for the reflectance are taken from: 
[Polished Aluminum Reflectance vs Wavelength plot](https://www.researchgate.net/profile/Pushpendra-Jain-2/publication/284209100/figure/fig4/AS:669335462883347@1536593418909/Reflectance-spectra-for-polished-and-unpolished-aluminum-surfaces-for-300-to-2500-nm.png)
DOI:[10.4236/ampc.2015.511046](http://dx.doi.org/10.4236/ampc.2015.511046)

The values for the refractive index are taken from: 
[Polished Aluminum Refractive Index vs Energy plot](https://refractiveindex.info/?shelf=3d&book=metals&page=aluminium)