### PR TITLE
Fix for Geant4 1.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .sconsign.dblite
 source/.DS_Store
 *~
+.vscode
 
 # nexus output files
 *.h5

--- a/source/physics/BaseDriftField.h
+++ b/source/physics/BaseDriftField.h
@@ -11,6 +11,7 @@
 
 #include <G4VUserRegionInformation.hh>
 #include <G4LorentzVector.hh>
+#include <G4Types.hh>
 
 class G4Material;
 

--- a/source/physics/RadiusDependentDriftField.h
+++ b/source/physics/RadiusDependentDriftField.h
@@ -12,6 +12,7 @@
 
 #include "BaseDriftField.h"
 #include <G4LorentzVector.hh>
+#include <G4Types.hh>
 
 
 namespace nexus {


### PR DESCRIPTION
This PR adds include lines that are necessary to define the `G4double` type. This is necessary as of Geant4 version > 11.0.

Also, as a small bonus it adds VSCode configurations to gitignore. 