### PR TITLE
Clean base geometry

### DIFF
--- a/source/geometries/GeometryBase.h
+++ b/source/geometries/GeometryBase.h
@@ -40,9 +40,6 @@ namespace nexus {
     /// Returns the 3 dimensions of the geometry (x, y, z)
     G4ThreeVector GetDimensions();
 
-    /// Returns true if geometry has a drift field
-    G4bool GetDrift() const;
-
     // Getter for the starting point of EL generation in z
     G4double GetELzCoord() const;
 
@@ -72,9 +69,6 @@ namespace nexus {
     /// Sets the span (maximum dimension) of the geometry
     void SetSpan(G4double);
 
-    /// Sets the drift variable to true if a drift field exists
-    void SetDrift(G4bool);
-
     /// Sets the 3 dimensions of the geometry (x, y, z)
     void SetDimensions(G4ThreeVector dim);
 
@@ -88,7 +82,6 @@ namespace nexus {
     G4LogicalVolume* logicVol_; ///< Pointer to the logical volume
     G4double span_; ///< Maximum dimension of the geometry
     G4ThreeVector dimensions_; ///< XYZ dimensions of a regular geometry
-    G4bool drift_; ///< True if geometry contains a drift field (for hit coordinates)
     G4double el_z_; ///< Starting point of EL generation in z
     G4ThreeVector coord_origin_; ///< Origin of coordinates of the mother volume
   };
@@ -116,10 +109,6 @@ namespace nexus {
   inline void GeometryBase::SetDimensions(G4ThreeVector dim) {  dimensions_ = dim; }
 
   inline  G4ThreeVector GeometryBase::GetDimensions()  { return dimensions_; }
-
-  inline void GeometryBase::SetDrift(G4bool drift) { drift_ = drift; }
-
-  inline G4bool GeometryBase::GetDrift() const { return drift_; }
 
   inline G4double GeometryBase::GetELzCoord() const {return el_z_;}
 

--- a/source/geometries/GeometryBase.h
+++ b/source/geometries/GeometryBase.h
@@ -49,6 +49,12 @@ namespace nexus {
     /// Setter for the starting point of EL generation in z
     void SetELzCoord(G4double z);
 
+    /// Getter for the origin of coordinates
+    G4ThreeVector GetCoordOrigin() const;
+
+    /// Setter for the origin of coordinates
+    void SetCoordOrigin(G4ThreeVector origin);
+
     /// Translates position to G4 global position
     void CalculateGlobalPos(G4ThreeVector& vertex) const;
 
@@ -84,12 +90,13 @@ namespace nexus {
     G4ThreeVector dimensions_; ///< XYZ dimensions of a regular geometry
     G4bool drift_; ///< True if geometry contains a drift field (for hit coordinates)
     G4double el_z_; ///< Starting point of EL generation in z
+    G4ThreeVector coord_origin_; ///< Origin of coordinates of the mother volume
   };
 
 
   // Inline definitions ///////////////////////////////////
 
-  inline GeometryBase::GeometryBase(): logicVol_(0), span_(25.*m), drift_(false), el_z_(0.*mm) {}
+  inline GeometryBase::GeometryBase(): logicVol_(0), span_(25.*m),  el_z_(0.*mm), coord_origin_(G4ThreeVector(0., 0., 0.)) {}
 
   inline GeometryBase::~GeometryBase() {}
 
@@ -117,6 +124,10 @@ namespace nexus {
   inline G4double GeometryBase::GetELzCoord() const {return el_z_;}
 
   inline void GeometryBase::SetELzCoord(G4double z) {el_z_ = z;}
+
+  inline G4ThreeVector GeometryBase::GetCoordOrigin() const {return coord_origin_;}
+
+  inline void GeometryBase::SetCoordOrigin(G4ThreeVector origin) {coord_origin_ = origin;}
 
   // This methods is to be used only in the Next1EL and NEW geometries
   inline void GeometryBase::CalculateGlobalPos(G4ThreeVector& vertex) const

--- a/source/geometries/Next100.h
+++ b/source/geometries/Next100.h
@@ -70,7 +70,7 @@ namespace nexus {
     G4ThreeVector specific_vertex_;
 
     /// Position of gate in its mother volume
-    G4double gate_zpos_in_vessel_;
+    G4ThreeVector displ_from_origin_;
 
     /// Whether or not to build LSC HallA.
     G4bool lab_walls_;

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -207,7 +207,8 @@ namespace nexus {
     G4double stand_out_length =
       sapphire_window_thickn_ + tpb_thickn_ + optical_pad_thickn_ + pmt_stand_out_;
 
-    copper_plate_posz_ = GetELzCoord() + gate_sapphire_wdw_dist_ + stand_out_length + copper_plate_thickn_/2.;
+    copper_plate_posz_ = GetCoordOrigin()[2]
+      + gate_sapphire_wdw_dist_ + stand_out_length + copper_plate_thickn_/2.;
 
     new G4PVPlacement(0, G4ThreeVector(0., 0., copper_plate_posz_), copper_plate_logic,
                       "EP_COPPER_PLATE", mother_logic_, false, 0, false);
@@ -414,7 +415,7 @@ namespace nexus {
       do {
         vertex = copper_gen_->GenerateVertex("VOLUME");
         G4ThreeVector glob_vtx(vertex);
-        glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+        glob_vtx = glob_vtx - GetCoordOrigin();
         VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
       } while (VertexVolume->GetName() != region);
     }
@@ -430,7 +431,7 @@ namespace nexus {
         G4double z_translation = vacuum_posz_;
         vertex.setZ(vertex.z() + z_translation);
         G4ThreeVector glob_vtx(vertex);
-        glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+        glob_vtx = glob_vtx - GetCoordOrigin();
         VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
       } while (VertexVolume->GetName() != region);
     }

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -209,7 +209,7 @@ void Next100FieldCage::Construct()
   holder_r_ = (active_diam_+2.*teflon_thickn_+holder_long_y_)/2.;
 
   /// Calculate relative positions in mother volume
-  gate_grid_zpos_  = GetELzCoord() - grid_thickn_/2.;
+  gate_grid_zpos_  = GetCoordOrigin()[2] - grid_thickn_/2.;
   active_zpos_     = gate_grid_zpos_ + grid_thickn_/2. + active_length_/2.;
   cathode_zpos_    = gate_grid_zpos_ + grid_thickn_/2. + active_length_ + grid_thickn_/2.;
   gate_zpos_       = gate_grid_zpos_ + grid_thickn_/2. + gate_ring_thickn_/2. - grid_thickn_;
@@ -325,7 +325,7 @@ void Next100FieldCage::BuildActive()
 
   /// Define a drift field for this volume
   UniformElectricDriftField* field = new UniformElectricDriftField();
-  G4double global_active_zpos = active_zpos_ - GetELzCoord();
+  G4double global_active_zpos = active_zpos_ - GetCoordOrigin()[2];
   field->SetCathodePosition(global_active_zpos + active_length_/2.);
   field->SetAnodePosition(global_active_zpos - active_length_/2.);
   field->SetDriftVelocity(1. * mm/microsecond);
@@ -344,7 +344,7 @@ void Next100FieldCage::BuildActive()
 
   /// Visibilities
   active_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
-  
+
   /// Verbosity
   if (verbosity_) {
     G4cout << "Active starts in " << (active_zpos_ - active_length_/2.)/mm
@@ -430,7 +430,7 @@ void Next100FieldCage::BuildBuffer()
               (cathode_thickn_/2. - grid_thickn_/2.)/2. +  overlap_/2., 0, twopi);
 
   G4ThreeVector buff_cathode_pos =
-  G4ThreeVector(0., 0., -buffer_length_/2. + (cathode_thickn_/2.-grid_thickn_/2.)/2. +overlap_/2.);
+  G4ThreeVector(0., 0., -buffer_length_/2. + (cathode_thickn_/2.-grid_thickn_/2.)/2. + overlap_/2.);
 
   G4UnionSolid* union_buffer =
     new G4UnionSolid("BUFFER", buffer_solid, buffer_cathode_solid, 0, buff_cathode_pos);
@@ -483,7 +483,8 @@ void Next100FieldCage::BuildELRegion()
 {
   /// GATE ring.
   G4Tubs* gate_solid =
-    new G4Tubs("GATE_RING", gate_int_diam_/2., gate_ext_diam_/2., gate_ring_thickn_/2., 0, twopi);
+    new G4Tubs("GATE_RING", gate_int_diam_/2., gate_ext_diam_/2., gate_ring_thickn_/2.,
+               0, twopi);
 
   G4LogicalVolume* gate_logic =
     new G4LogicalVolume(gate_solid, steel_, "GATE_RING");
@@ -494,7 +495,8 @@ void Next100FieldCage::BuildELRegion()
 
   /// EL gap.
   G4Tubs* el_gap_solid =
-    new G4Tubs("EL_GAP", 0., gate_int_diam_/2., (el_gap_length_ + 2*grid_thickn_)/2., 0, twopi);
+    new G4Tubs("EL_GAP", 0., gate_int_diam_/2., (el_gap_length_ + 2*grid_thickn_)/2.,
+               0, twopi);
 
   G4LogicalVolume* el_gap_logic =
     new G4LogicalVolume(el_gap_solid, gas_, "EL_GAP");
@@ -505,7 +507,8 @@ void Next100FieldCage::BuildELRegion()
 
   /// ANODE ring.
   G4Tubs* anode_solid =
-    new G4Tubs("ANODE_RING", gate_int_diam_/2., gate_ext_diam_/2., gate_ring_thickn_/2., 0, twopi);
+    new G4Tubs("ANODE_RING", gate_int_diam_/2., gate_ext_diam_/2., gate_ring_thickn_/2.,
+               0, twopi);
 
   G4LogicalVolume* anode_logic =
     new G4LogicalVolume(anode_solid, steel_, "ANODE_RING");
@@ -517,7 +520,7 @@ void Next100FieldCage::BuildELRegion()
   if (elfield_) {
     /// Define EL electric field
     UniformElectricDriftField* el_field = new UniformElectricDriftField();
-    G4double global_el_gap_zpos = el_gap_zpos_ - GetELzCoord();
+    G4double global_el_gap_zpos = el_gap_zpos_ - GetCoordOrigin()[2];
     el_field->SetCathodePosition(global_el_gap_zpos + el_gap_length_/2. + grid_thickn_);
     el_field->SetAnodePosition  (global_el_gap_zpos - el_gap_length_/2. - grid_thickn_);
     el_field->SetDriftVelocity(2.5 * mm/microsecond);
@@ -569,11 +572,13 @@ void Next100FieldCage::BuildELRegion()
                                              nullptr, el_gap_gen_pos);
 
   // Gate ring vertex generator
-  gate_gen_ = new CylinderPointSampler2020(gate_int_diam_/2., gate_ext_diam_/2., gate_ring_thickn_/2.,
-                                           0., twopi, nullptr, G4ThreeVector(0., 0., gate_zpos_));
+  gate_gen_ =
+    new CylinderPointSampler2020(gate_int_diam_/2., gate_ext_diam_/2., gate_ring_thickn_/2.,
+                                 0., twopi, nullptr, G4ThreeVector(0., 0., gate_zpos_));
   // Anode ring vertex generator
-  anode_gen_ = new CylinderPointSampler2020(gate_int_diam_/2., gate_ext_diam_/2., gate_ring_thickn_/2.,
-                                            0., twopi, nullptr, G4ThreeVector(0., 0., anode_zpos_));
+  anode_gen_ =
+    new CylinderPointSampler2020(gate_int_diam_/2., gate_ext_diam_/2., gate_ring_thickn_/2.,
+                                 0., twopi, nullptr, G4ThreeVector(0., 0., anode_zpos_));
 
   /// Visibilities
   if (visibility_) {
@@ -639,7 +644,8 @@ void Next100FieldCage::BuildLightTube()
     {(active_diam_ + 2.*teflon_thickn_)/2., (active_diam_ + 2.*teflon_thickn_)/2.};
 
   G4Polyhedra* teflon_buffer_solid =
-   new G4Polyhedra("LIGHT_TUBE_BUFFER", 0., twopi, n_panels_, 2, zplane_buff, rinner, router_buff);
+   new G4Polyhedra("LIGHT_TUBE_BUFFER", 0., twopi, n_panels_, 2, zplane_buff,
+                   rinner, router_buff);
 
   G4LogicalVolume* teflon_buffer_logic =
     new G4LogicalVolume(teflon_buffer_solid, teflon_, "LIGHT_TUBE_BUFFER");
@@ -653,7 +659,8 @@ void Next100FieldCage::BuildLightTube()
     {(active_diam_ + 2.*tpb_thickn_)/2., (active_diam_ + 2.*tpb_thickn_)/2.};
 
   G4Polyhedra* tpb_buffer_solid =
-    new  G4Polyhedra("BUFFER_TPB", 0., twopi, n_panels_, 2, zplane_buff, rinner, router_tpb_buff);
+    new  G4Polyhedra("BUFFER_TPB", 0., twopi, n_panels_, 2, zplane_buff,
+                     rinner, router_tpb_buff);
 
   G4LogicalVolume* tpb_buffer_logic =
     new G4LogicalVolume(tpb_buffer_solid, tpb_, "BUFFER_TPB");
@@ -686,7 +693,8 @@ void Next100FieldCage::BuildLightTube()
 
   // Vertex generator
   G4double teflon_ext_radius = (active_diam_ + 2.*teflon_thickn_)/2. / cos(pi/n_panels_);
-  G4double cathode_gap_zpos  = teflon_drift_zpos_ + teflon_drift_length_/2. + cathode_thickn_/2.;
+  G4double cathode_gap_zpos  =
+    teflon_drift_zpos_ + teflon_drift_length_/2. + cathode_thickn_/2.;
   G4double teflon_zpos = (teflon_drift_length_ * teflon_drift_zpos_ +
                          cathode_thickn_ * cathode_gap_zpos +
                          teflon_buffer_length_ * teflon_buffer_zpos_) / teflon_total_length_;
@@ -739,10 +747,11 @@ void Next100FieldCage::BuildFieldCage()
   G4int    num_drift_rings = 48;
   G4int    num_buffer_rings = 4;
   G4double posz;
-  G4double first_ring_drift_z_pos = GetELzCoord() + gate_teflon_dist_ + drift_ring_dist_/2. + active_short_z/2.;
+  G4double first_ring_drift_z_pos =
+    GetCoordOrigin()[2] + gate_teflon_dist_ + drift_ring_dist_/2. + active_short_z/2.;
 
-  G4double first_ring_buff_z_pos = first_ring_drift_z_pos + (num_drift_rings-1)*drift_ring_dist_ +
-                                   ring_drift_buffer_dist;
+  G4double first_ring_buff_z_pos =
+    first_ring_drift_z_pos + (num_drift_rings-1)*drift_ring_dist_ + ring_drift_buffer_dist;
 
   G4Tubs* ring_solid =
     new G4Tubs("FIELD_RING", ring_int_diam_/2., ring_ext_diam_/2., ring_thickn_/2., 0, twopi);
@@ -770,9 +779,10 @@ void Next100FieldCage::BuildFieldCage()
   G4double ring_gen_lenght =   first_ring_buff_z_pos + (num_buffer_rings-1)*buffer_ring_dist_
                              - first_ring_drift_z_pos + ring_thickn_;
   G4double ring_gen_zpos = first_ring_drift_z_pos + ring_gen_lenght/2. - ring_thickn_/2.;
-  ring_gen_ = new CylinderPointSampler2020(ring_int_diam_/2., ring_ext_diam_/2., ring_gen_lenght/2.,
-                                           0., twopi, nullptr,
-                                           G4ThreeVector(0., 0., ring_gen_zpos));
+  ring_gen_ =
+    new CylinderPointSampler2020(ring_int_diam_/2., ring_ext_diam_/2., ring_gen_lenght/2.,
+                                 0., twopi, nullptr,
+                                 G4ThreeVector(0., 0., ring_gen_zpos));
 
   // Ring holders.
   // ACTIVE holders.
@@ -881,7 +891,8 @@ void Next100FieldCage::BuildFieldCage()
   for (G4int i=10; i<360; i +=20){
     G4RotationMatrix* rot = new G4RotationMatrix();
     rot -> rotateZ((90-i) *deg);
-    new G4PVPlacement(rot, G4ThreeVector(cathode_holder_r*cos(i*deg),cathode_holder_r*sin(i*deg),
+    new G4PVPlacement(rot,
+                      G4ThreeVector(cathode_holder_r*cos(i*deg),cathode_holder_r*sin(i*deg),
                       cathode_zpos_),cathode_holder_logic, "CATHODE_HOLDER", mother_logic_,
                       false, numbering, false);
     numbering +=1;}
@@ -943,7 +954,7 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
     do {
       vertex = active_gen_->GenerateVertex("VOLUME");
       G4ThreeVector glob_vtx(vertex);
-      glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+      glob_vtx = glob_vtx - GetCoordOrigin();
       VertexVolume =
         geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
     } while (VertexVolume->GetName() != region);
@@ -954,7 +965,7 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
     do {
       vertex = cathode_gen_->GenerateVertex("VOLUME");
       G4ThreeVector glob_vtx(vertex);
-      glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+      glob_vtx = glob_vtx - GetCoordOrigin();
       VertexVolume =
         geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
     } while (VertexVolume->GetName() != region);
@@ -965,7 +976,7 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
     do {
       vertex = buffer_gen_->GenerateVertex("VOLUME");
       G4ThreeVector glob_vtx(vertex);
-      glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+      glob_vtx = glob_vtx - GetCoordOrigin();
       VertexVolume =
         geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
     } while (VertexVolume->GetName() != region);
@@ -976,7 +987,7 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
     do {
       vertex = xenon_gen_->GenerateVertex("VOLUME");
       G4ThreeVector glob_vtx(vertex);
-      glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+      glob_vtx = glob_vtx - GetCoordOrigin();
       VertexVolume =
         geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
     } while (
@@ -990,7 +1001,7 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
     do {
       vertex = teflon_gen_->GenerateVertex("VOLUME");
       G4ThreeVector glob_vtx(vertex);
-      glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+      glob_vtx = glob_vtx - GetCoordOrigin();
       VertexVolume =
         geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
     } while (
@@ -1003,7 +1014,7 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
     do {
       vertex = hdpe_gen_->GenerateVertex("VOLUME");
       G4ThreeVector glob_vtx(vertex);
-      glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+      glob_vtx = glob_vtx - GetCoordOrigin();
       VertexVolume =
         geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
     } while (VertexVolume->GetName() != region);
@@ -1014,7 +1025,7 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
     do {
       vertex = el_gap_gen_->GenerateVertex("VOLUME");
       G4ThreeVector glob_vtx(vertex);
-      glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+      glob_vtx = glob_vtx - GetCoordOrigin();
       VertexVolume =
         geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
     } while (VertexVolume->GetName() != region);
@@ -1025,7 +1036,7 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
     do {
       vertex = ring_gen_->GenerateVertex("VOLUME");
       G4ThreeVector glob_vtx(vertex);
-      glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+      glob_vtx = glob_vtx - GetCoordOrigin();
       VertexVolume =
         geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
     } while (VertexVolume->GetName() != region);
@@ -1036,7 +1047,7 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
     do {
       vertex = gate_gen_->GenerateVertex("VOLUME");
       G4ThreeVector glob_vtx(vertex);
-      glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+      glob_vtx = glob_vtx - GetCoordOrigin();
       VertexVolume =
         geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
     } while (VertexVolume->GetName() != region);
@@ -1047,7 +1058,7 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
     do {
       vertex = anode_gen_->GenerateVertex("VOLUME");
       G4ThreeVector glob_vtx(vertex);
-      glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+      glob_vtx = glob_vtx - GetCoordOrigin();
       VertexVolume =
         geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
     } while (VertexVolume->GetName() != region);
@@ -1058,7 +1069,7 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
     do {
       vertex = holder_gen_->GenerateVertex("VOLUME");
       G4ThreeVector glob_vtx(vertex);
-      glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+      glob_vtx = glob_vtx - GetCoordOrigin();
       VertexVolume =
         geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
     } while ((VertexVolume->GetName() != "ACT_HOLDER")  &&

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -30,10 +30,8 @@ namespace nexus {
 
   Next100Ics::Next100Ics():
     GeometryBase(),
-
     in_rad_   (55.465 * cm),
     thickness_(12.0   * cm),
-
     visibility_ (0)
   {
 
@@ -61,7 +59,8 @@ namespace nexus {
     G4double offset = 1.* mm;
 
     // ICS
-    G4double ics_z_pos = GetELzCoord() + length/2. - gate_tp_distance_;
+    G4double ics_z_pos = length/2. - gate_tp_distance_;
+    G4ThreeVector coord_origin = GetCoordOrigin();
 
     G4Tubs* ics_body = new G4Tubs("ICS", in_rad_, in_rad_ + thickness_,
                                   length/2., 0.*deg, 360.*deg);
@@ -83,17 +82,25 @@ namespace nexus {
     G4Tubs* port_hole_solid = new G4Tubs("PORT_HOLE", 0., port_hole_rad,
                                          (thickness_ + offset)/2., 0.*deg, 360.*deg);
 
-    ics_solid = new G4SubtractionSolid("ICS", ics_body, port_hole_solid,
-                port_a_Rot, G4ThreeVector(port_x, port_y, port_z_1a_-ics_z_pos));
+    G4ThreeVector pos1a =
+      G4ThreeVector(port_x, port_y, port_z_1a_-ics_z_pos) - coord_origin;
+    ics_solid =
+      new G4SubtractionSolid("ICS", ics_body, port_hole_solid, port_a_Rot, pos1a);
 
-    ics_solid = new G4SubtractionSolid("ICS", ics_solid, port_hole_solid,
-                port_a_Rot, G4ThreeVector(port_x, port_y, port_z_2a_-ics_z_pos));
+    G4ThreeVector pos2a =
+      G4ThreeVector(port_x, port_y, port_z_2a_-ics_z_pos) - coord_origin;
+    ics_solid =
+      new G4SubtractionSolid("ICS", ics_solid, port_hole_solid, port_a_Rot, pos2a);
 
-    ics_solid = new G4SubtractionSolid("ICS", ics_solid, port_hole_solid,
-                port_b_Rot, G4ThreeVector(-port_x, port_y, port_z_1b_-ics_z_pos));
+    G4ThreeVector pos1b =
+      G4ThreeVector(-port_x, port_y, port_z_1b_-ics_z_pos) - coord_origin;
+    ics_solid =
+      new G4SubtractionSolid("ICS", ics_solid, port_hole_solid, port_b_Rot, pos1b);
 
-    ics_solid = new G4SubtractionSolid("ICS", ics_solid, port_hole_solid,
-                port_b_Rot, G4ThreeVector(-port_x, port_y, port_z_2b_-ics_z_pos));
+    G4ThreeVector pos2b =
+      G4ThreeVector(-port_x, port_y, port_z_2b_-ics_z_pos) - coord_origin;;
+    ics_solid =
+      new G4SubtractionSolid("ICS", ics_solid, port_hole_solid, port_b_Rot, pos2b);
 
     /// Upper holes
     // z distances measured with respect to TP plate, ie the start of ICS
@@ -144,7 +151,9 @@ namespace nexus {
       new G4LogicalVolume(ics_solid,
         G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"), "ICS");
 
-    new G4PVPlacement(0, G4ThreeVector(0., 0., ics_z_pos), ics_logic,
+    G4ThreeVector ics_pos_in_mother =
+      G4ThreeVector(0., 0., ics_z_pos) + GetCoordOrigin();
+    new G4PVPlacement(0, ics_pos_in_mother, ics_logic,
                       "ICS", mother_logic_, false, 0, false);
 
 
@@ -159,9 +168,10 @@ namespace nexus {
     }
 
     // VERTEX GENERATOR
+    G4ThreeVector gen_pos = G4ThreeVector(0., 0., ics_z_pos) + GetCoordOrigin();
     ics_gen_ =
       new CylinderPointSampler2020(in_rad_, in_rad_ + thickness_, length/2., 0.*deg, 360.*deg,
-                                   0, G4ThreeVector(0., 0., ics_z_pos));
+                                   0, gen_pos);
   }
 
 
@@ -181,7 +191,7 @@ namespace nexus {
         vertex = ics_gen_->GenerateVertex("VOLUME");
 
         G4ThreeVector glob_vtx(vertex);
-        glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+        glob_vtx = glob_vtx - GetCoordOrigin();
         VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
       } while (VertexVolume->GetName() != "ICS");
     }

--- a/source/geometries/Next100InnerElements.cc
+++ b/source/geometries/Next100InnerElements.cc
@@ -56,7 +56,8 @@ namespace nexus {
   void Next100InnerElements::Construct()
   {
     // Position in Z of the beginning of the drift region
-    G4double gate_zpos = GetELzCoord();
+    //G4double gate_zpos = GetELzCoord();
+    G4ThreeVector coord_origin = GetCoordOrigin();
     // Reading mother material
     gas_ = mother_logic_->GetMaterial();
     pressure_ =    gas_->GetPressure();
@@ -65,19 +66,19 @@ namespace nexus {
     // Field Cage
     field_cage_->SetMotherLogicalVolume(mother_logic_);
     field_cage_->SetMotherPhysicalVolume(mother_phys_);
-    field_cage_->SetELzCoord(gate_zpos);
+    field_cage_->SetCoordOrigin(coord_origin);
     field_cage_->SetELtoSapphireWDWdistance(gate_sapphire_wdw_distance_);
     field_cage_->Construct();
 
     // Energy Plane
     energy_plane_->SetMotherLogicalVolume(mother_logic_);
-    energy_plane_->SetELzCoord(gate_zpos);
+    energy_plane_->SetCoordOrigin(coord_origin);
     energy_plane_->SetELtoSapphireWDWdistance(gate_sapphire_wdw_distance_);
     energy_plane_->Construct();
 
     // Tracking plane
     tracking_plane_->SetMotherPhysicalVolume(mother_phys_);
-    tracking_plane_->SetELzCoord(gate_zpos);
+    tracking_plane_->SetCoordOrigin(coord_origin);
     tracking_plane_->SetELtoTPdistance(gate_tracking_plane_distance_);
     tracking_plane_->Construct();
   }

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -580,30 +580,30 @@ namespace nexus {
     if (region == "SHIELDING_LEAD") {
         G4VPhysicalVolume *VertexVolume;
         do {
-          	vertex = lead_gen_->GenerateVertex("WHOLE_VOL");
-          	G4ThreeVector glob_vtx(vertex);
-          	glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
-          	VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
+          vertex = lead_gen_->GenerateVertex("WHOLE_VOL");
+          G4ThreeVector glob_vtx(vertex);
+          glob_vtx = glob_vtx - GetCoordOrigin();
+          VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
         } while (VertexVolume->GetName() != "LEAD_BOX");
     }
 
     else if (region == "SHIELDING_STEEL") {
       G4VPhysicalVolume *VertexVolume;
       do {
-          vertex = steel_gen_->GenerateVertex("WHOLE_VOL");
-          G4ThreeVector glob_vtx(vertex);
-          glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
-          VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
+        vertex = steel_gen_->GenerateVertex("WHOLE_VOL");
+        G4ThreeVector glob_vtx(vertex);
+        glob_vtx = glob_vtx - GetCoordOrigin();
+        VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
       } while (VertexVolume->GetName() != "STEEL_BOX");
     }
 
     else if (region == "INNER_AIR") {
       G4VPhysicalVolume *VertexVolume;
       do {
-          vertex = inner_air_gen_->GenerateVertex("INSIDE");
-          G4ThreeVector glob_vtx(vertex);
-          glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
-          VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
+        vertex = inner_air_gen_->GenerateVertex("INSIDE");
+        G4ThreeVector glob_vtx(vertex);
+        glob_vtx = glob_vtx - GetCoordOrigin();
+        VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
       } while (VertexVolume->GetName() != "INNER_AIR");
     }
 
@@ -615,7 +615,7 @@ namespace nexus {
         G4double rand = G4UniformRand();
 
         if (rand < perc_roof_vol_) { //ROOF BEAM STRUCTURE
-        	if (G4UniformRand() <  perc_front_roof_vol_){
+          if (G4UniformRand() <  perc_front_roof_vol_){
             vertex = front_roof_gen_->GenerateVertex("INSIDE");
             if (G4UniformRand() < 0.5) {
               vertex.setZ(vertex.z() + (shield_z_/2.+steel_thickness_+lead_thickness_/2.));
@@ -623,117 +623,117 @@ namespace nexus {
             else{
               vertex.setZ(vertex.z() - (shield_z_/2.+steel_thickness_+lead_thickness_/2.));
             }
-        	}
-        	else{
-              vertex = lat_roof_gen_->GenerateVertex("INSIDE");
-          	  if (G4UniformRand() < 0.5) {
-          	    vertex.setX(vertex.x() + (shield_x_/2.+ steel_thickness_ + lead_thickness_/2.));
-          	  }
-          	  else{
-          	    vertex.setX(vertex.x() - (shield_x_/2.+ steel_thickness_ + lead_thickness_/2.));
-          	  }
-        	}
+          }
+          else{
+            vertex = lat_roof_gen_->GenerateVertex("INSIDE");
+            if (G4UniformRand() < 0.5) {
+              vertex.setX(vertex.x() + (shield_x_/2.+ steel_thickness_ + lead_thickness_/2.));
+            }
+            else{
+              vertex.setX(vertex.x() - (shield_x_/2.+ steel_thickness_ + lead_thickness_/2.));
+            }
+          }
         }
 
         else if (rand < (perc_top_struct_vol_ + perc_roof_vol_)) { //TOP BEAM STRUCTURE
-            	G4double random = G4UniformRand();
-            	if (random <  perc_struc_x_vol_){
-            	  G4double rand_beam = int (4* G4UniformRand());
-                vertex = struct_x_gen_->GenerateVertex("INSIDE");
-            	  if (rand_beam == 1) {
-            	    vertex.setZ(vertex.z()-roof_z_separation_);
-            	  }
-            	  else if (rand_beam == 2) {
-            	    vertex.setZ(vertex.z()-(roof_z_separation_+lateral_z_separation_));
-            	  }
-            	  else if (rand_beam == 3) {
-            	    vertex.setZ(vertex.z()-(2*roof_z_separation_+lateral_z_separation_));
-            	  }
-            	}
-            	else {
-                vertex = struct_z_gen_->GenerateVertex("INSIDE");
-            	  if (G4UniformRand() < 0.5) {
-            	    vertex.setX(vertex.x()+front_x_separation_);
-            	  }
-              }
-        }
-
-        else{ //LATERAL BEAM STRUCTURE
-              G4double lat_prob = beam_thickness_1/(beam_thickness_1+beam_thickness_2);
-              if (G4UniformRand()<lat_prob){ //lateral
-              	G4double rand_beam = int (4 * G4UniformRand());
-                vertex = lat_beam_gen_->GenerateVertex("INSIDE");
-              	if (rand_beam ==1){
-              	  vertex.setZ(vertex.z() - lateral_z_separation_);
-              	}
-              	else if (rand_beam ==2){
-              	  vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ + lead_thickness_));
-              	}
-              	else if (rand_beam ==3){
-              	  vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ + lead_thickness_));
-              	  vertex.setZ(vertex.z() - lateral_z_separation_);
-              	}
-              }
-              else{ // front
-                G4double rand_beam = int (4 * G4UniformRand());
-                vertex = front_beam_gen_->GenerateVertex("INSIDE");
-              	if (rand_beam ==1){
-              	  vertex.setX(vertex.x() + front_x_separation_);
-              	}
-              	else if (rand_beam ==2){
-              	  vertex.setZ(vertex.z() - (shield_z_+2*steel_thickness_+lead_thickness_));
-              	}
-              	else if (rand_beam ==3){
-              	  vertex.setX(vertex.x() + front_x_separation_);
-              	  vertex.setZ(vertex.z() - (shield_z_+2*steel_thickness_+lead_thickness_));
-              	}
-              }
+          G4double random = G4UniformRand();
+          if (random <  perc_struc_x_vol_){
+            G4double rand_beam = int (4* G4UniformRand());
+            vertex = struct_x_gen_->GenerateVertex("INSIDE");
+            if (rand_beam == 1) {
+              vertex.setZ(vertex.z()-roof_z_separation_);
             }
+            else if (rand_beam == 2) {
+              vertex.setZ(vertex.z()-(roof_z_separation_+lateral_z_separation_));
+            }
+            else if (rand_beam == 3) {
+              vertex.setZ(vertex.z()-(2*roof_z_separation_+lateral_z_separation_));
+            }
+          }
+          else {
+            vertex = struct_z_gen_->GenerateVertex("INSIDE");
+            if (G4UniformRand() < 0.5) {
+              vertex.setX(vertex.x()+front_x_separation_);
+            }
+          }
         }
 
+        else { //LATERAL BEAM STRUCTURE
+          G4double lat_prob = beam_thickness_1/(beam_thickness_1+beam_thickness_2);
+          if (G4UniformRand()<lat_prob){ //lateral
+            G4double rand_beam = int (4 * G4UniformRand());
+            vertex = lat_beam_gen_->GenerateVertex("INSIDE");
+            if (rand_beam ==1){
+              vertex.setZ(vertex.z() - lateral_z_separation_);
+            }
+            else if (rand_beam ==2){
+              vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ + lead_thickness_));
+            }
+            else if (rand_beam ==3){
+              vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ + lead_thickness_));
+              vertex.setZ(vertex.z() - lateral_z_separation_);
+            }
+          }
+          else{ // front
+            G4double rand_beam = int (4 * G4UniformRand());
+            vertex = front_beam_gen_->GenerateVertex("INSIDE");
+            if (rand_beam ==1){
+              vertex.setX(vertex.x() + front_x_separation_);
+            }
+            else if (rand_beam ==2){
+              vertex.setZ(vertex.z() - (shield_z_+2*steel_thickness_+lead_thickness_));
+            }
+            else if (rand_beam ==3){
+              vertex.setX(vertex.x() + front_x_separation_);
+              vertex.setZ(vertex.z() - (shield_z_+2*steel_thickness_+lead_thickness_));
+            }
+          }
+        }
+    }
+    
     else if(region=="PEDESTAL"){
-        G4double rand = G4UniformRand();
-
-        if (rand < perc_ped_bottom_vol_) { //SUPPORT-BOTTOM
-          vertex = ped_support_bottom_gen_->GenerateVertex("INSIDE");
-      	  if (G4UniformRand() < 0.5) {
-      	    vertex.setZ(vertex.z() - support_beam_dist_);
-      	  }
+      G4double rand = G4UniformRand();
+      
+      if (rand < perc_ped_bottom_vol_) { //SUPPORT-BOTTOM
+        vertex = ped_support_bottom_gen_->GenerateVertex("INSIDE");
+        if (G4UniformRand() < 0.5) {
+          vertex.setZ(vertex.z() - support_beam_dist_);
         }
-        else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_)) { //SUPPORT-TOP
-          vertex = ped_support_top_gen_->GenerateVertex("INSIDE");
-          if (G4UniformRand() < 0.5) {
-      	    vertex.setZ(vertex.z() - support_beam_dist_);
-      	  }
-        }
-        else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_ + perc_ped_front_vol_)){ //FRONT BEAM
-          vertex = ped_front_gen_->GenerateVertex("INSIDE");
-          if (G4UniformRand() < 0.5) {
-      	    vertex.setZ(vertex.z() - (2.*support_front_dist_ + support_beam_dist_));
-      	  }
-        }
-        else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_ + perc_ped_front_vol_
-                                                                  + perc_ped_lateral_vol_)){ // LATERAL BEAM
-          vertex = ped_lateral_gen_->GenerateVertex("INSIDE");
-          if (G4UniformRand() < 0.5) {
-            vertex.setX(vertex.x() - (pedestal_x_ + pedestal_lateral_beam_thickness_));
-          }
-         }
-        else { // ROOF
-          if (G4UniformRand() < 0.5) {
-            vertex = ped_roof_lat_gen_->GenerateVertex("INSIDE");
-            if (G4UniformRand() < 0.5){
-              vertex.setX(vertex.x() - pedestal_top_x_ - pedestal_roof_thickness_);
-            }
-          }
-          else{
-            vertex = ped_roof_front_gen_->GenerateVertex("INSIDE");
-            if (G4UniformRand() < 0.5){
-              vertex.setZ(vertex.z() - pedestal_lateral_length_ + pedestal_roof_thickness_);
-            }
-          }
-         }
       }
+      else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_)) { //SUPPORT-TOP
+        vertex = ped_support_top_gen_->GenerateVertex("INSIDE");
+        if (G4UniformRand() < 0.5) {
+          vertex.setZ(vertex.z() - support_beam_dist_);
+        }
+      }
+      else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_ + perc_ped_front_vol_)){ //FRONT BEAM
+        vertex = ped_front_gen_->GenerateVertex("INSIDE");
+        if (G4UniformRand() < 0.5) {
+          vertex.setZ(vertex.z() - (2.*support_front_dist_ + support_beam_dist_));
+        }
+      }
+      else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_ + perc_ped_front_vol_
+                       + perc_ped_lateral_vol_)){ // LATERAL BEAM
+        vertex = ped_lateral_gen_->GenerateVertex("INSIDE");
+        if (G4UniformRand() < 0.5) {
+          vertex.setX(vertex.x() - (pedestal_x_ + pedestal_lateral_beam_thickness_));
+        }
+      }
+      else { // ROOF
+        if (G4UniformRand() < 0.5) {
+          vertex = ped_roof_lat_gen_->GenerateVertex("INSIDE");
+          if (G4UniformRand() < 0.5){
+            vertex.setX(vertex.x() - pedestal_top_x_ - pedestal_roof_thickness_);
+          }
+        }
+        else{
+          vertex = ped_roof_front_gen_->GenerateVertex("INSIDE");
+          if (G4UniformRand() < 0.5){
+            vertex.setZ(vertex.z() - pedestal_lateral_length_ + pedestal_roof_thickness_);
+          }
+        }
+      }
+    }
 
     // Note: BUBBLE_SEAL and EDPM_SEAL are not implemented as logical volumes, only their
     // generators. They are placed in INNER_AIR volume.
@@ -743,26 +743,26 @@ namespace nexus {
         vertex = bubble_seal_front_gen_->GenerateVertex("INSIDE");
         if (G4UniformRand() < 0.5){
           vertex.setZ(vertex.z() + (support_beam_dist_/2. + support_front_dist_
-                                 + pedestal_front_beam_thickness_/2. + bubble_seal_thickness_/2.));
+                                    + pedestal_front_beam_thickness_/2. + bubble_seal_thickness_/2.));
         }
         else{
           vertex.setZ(vertex.z() - (support_beam_dist_/2. + support_front_dist_
-                                 + pedestal_front_beam_thickness_/2. + bubble_seal_thickness_/2.));
+                                    + pedestal_front_beam_thickness_/2. + bubble_seal_thickness_/2.));
         }
       }
       else{ // lateral
         vertex = bubble_seal_lateral_gen_->GenerateVertex("INSIDE");
         if (G4UniformRand() < 0.5){
           vertex.setX(vertex.x() + (pedestal_x_/2. + pedestal_lateral_beam_thickness_
-                                 + bubble_seal_thickness_/2.));
+                                    + bubble_seal_thickness_/2.));
         }
         else{
           vertex.setX(vertex.x() - (pedestal_x_/2. + pedestal_lateral_beam_thickness_
-                                 + bubble_seal_thickness_/2.));
+                                    + bubble_seal_thickness_/2.));
         }
       }
-      }
-
+    }
+    
     else if(region=="EDPM_SEAL"){
       G4double rand = G4UniformRand();
       if (rand<perc_edpm_front_vol_){ // front

--- a/source/geometries/Next100TrackingPlane.cc
+++ b/source/geometries/Next100TrackingPlane.cc
@@ -100,7 +100,7 @@ void Next100TrackingPlane::Construct()
   sipm_board_geom_->Construct();
   G4LogicalVolume* sipm_board_logic = sipm_board_geom_->GetLogicalVolume();
 
-  G4double zpos = GetELzCoord() - gate_tp_dist_ + sipm_board_geom_->GetThickness()/2.;
+  G4double zpos = GetCoordOrigin()[2] - gate_tp_dist_ + sipm_board_geom_->GetThickness()/2.;
 
   // SiPM boards are positioned bottom (negative Y) to top (positive Y)
   // and left (negative X) to right (positive X).
@@ -211,7 +211,7 @@ G4ThreeVector Next100TrackingPlane::GenerateVertex(const G4String& region) const
         G4int board_num = G4RandFlat::shootInt((long) 0, board_pos_.size());
         vertex += board_pos_[board_num];
         G4ThreeVector glob_vtx(vertex);
-        glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+        glob_vtx = glob_vtx - GetCoordOrigin();
         VertexVolume =
           geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
 

--- a/source/geometries/Next100TrackingPlane.cc
+++ b/source/geometries/Next100TrackingPlane.cc
@@ -84,7 +84,7 @@ void Next100TrackingPlane::Construct()
   G4LogicalVolume* copper_plate_logic =
     new G4LogicalVolume(copper_plate_solid, copper, copper_plate_name);
 
-  G4double copper_plate_zpos = GetELzCoord() - gate_tp_dist_ - copper_plate_thickness_/2.;
+  G4double copper_plate_zpos = GetCoordOrigin()[2] - gate_tp_dist_ - copper_plate_thickness_/2.;
 
   G4VPhysicalVolume* copper_plate_phys =
     new G4PVPlacement(nullptr, G4ThreeVector(0.,0.,copper_plate_zpos),

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -271,7 +271,7 @@ namespace nexus {
 
     G4LogicalVolume* vessel_gas_logic = new G4LogicalVolume(vessel_gas_solid, vessel_gas_mat, "VESSEL_GAS");
     internal_logic_vol_ = vessel_gas_logic;
-    SetELzCoord(-body_length_/2. - endcap_in_z_width_ + endcap_tp_distance_ + gate_tp_distance_);
+    SetGateZpos(-body_length_/2. - endcap_in_z_width_ + endcap_tp_distance_ + gate_tp_distance_);
     internal_phys_vol_ =
       new G4PVPlacement(0, G4ThreeVector(0.,0.,0.), vessel_gas_logic,
                         "VESSEL_GAS", vessel_logic, false, 0);

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -39,6 +39,10 @@ namespace nexus {
     G4VPhysicalVolume* GetInternalPhysicalVolume();
 
     void SetELtoTPdistance(G4double);
+    void SetGateZpos(G4double);
+
+    G4double GetGateZpos();
+
     // get Z position of calibration ports
     G4double* GetPortZpositions();
 
@@ -51,6 +55,7 @@ namespace nexus {
     G4double body_length_;
     G4double endcap_in_rad_, endcap_in_body_, endcap_theta_, endcap_in_z_width_;
     G4double endcap_tp_distance_, gate_tp_distance_;
+    G4double gate_z_pos_;
     G4double port_base_height_, port_tube_height_, port_tube_tip_;
     G4double port_x_, port_y_, source_height_, port_z_1a_, port_z_1b_, port_z_2a_, port_z_2b_;
     G4double sc_yield_, e_lifetime_;
@@ -90,6 +95,14 @@ namespace nexus {
 
   inline void Next100Vessel::SetELtoTPdistance(G4double distance){
     gate_tp_distance_ = distance;
+  }
+
+  inline void Next100Vessel::SetGateZpos(G4double pos){
+    gate_z_pos_ = pos;
+  }
+
+  inline G4double Next100Vessel::GetGateZpos(){
+    return gate_z_pos_;
   }
 
 } // end namespace nexus

--- a/source/geometries/Next1EL.cc
+++ b/source/geometries/Next1EL.cc
@@ -293,7 +293,6 @@ void Next1EL::BuildLab()
 
   lab_logic_ = new G4LogicalVolume(lab_solid, air_, "LAB");
   lab_logic_->SetVisAttributes(G4VisAttributes::GetInvisible());
-  this->SetDrift(true);
 
   // Set this volume as the wrapper for the whole geometry
   // (i.e., this is the volume that will be placed in the world)


### PR DESCRIPTION
This PR addresses issue #47 and eliminates the concept of `EL z coordinate` replacing it with the origin of coordinates, which is more general and can be used with any geometry, when it is not placed in (0, 0, 0).
I have implemented the changes only for NEXT-100, for the moment, to receive feedback. If we consider this approach OK, the next steps would be to remove the setter/getter of `ELzCoord` from `GeometryBase.h` and do the same with the NEW and DEMO geometries. I would probably implement the changes only in DEMO, since NEW is soon to become obsolete; we could simply transfer the `ELzCoord` setter/getter to each NEW class that needs them.
I would like to know @jmalbos and @jmunozv's opinions on this topic, plus anybody else's who wants to contribute.