### PR TITLE
Use total drift length of EL gap to generate EL photons

### DIFF
--- a/source/physics/BaseDriftField.h
+++ b/source/physics/BaseDriftField.h
@@ -40,6 +40,7 @@ namespace nexus {
       GeneratePointAlongDriftLine(const G4LorentzVector&, const G4LorentzVector&) = 0;
 
     virtual G4double LightYield() const;
+    virtual G4double GetTotalDriftLength() const;
 
   private:
     void Print() const;
@@ -52,6 +53,8 @@ namespace nexus {
   inline BaseDriftField::~BaseDriftField() {}
 
   inline G4double BaseDriftField::LightYield() const {return 0.;}
+
+  inline G4double BaseDriftField::GetTotalDriftLength() const {return 0.;}
 
   inline void BaseDriftField::Print() const {}
 

--- a/source/physics/Electroluminescence.cc
+++ b/source/physics/Electroluminescence.cc
@@ -79,7 +79,7 @@ Electroluminescence::PostStepDoIt(const G4Track& track, const G4Step& step)
 
   // Get the light yield from the field
   const G4double yield = field->LightYield();
-  G4double step_length = step.GetStepLength();
+  G4double step_length = field->GetTotalDriftLength();
 
   if (yield <= 0.)
     return G4VDiscreteProcess::PostStepDoIt(track, step);

--- a/source/physics/UniformElectricDriftField.cc
+++ b/source/physics/UniformElectricDriftField.cc
@@ -115,4 +115,11 @@ namespace nexus {
   }
 
 
+
+  G4double UniformElectricDriftField::GetTotalDriftLength() const
+  {
+    return std::abs(anode_pos_ - cathode_pos_);
+  }
+
+
 } // end namespace nexus

--- a/source/physics/UniformElectricDriftField.h
+++ b/source/physics/UniformElectricDriftField.h
@@ -64,6 +64,8 @@ namespace nexus {
     void SetNumberOfPhotons(G4double);
     G4double GetNumberOfPhotons() const;
 
+    virtual G4double GetTotalDriftLength() const;
+
   private:
     /// Returns true if coordinate is between anode and cathode
     G4bool CheckCoordinate(G4double);


### PR DESCRIPTION
Due to a change in `Geant4-11.1`, the step length returned by the ionization electron crossing the EL gap is 0 instead of the gap length. An effect of this is that the number of EL photons is 0, as well.
This PR modifies the way we calculate the number of EL photons, using the actual length of the gap instead of the step length, to overcome this problem.