### PR TITLE
Add option to kill particle after step selection

### DIFF
--- a/macros/NEW_geantino.config.mac
+++ b/macros/NEW_geantino.config.mac
@@ -21,6 +21,7 @@
 #/Actions/SaveAllSteppingAction/select_particle geantino
 #/Actions/SaveAllSteppingAction/select_volume   ACTIVE   #    full match
 #/Actions/SaveAllSteppingAction/select_volume   TPB      # partial match
+#/Actions/SaveAllSteppingAction/kill_after_selection true
 
 # GEOMETRY
 /Geometry/NextNew/pressure 10. bar

--- a/source/actions/SaveAllSteppingAction.cc
+++ b/source/actions/SaveAllSteppingAction.cc
@@ -41,7 +41,8 @@ final_volumes_(),
 proc_names_(),
 initial_poss_(),
 final_poss_(),
-times_()
+times_(),
+kill_after_selection_(false)
 {
   msg_ = new G4GenericMessenger(this, "/Actions/SaveAllSteppingAction/");
 
@@ -52,6 +53,10 @@ times_()
   msg_->DeclareMethod("select_volume",
                       &SaveAllSteppingAction::AddSelectedVolume,
                       "add a new volume to select");
+
+  msg_->DeclareProperty("kill_after_selection",
+                        kill_after_selection_,
+                        "Whether to kill a particle after a step has been selected");
 
   PersistencyManager* pm = dynamic_cast<PersistencyManager*>
         (G4VPersistencyManager::GetPersistencyManager());
@@ -102,6 +107,9 @@ void SaveAllSteppingAction::UserSteppingAction(const G4Step* step)
   initial_poss_   [key].push_back(initial_pos);
     final_poss_   [key].push_back(  final_pos);
          times_   [key].push_back(  step_time);
+
+  if (kill_after_selection_)
+    step->GetTrack()->SetTrackStatus(fStopAndKill);
 }
 
 

--- a/source/actions/SaveAllSteppingAction.cc
+++ b/source/actions/SaveAllSteppingAction.cc
@@ -34,7 +34,14 @@ REGISTER_CLASS(SaveAllSteppingAction, G4UserSteppingAction)
 SaveAllSteppingAction::SaveAllSteppingAction():
 G4UserSteppingAction(),
 msg_(0),
-selected_volumes_()
+selected_volumes_(),
+selected_particles_(),
+initial_volumes_(),
+final_volumes_(),
+proc_names_(),
+initial_poss_(),
+final_poss_(),
+times_()
 {
   msg_ = new G4GenericMessenger(this, "/Actions/SaveAllSteppingAction/");
 

--- a/source/actions/SaveAllSteppingAction.h
+++ b/source/actions/SaveAllSteppingAction.h
@@ -65,6 +65,8 @@ namespace nexus {
     StepContainer<G4ThreeVector>   final_poss_;
     StepContainer<G4double>             times_;
 
+    G4bool kill_after_selection_;
+
   public:
 
     StepContainer<G4String> get_initial_volumes();


### PR DESCRIPTION
This PRs adds a command to `SaveAllSteppingAction` that allows killing the tracked particle once it has been selected. This is meant to reduce computation time when tracking photons that usually interact several times before absorption.