### PR TITLE
Honeycomb

### DIFF
--- a/source/geometries/Honeycomb.cc
+++ b/source/geometries/Honeycomb.cc
@@ -179,7 +179,7 @@ namespace nexus {
       do {
         vertex = gen_->GenerateVertex("VOLUME");
         G4ThreeVector glob_vtx(vertex);
-        glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+        glob_vtx = glob_vtx - GetCoordOrigin();
         VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
       } while (VertexVolume->GetName() != region);
     }

--- a/source/geometries/Honeycomb.cc
+++ b/source/geometries/Honeycomb.cc
@@ -14,59 +14,131 @@
 #include <G4LogicalVolume.hh>
 #include <G4RotationMatrix.hh>
 #include <G4MultiUnion.hh>
+#include <G4PVPlacement.hh>
 #include <G4VisAttributes.hh>
 
 
 namespace nexus {
-  
+
   using namespace CLHEP;
-  
+
   Honeycomb::Honeycomb(): GeometryBase(), angle_(pi / 6.), beam_dist_(102.25 * mm),
                           beam_thickn_(6 * mm)
   {
+    compl_angle_ = pi/2. - angle_;
   }
-  
+
   Honeycomb::~Honeycomb()
   {
   }
 
   void Honeycomb::Construct()
   {
-    HoneycombBeam* short_beam  = new HoneycombBeam(1085.9*mm, 117*mm, beam_thickn_);
-    HoneycombBeam* medium_beam = new HoneycombBeam(1170.2*mm, 130*mm, beam_thickn_);
-    HoneycombBeam* long_beam   = new HoneycombBeam(1210.6*mm, 130*mm, beam_thickn_);
+    G4double shorter_height = 117 * mm;
+    //G4double shorter_height = 130 * mm;
+    G4double longer_height  = 130 * mm;
+    HoneycombBeam* short_beam  = new HoneycombBeam(1085.9*mm, shorter_height, beam_thickn_);
+    HoneycombBeam* medium_beam = new HoneycombBeam(1170.2*mm, longer_height, beam_thickn_);
+    HoneycombBeam* long_beam   = new HoneycombBeam(1210.6*mm, longer_height, beam_thickn_);
+
+    G4double short_displ = (longer_height-shorter_height)/2.;
 
     short_beam->Construct();
     medium_beam->Construct();
     long_beam->Construct();
 
-     
+
     G4MultiUnion* struct_solid = new G4MultiUnion("HONEYCOMB");
 
     G4RotationMatrix rot;
-    G4double long_hup_ypos = beam_dist_/2. + beam_thickn_;
-    struct_solid->AddNode(short_beam->GetSolidVol(),
-                          G4Transform3D(rot, G4ThreeVector(0., long_hup_ypos, 0.)));
+
+    G4ThreeVector ini_pos = G4ThreeVector(-(beam_dist_+beam_thickn_)/2., 0., 0.);
+    struct_solid->AddNode(long_beam->GetSolidVol(),
+                          G4Transform3D(rot, ini_pos));
 
     G4RotationMatrix rot_left;
-    rot_left.rotateY(pi / 6);
-    G4double r_pos = 2.5*beam_thickn_+2.5*beam_dist_;
-    G4double z = r_pos * cos(angle_);
+    rot_left.rotateY(-compl_angle_);
+    G4RotationMatrix rot_right;
+    rot_right.rotateY(-(pi/2.+angle_));
+
+    G4double r_pos = 1/2*beam_dist_+ 2*(beam_dist_+beam_thickn_) + 1/2*beam_thickn_;
+    r_pos =  r_pos + (beam_dist_ + beam_thickn_)/2.*cos(compl_angle_) + 2.75*cm;
     G4double x = r_pos * sin(angle_);
+    G4double z = r_pos * cos(angle_);
+
     struct_solid->AddNode(short_beam->GetSolidVol(),
-                          G4Transform3D(rot_left, G4ThreeVector(x, 0, z)));
+                          G4Transform3D(rot_left, G4ThreeVector(x, short_displ, z)));
+    struct_solid->AddNode(short_beam->GetSolidVol(),
+                          G4Transform3D(rot_right, G4ThreeVector(-x, short_displ, z)));
+    struct_solid->AddNode(short_beam->GetSolidVol(),
+                          G4Transform3D(rot_left, G4ThreeVector(-x, short_displ, -z)));
+    struct_solid->AddNode(short_beam->GetSolidVol(),
+                          G4Transform3D(rot_right, G4ThreeVector(x, short_displ, -z)));
+
+
+    x = (r_pos-(beam_dist_+beam_thickn_)) * sin(angle_);
+    z = (r_pos-(beam_dist_+beam_thickn_)) * cos(angle_);
+    struct_solid->AddNode(medium_beam->GetSolidVol(),
+                          G4Transform3D(rot_left, G4ThreeVector(x, 0., z)));
+    struct_solid->AddNode(medium_beam->GetSolidVol(),
+                          G4Transform3D(rot_left, G4ThreeVector(-x, 0., -z)));
+    struct_solid->AddNode(medium_beam->GetSolidVol(),
+                          G4Transform3D(rot_right, G4ThreeVector(x, 0., -z)));
+    struct_solid->AddNode(medium_beam->GetSolidVol(),
+                          G4Transform3D(rot_right, G4ThreeVector(-x, 0., z)));
+
+
+    x = (r_pos-2*(beam_dist_+beam_thickn_)) * sin(angle_);
+    z = (r_pos-2*(beam_dist_+beam_thickn_)) * cos(angle_);
+    struct_solid->AddNode(long_beam->GetSolidVol(),
+                          G4Transform3D(rot_left, G4ThreeVector(x, 0., z)));
+
+
+    struct_solid->AddNode(long_beam->GetSolidVol(),
+                          G4Transform3D(rot_left, G4ThreeVector(-x, 0., -z)));
+
+    struct_solid->AddNode(long_beam->GetSolidVol(),
+                          G4Transform3D(rot_right, G4ThreeVector(x, 0., -z)));
+    struct_solid->AddNode(long_beam->GetSolidVol(),
+                          G4Transform3D(rot_right, G4ThreeVector(-x, 0., z)));
+
+
+    x = ini_pos.x() - (beam_dist_+beam_thickn_);
+    struct_solid->AddNode(medium_beam->GetSolidVol(),
+                          G4Transform3D(rot, G4ThreeVector(x, 0., 0.)));
+    x = ini_pos.x() - 2*(beam_dist_+beam_thickn_);
+    struct_solid->AddNode(short_beam->GetSolidVol(),
+                          G4Transform3D(rot, G4ThreeVector(x, short_displ, 0.)));
+    x = ini_pos.x() + (beam_dist_+beam_thickn_);
+    struct_solid->AddNode(long_beam->GetSolidVol(),
+                          G4Transform3D(rot, G4ThreeVector(x, 0., 0.)));
+    x = ini_pos.x() + 2*(beam_dist_+beam_thickn_);
+    struct_solid->AddNode(medium_beam->GetSolidVol(),
+                          G4Transform3D(rot, G4ThreeVector(x, 0., 0.)));
+    x = ini_pos.x() + 3*(beam_dist_+beam_thickn_);
+    struct_solid->AddNode(short_beam->GetSolidVol(),
+                          G4Transform3D(rot, G4ThreeVector(x, short_displ, 0.)));
 
     struct_solid->Voxelize();
 
     G4LogicalVolume* struct_logic = new G4LogicalVolume(struct_solid, materials::Steel(),
                                                 "UnionBeams");
 
-    this->SetLogicalVolume(struct_logic);
+    //this->SetLogicalVolume(struct_logic);
+
+
+    G4RotationMatrix rot_placement;
+    rot_placement.rotateZ(-pi/2);
+    rot_placement.rotateY(pi/2);
+
+    G4double hc_posz_ = end_of_EP_copper_plate_z_ + longer_height/2.;
+    new G4PVPlacement(G4Transform3D(rot_placement, G4ThreeVector(0., 0., hc_posz_)),
+                      struct_logic, "HONEYCOMB", mother_logic_, false, 0, true);
 
     G4VisAttributes red_col = nexus::Red();
     red_col.SetForceSolid(true);
     struct_logic->SetVisAttributes(red_col);
-    
+
   }
 
   G4ThreeVector Honeycomb::GenerateVertex(const G4String& region) const

--- a/source/geometries/Honeycomb.cc
+++ b/source/geometries/Honeycomb.cc
@@ -1,0 +1,76 @@
+// ----------------------------------------------------------------------------
+// nexus | Honeycomb.cc
+//
+// Support structure to the EP copper plate.
+//
+// The NEXT Collaboration
+// ----------------------------------------------------------------------------
+
+#include "Honeycomb.h"
+#include "HoneycombBeam.h"
+#include "MaterialsList.h"
+#include "Visibilities.h"
+
+#include <G4LogicalVolume.hh>
+#include <G4RotationMatrix.hh>
+#include <G4MultiUnion.hh>
+#include <G4VisAttributes.hh>
+
+
+namespace nexus {
+  
+  using namespace CLHEP;
+  
+  Honeycomb::Honeycomb(): GeometryBase(), angle_(pi / 6.), beam_dist_(102.25 * mm),
+                          beam_thickn_(6 * mm)
+  {
+  }
+  
+  Honeycomb::~Honeycomb()
+  {
+  }
+
+  void Honeycomb::Construct()
+  {
+    HoneycombBeam* short_beam  = new HoneycombBeam(1085.9*mm, 117*mm, beam_thickn_);
+    HoneycombBeam* medium_beam = new HoneycombBeam(1170.2*mm, 130*mm, beam_thickn_);
+    HoneycombBeam* long_beam   = new HoneycombBeam(1210.6*mm, 130*mm, beam_thickn_);
+
+    short_beam->Construct();
+    medium_beam->Construct();
+    long_beam->Construct();
+
+     
+    G4MultiUnion* struct_solid = new G4MultiUnion("HONEYCOMB");
+
+    G4RotationMatrix rot;
+    G4double long_hup_ypos = beam_dist_/2. + beam_thickn_;
+    struct_solid->AddNode(short_beam->GetSolidVol(),
+                          G4Transform3D(rot, G4ThreeVector(0., long_hup_ypos, 0.)));
+
+    G4RotationMatrix rot_left;
+    rot_left.rotateY(pi / 6);
+    G4double r_pos = 2.5*beam_thickn_+2.5*beam_dist_;
+    G4double z = r_pos * cos(angle_);
+    G4double x = r_pos * sin(angle_);
+    struct_solid->AddNode(short_beam->GetSolidVol(),
+                          G4Transform3D(rot_left, G4ThreeVector(x, 0, z)));
+
+    struct_solid->Voxelize();
+
+    G4LogicalVolume* struct_logic = new G4LogicalVolume(struct_solid, materials::Steel(),
+                                                "UnionBeams");
+
+    this->SetLogicalVolume(struct_logic);
+
+    G4VisAttributes red_col = nexus::Red();
+    red_col.SetForceSolid(true);
+    struct_logic->SetVisAttributes(red_col);
+    
+  }
+
+  G4ThreeVector Honeycomb::GenerateVertex(const G4String& region) const
+  {
+    return G4ThreeVector(0, 0, 0);
+  }
+}

--- a/source/geometries/Honeycomb.cc
+++ b/source/geometries/Honeycomb.cc
@@ -10,7 +10,7 @@
 #include "HoneycombBeam.h"
 #include "MaterialsList.h"
 #include "Visibilities.h"
-#include "CylinderPointSampler2020.h"
+#include "CylinderPointSampler.h"
 
 #include <G4LogicalVolume.hh>
 #include <G4RotationMatrix.hh>
@@ -164,9 +164,9 @@ namespace nexus {
 
     // Vertex generator
     gen_  =
-      new CylinderPointSampler2020(0., longer_length/2., longer_height/2.,
-                                   0., 360.*deg, 0,
-                                   G4ThreeVector(0., 0., hc_posz));
+      new CylinderPointSampler(0., longer_length/2., longer_height/2.,
+                               0., 360.*deg, 0,
+                               G4ThreeVector(0., 0., hc_posz));
 
   }
 
@@ -177,7 +177,7 @@ namespace nexus {
     if (region == "HONEYCOMB") {
       G4VPhysicalVolume* VertexVolume;
       do {
-        vertex = gen_->GenerateVertex("VOLUME");
+        vertex = gen_->GenerateVertex(VOLUME);
         G4ThreeVector glob_vtx(vertex);
         glob_vtx = glob_vtx - GetCoordOrigin();
         VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);

--- a/source/geometries/Honeycomb.cc
+++ b/source/geometries/Honeycomb.cc
@@ -10,6 +10,7 @@
 #include "HoneycombBeam.h"
 #include "MaterialsList.h"
 #include "Visibilities.h"
+#include "CylinderPointSampler2020.h"
 
 #include <G4LogicalVolume.hh>
 #include <G4RotationMatrix.hh>
@@ -17,16 +18,22 @@
 #include <G4PVPlacement.hh>
 #include <G4VisAttributes.hh>
 #include <G4Trd.hh>
-
+#include <G4TransportationManager.hh>
 
 namespace nexus {
 
   using namespace CLHEP;
 
-  Honeycomb::Honeycomb(): GeometryBase(), angle_(pi / 6.), beam_dist_(102.25 * mm),
+  Honeycomb::Honeycomb(): GeometryBase(),
+                          angle_(pi / 6.),
+                          beam_dist_(102.25 * mm),
                           beam_thickn_(6 * mm)
   {
     compl_angle_ = pi/2. - angle_;
+
+    /// Initializing the geometry navigator (used in vertex generation)
+    geom_navigator_ =
+      G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking();
   }
 
   Honeycomb::~Honeycomb()
@@ -37,13 +44,14 @@ namespace nexus {
   {
     G4double shorter_height = 117 * mm;
     G4double longer_height  = 130 * mm;
+    G4double longer_length  = 1210.6*mm;
 
     HoneycombBeam* short_beam =
       new HoneycombBeam(beam_thickn_, 1085.9*mm, 184*mm, shorter_height);
     HoneycombBeam* medium_beam =
       new HoneycombBeam(beam_thickn_, 1170.2*mm, 273.5*mm, longer_height);
     HoneycombBeam* long_beam =
-      new HoneycombBeam(beam_thickn_, 1210.6*mm, 407.4*mm, longer_height);
+      new HoneycombBeam(beam_thickn_, longer_length, 407.4*mm, longer_height);
 
     G4double short_displ = (longer_height-shorter_height)/2.;
 
@@ -57,7 +65,8 @@ namespace nexus {
     G4RotationMatrix rot;
     rot.rotateX(3*pi/2.);
 
-    G4ThreeVector ini_pos = G4ThreeVector(-(beam_dist_+beam_thickn_)/2., 0., 0.);
+    G4ThreeVector ini_pos =
+      G4ThreeVector(-(beam_dist_+beam_thickn_)/2., 0., 0.);
     struct_solid->AddNode(long_beam->GetSolidVol(),
                           G4Transform3D(rot, ini_pos));
 
@@ -68,19 +77,24 @@ namespace nexus {
     rot_right.rotateX(3*pi/2.);
     rot_right.rotateY(-(pi/2.+angle_));
 
-    G4double r_pos = 1/2*beam_dist_+ 2*(beam_dist_+beam_thickn_) + 1/2*beam_thickn_;
+    G4double r_pos =
+      1/2*beam_dist_+ 2*(beam_dist_+beam_thickn_) + 1/2*beam_thickn_;
     r_pos =  r_pos + (beam_dist_ + beam_thickn_)/2.*cos(compl_angle_) + 2.75*cm;
     G4double x = r_pos * sin(angle_);
     G4double z = r_pos * cos(angle_);
 
     struct_solid->AddNode(short_beam->GetSolidVol(),
-                          G4Transform3D(rot_left, G4ThreeVector(x, short_displ, z)));
+                          G4Transform3D(rot_left,
+                                        G4ThreeVector(x, short_displ, z)));
     struct_solid->AddNode(short_beam->GetSolidVol(),
-                          G4Transform3D(rot_right, G4ThreeVector(-x, short_displ, z)));
+                          G4Transform3D(rot_right,
+                                        G4ThreeVector(-x, short_displ, z)));
     struct_solid->AddNode(short_beam->GetSolidVol(),
-                          G4Transform3D(rot_left, G4ThreeVector(-x, short_displ, -z)));
+                          G4Transform3D(rot_left,
+                                        G4ThreeVector(-x, short_displ, -z)));
     struct_solid->AddNode(short_beam->GetSolidVol(),
-                          G4Transform3D(rot_right, G4ThreeVector(x, short_displ, -z)));
+                          G4Transform3D(rot_right,
+                                        G4ThreeVector(x, short_displ, -z)));
 
 
     x = (r_pos-(beam_dist_+beam_thickn_)) * sin(angle_);
@@ -116,7 +130,8 @@ namespace nexus {
                           G4Transform3D(rot, G4ThreeVector(x, 0., 0.)));
     x = ini_pos.x() - 2*(beam_dist_+beam_thickn_);
     struct_solid->AddNode(short_beam->GetSolidVol(),
-                          G4Transform3D(rot, G4ThreeVector(x, short_displ, 0.)));
+                          G4Transform3D(rot,
+                                        G4ThreeVector(x, short_displ, 0.)));
     x = ini_pos.x() + (beam_dist_+beam_thickn_);
     struct_solid->AddNode(long_beam->GetSolidVol(),
                           G4Transform3D(rot, G4ThreeVector(x, 0., 0.)));
@@ -125,32 +140,54 @@ namespace nexus {
                           G4Transform3D(rot, G4ThreeVector(x, 0., 0.)));
     x = ini_pos.x() + 3*(beam_dist_+beam_thickn_);
     struct_solid->AddNode(short_beam->GetSolidVol(),
-                          G4Transform3D(rot, G4ThreeVector(x, short_displ, 0.)));
+                          G4Transform3D(rot,
+                                        G4ThreeVector(x, short_displ, 0.)));
 
     struct_solid->Voxelize();
 
-    G4LogicalVolume* struct_logic = new G4LogicalVolume(struct_solid, materials::Steel(),
-                                                "UnionBeams");
-
-    //this->SetLogicalVolume(struct_logic);
-
+    G4LogicalVolume* struct_logic =
+      new G4LogicalVolume(struct_solid, materials::Steel(), "HONEYCOMB");
 
     G4RotationMatrix rot_placement;
     rot_placement.rotateZ(-pi/2);
     rot_placement.rotateY(-pi/2);
 
-    G4double hc_posz_ = end_of_EP_copper_plate_z_ + longer_height/2.;
-    new G4PVPlacement(G4Transform3D(rot_placement, G4ThreeVector(0., 0., hc_posz_)),
-                      struct_logic, "HONEYCOMB", mother_logic_, false, 0, true);
+    G4double hc_posz = end_of_EP_copper_plate_z_ + longer_height/2.;
+    new G4PVPlacement(G4Transform3D(rot_placement,
+                                    G4ThreeVector(0., 0., hc_posz)),
+                      struct_logic, "HONEYCOMB", mother_logic_,
+                      false, 0, false);
 
     G4VisAttributes red_col = nexus::Red();
     red_col.SetForceSolid(true);
     struct_logic->SetVisAttributes(red_col);
 
+    // Vertex generator
+    gen_  =
+      new CylinderPointSampler2020(0., longer_length/2., longer_height/2.,
+                                   0., 360.*deg, 0,
+                                   G4ThreeVector(0., 0., hc_posz));
+
   }
 
   G4ThreeVector Honeycomb::GenerateVertex(const G4String& region) const
   {
-    return G4ThreeVector(0, 0, 0);
+    G4ThreeVector vertex(0, 0, 0);
+
+    if (region == "HONEYCOMB") {
+      G4VPhysicalVolume* VertexVolume;
+      do {
+        vertex = gen_->GenerateVertex("VOLUME");
+        G4ThreeVector glob_vtx(vertex);
+        glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+        VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
+      } while (VertexVolume->GetName() != region);
+    }
+    else {
+      G4Exception("[Honeycomb]", "GenerateVertex()", FatalException,
+     		  "Unknown vertex generation region!");
+    }
+
+    return vertex;
   }
 }

--- a/source/geometries/Honeycomb.cc
+++ b/source/geometries/Honeycomb.cc
@@ -16,6 +16,7 @@
 #include <G4MultiUnion.hh>
 #include <G4PVPlacement.hh>
 #include <G4VisAttributes.hh>
+#include <G4Trd.hh>
 
 
 namespace nexus {
@@ -35,11 +36,14 @@ namespace nexus {
   void Honeycomb::Construct()
   {
     G4double shorter_height = 117 * mm;
-    //G4double shorter_height = 130 * mm;
     G4double longer_height  = 130 * mm;
-    HoneycombBeam* short_beam  = new HoneycombBeam(1085.9*mm, shorter_height, beam_thickn_);
-    HoneycombBeam* medium_beam = new HoneycombBeam(1170.2*mm, longer_height, beam_thickn_);
-    HoneycombBeam* long_beam   = new HoneycombBeam(1210.6*mm, longer_height, beam_thickn_);
+
+    HoneycombBeam* short_beam =
+      new HoneycombBeam(beam_thickn_, 1085.9*mm, 184*mm, shorter_height);
+    HoneycombBeam* medium_beam =
+      new HoneycombBeam(beam_thickn_, 1170.2*mm, 273.5*mm, longer_height);
+    HoneycombBeam* long_beam =
+      new HoneycombBeam(beam_thickn_, 1210.6*mm, 407.4*mm, longer_height);
 
     G4double short_displ = (longer_height-shorter_height)/2.;
 
@@ -51,14 +55,17 @@ namespace nexus {
     G4MultiUnion* struct_solid = new G4MultiUnion("HONEYCOMB");
 
     G4RotationMatrix rot;
+    rot.rotateX(3*pi/2.);
 
     G4ThreeVector ini_pos = G4ThreeVector(-(beam_dist_+beam_thickn_)/2., 0., 0.);
     struct_solid->AddNode(long_beam->GetSolidVol(),
                           G4Transform3D(rot, ini_pos));
 
     G4RotationMatrix rot_left;
+    rot_left.rotateX(3*pi/2.);
     rot_left.rotateY(-compl_angle_);
     G4RotationMatrix rot_right;
+    rot_right.rotateX(3*pi/2.);
     rot_right.rotateY(-(pi/2.+angle_));
 
     G4double r_pos = 1/2*beam_dist_+ 2*(beam_dist_+beam_thickn_) + 1/2*beam_thickn_;
@@ -84,6 +91,7 @@ namespace nexus {
                           G4Transform3D(rot_left, G4ThreeVector(-x, 0., -z)));
     struct_solid->AddNode(medium_beam->GetSolidVol(),
                           G4Transform3D(rot_right, G4ThreeVector(x, 0., -z)));
+
     struct_solid->AddNode(medium_beam->GetSolidVol(),
                           G4Transform3D(rot_right, G4ThreeVector(-x, 0., z)));
 
@@ -129,7 +137,7 @@ namespace nexus {
 
     G4RotationMatrix rot_placement;
     rot_placement.rotateZ(-pi/2);
-    rot_placement.rotateY(pi/2);
+    rot_placement.rotateY(-pi/2);
 
     G4double hc_posz_ = end_of_EP_copper_plate_z_ + longer_height/2.;
     new G4PVPlacement(G4Transform3D(rot_placement, G4ThreeVector(0., 0., hc_posz_)),

--- a/source/geometries/Honeycomb.h
+++ b/source/geometries/Honeycomb.h
@@ -14,7 +14,7 @@
 #include <G4Navigator.hh>
 
 namespace nexus {
-  class CylinderPointSampler2020;
+  class CylinderPointSampler;
 
   class Honeycomb: public GeometryBase
   {
@@ -48,7 +48,7 @@ namespace nexus {
     G4double angle_, beam_dist_, beam_thickn_;
     G4double compl_angle_;
 
-    CylinderPointSampler2020* gen_;
+    CylinderPointSampler* gen_;
 
     G4Navigator* geom_navigator_;
   };

--- a/source/geometries/Honeycomb.h
+++ b/source/geometries/Honeycomb.h
@@ -11,7 +11,11 @@
 
 #include "GeometryBase.h"
 
+#include <G4Navigator.hh>
+
 namespace nexus {
+  class CylinderPointSampler2020;
+
   class Honeycomb: public GeometryBase
   {
   public:
@@ -43,6 +47,10 @@ namespace nexus {
     // Relationships among beams
     G4double angle_, beam_dist_, beam_thickn_;
     G4double compl_angle_;
+
+    CylinderPointSampler2020* gen_;
+
+    G4Navigator* geom_navigator_;
   };
 
   inline void Honeycomb::SetMotherLogicalVolume(G4LogicalVolume* mother_logic) {

--- a/source/geometries/Honeycomb.h
+++ b/source/geometries/Honeycomb.h
@@ -1,0 +1,38 @@
+// ----------------------------------------------------------------------------
+// nexus | Honeycomb.h
+//
+// Support structure to the EP copper plate.
+//
+// The NEXT Collaboration
+// ----------------------------------------------------------------------------
+
+#ifndef HONEYCOMB_H
+#define HONEYCOMB_H
+
+#include "GeometryBase.h"
+
+namespace nexus {
+  class Honeycomb: public GeometryBase
+  {
+  public:
+    /// Constructor
+    Honeycomb();
+
+    /// Destructor
+    ~Honeycomb();
+
+    void Construct();
+
+    /// Generate a vertex within a given region of the geometry
+    G4ThreeVector GenerateVertex(const G4String& region) const;
+
+
+  private:
+
+    // Beam rotation angle
+    G4double angle_, beam_dist_, beam_thickn_; 
+  };
+
+} // end namespace nexus
+
+#endif

--- a/source/geometries/Honeycomb.h
+++ b/source/geometries/Honeycomb.h
@@ -26,12 +26,30 @@ namespace nexus {
     /// Generate a vertex within a given region of the geometry
     G4ThreeVector GenerateVertex(const G4String& region) const;
 
+    /// Sets the logical volume where all inner elements are placed
+    void SetMotherLogicalVolume(G4LogicalVolume* mother_logic);
+
+    /// Sets the z position of the outer surface of the copper plate
+    void SetEndOfCopperPlateZ(G4double z);
+
+
 
   private:
 
-    // Beam rotation angle
-    G4double angle_, beam_dist_, beam_thickn_; 
+    G4LogicalVolume* mother_logic_;
+
+    G4double end_of_EP_copper_plate_z_;
+
+    // Relationships among beams
+    G4double angle_, beam_dist_, beam_thickn_;
+    G4double compl_angle_;
   };
+
+  inline void Honeycomb::SetMotherLogicalVolume(G4LogicalVolume* mother_logic) {
+    mother_logic_ = mother_logic;}
+
+  inline void Honeycomb::SetEndOfCopperPlateZ(G4double z) {
+    end_of_EP_copper_plate_z_ = z;}
 
 } // end namespace nexus
 

--- a/source/geometries/HoneycombBeam.cc
+++ b/source/geometries/HoneycombBeam.cc
@@ -1,0 +1,42 @@
+// ----------------------------------------------------------------------------
+// nexus | HoneycombBeam.cc
+//
+// Beam of the support structure to the EP copper plate.
+//
+// The NEXT Collaboration
+// ----------------------------------------------------------------------------
+
+#include "HoneycombBeam.h"
+#include "MaterialsList.h"
+
+#include <G4Box.hh>
+#include <G4Material.hh>
+#include <G4LogicalVolume.hh>
+
+
+namespace nexus {
+  
+  using namespace CLHEP;
+  
+  HoneycombBeam::HoneycombBeam(G4double length, G4double height,
+                               G4double thickn):
+    GeometryBase(), length_(length), height_(height), thickn_(thickn)
+  {
+  }
+  
+  HoneycombBeam::~HoneycombBeam()
+  {
+  }
+
+  void HoneycombBeam::Construct()
+  {
+    beam_solid_ =
+      new G4Box("HONEYCOMB_BEAM", thickn_/2., height_/2., length_/2.);
+    G4Material* steel = materials::Steel();
+    G4LogicalVolume* beam_logic =
+      new G4LogicalVolume(beam_solid_, steel, "HONEYCOMB_BEAM");
+
+    this->SetLogicalVolume(beam_logic);
+  }
+  
+}

--- a/source/geometries/HoneycombBeam.cc
+++ b/source/geometries/HoneycombBeam.cc
@@ -9,21 +9,25 @@
 #include "HoneycombBeam.h"
 #include "MaterialsList.h"
 
-#include <G4Box.hh>
+#include <G4Trd.hh>
 #include <G4Material.hh>
 #include <G4LogicalVolume.hh>
 
 
 namespace nexus {
-  
+
   using namespace CLHEP;
-  
-  HoneycombBeam::HoneycombBeam(G4double length, G4double height,
-                               G4double thickn):
-    GeometryBase(), length_(length), height_(height), thickn_(thickn)
+
+  HoneycombBeam::HoneycombBeam(G4double thickn, G4double length_b,
+                               G4double length_t, G4double height):
+    GeometryBase(),
+    length_b_(length_b),
+    length_t_(length_t),
+    height_(height),
+    thickn_(thickn)
   {
   }
-  
+
   HoneycombBeam::~HoneycombBeam()
   {
   }
@@ -31,12 +35,13 @@ namespace nexus {
   void HoneycombBeam::Construct()
   {
     beam_solid_ =
-      new G4Box("HONEYCOMB_BEAM", thickn_/2., height_/2., length_/2.);
+      new G4Trd("HONEYCOMB_BEAM", thickn_/2., thickn_/2., length_b_/2.,
+                length_t_/2., height_/2.);
     G4Material* steel = materials::Steel();
     G4LogicalVolume* beam_logic =
       new G4LogicalVolume(beam_solid_, steel, "HONEYCOMB_BEAM");
 
     this->SetLogicalVolume(beam_logic);
   }
-  
+
 }

--- a/source/geometries/HoneycombBeam.h
+++ b/source/geometries/HoneycombBeam.h
@@ -11,30 +11,31 @@
 
 #include "GeometryBase.h"
 
-class G4Box;
+class G4Trd;
 
 namespace nexus {
   class HoneycombBeam: public GeometryBase
   {
   public:
     /// Constructor
-    HoneycombBeam(G4double length, G4double height, G4double thickn);
+    HoneycombBeam(G4double thickn, G4double length_b,
+                  G4double length_t, G4double height);
 
     /// Destructor
     ~HoneycombBeam();
 
     void Construct();
 
-    G4Box* GetSolidVol() const;
+    G4Trd* GetSolidVol() const;
     
 
   private:
 
-    G4double length_, height_, thickn_;
-    G4Box* beam_solid_;
+    G4double length_b_, length_t_, height_, thickn_;
+    G4Trd* beam_solid_;
   };
 
-  inline G4Box* HoneycombBeam::GetSolidVol() const {return beam_solid_;}
+  inline G4Trd* HoneycombBeam::GetSolidVol() const {return beam_solid_;}
 } // end namespace nexus
 
 #endif

--- a/source/geometries/HoneycombBeam.h
+++ b/source/geometries/HoneycombBeam.h
@@ -1,0 +1,40 @@
+// ----------------------------------------------------------------------------
+// nexus | HoneycombBeam.h
+//
+// Beam of the support structure to the EP copper plate.
+//
+// The NEXT Collaboration
+// ----------------------------------------------------------------------------
+
+#ifndef HONEYCOMB_BEAM_H
+#define HONEYCOMB_BEAM_H
+
+#include "GeometryBase.h"
+
+class G4Box;
+
+namespace nexus {
+  class HoneycombBeam: public GeometryBase
+  {
+  public:
+    /// Constructor
+    HoneycombBeam(G4double length, G4double height, G4double thickn);
+
+    /// Destructor
+    ~HoneycombBeam();
+
+    void Construct();
+
+    G4Box* GetSolidVol() const;
+    
+
+  private:
+
+    G4double length_, height_, thickn_;
+    G4Box* beam_solid_;
+  };
+
+  inline G4Box* HoneycombBeam::GetSolidVol() const {return beam_solid_;}
+} // end namespace nexus
+
+#endif

--- a/source/geometries/HoneycombBeam.h
+++ b/source/geometries/HoneycombBeam.h
@@ -14,6 +14,7 @@
 class G4Trd;
 
 namespace nexus {
+
   class HoneycombBeam: public GeometryBase
   {
   public:

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -256,7 +256,8 @@ namespace nexus {
              (region == "FIELD_RING") ||
              (region == "GATE_RING") ||
              (region == "ANODE_RING") ||
-             (region == "RING_HOLDER")) {
+             (region == "RING_HOLDER") ||
+             (region == "HONEYCOMB")) {
       vertex = inner_elements_->GenerateVertex(region);
     }
 

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -126,7 +126,8 @@ namespace nexus {
     G4double hut_length = hut_hole_length_ + hut_length_short_;
     G4double transl_z = copper_plate_thickn_/2. + hut_length/2 - offset/2.;
     G4Tubs* short_hut_solid =
-      new G4Tubs("SHORT_HUT", 0., hut_diam_/2., (hut_length + offset)/2., 0., twopi);
+      new G4Tubs("SHORT_HUT", 0., hut_diam_/2., (hut_length + offset)/2.,
+                 0., twopi);
     hut_pos = short_hut_pos_[0];
     hut_pos.setZ(transl_z);
     G4UnionSolid* copper_plate_hut_solid =
@@ -193,7 +194,8 @@ namespace nexus {
     transl_z = - copper_plate_thickn_/2. + hole_length_front_/2. - offset/2.;
     hole_pos.setZ(transl_z);
     G4SubtractionSolid* copper_plate_solid =
-      new G4SubtractionSolid("EP_COPPER_PLATE", copper_plate_hut_solid, hole_solid, 0, hole_pos);
+      new G4SubtractionSolid("EP_COPPER_PLATE", copper_plate_hut_solid,
+                             hole_solid, 0, hole_pos);
 
     for (G4int i=1; i<num_PMTs_; i++) {
       hole_pos = pmt_positions_[i];
@@ -249,13 +251,16 @@ namespace nexus {
       hole_length_front_ + pmt_stand_out_ + optical_pad_thickn_
       + sapphire_window_thickn_ + tpb_thickn_;
     G4Tubs* vacuum_front_solid =
-      new G4Tubs("HOLE_FRONT", 0., hole_diam_front_/2., vacuum_front_length/2., 0., twopi);
+      new G4Tubs("HOLE_FRONT", 0., hole_diam_front_/2., vacuum_front_length/2.,
+                 0., twopi);
 
     G4Tubs* vacuum_rear_solid =
-      new G4Tubs("HOLE_REAR", 0., hole_diam_rear_/2., (hole_length_rear_+offset)/2., 0., twopi);
+      new G4Tubs("HOLE_REAR", 0., hole_diam_rear_/2., (hole_length_rear_+offset)/2.,
+                 0., twopi);
 
     G4Tubs* vacuum_hut_solid =
-      new G4Tubs("HOLE_HUT", 0., hut_int_diam_/2., hut_hole_length_/2., 0., twopi);
+      new G4Tubs("HOLE_HUT", 0., hut_int_diam_/2., hut_hole_length_/2.,
+                 0., twopi);
 
     G4UnionSolid* vacuum_solid =
       new G4UnionSolid("EP_HOLE", vacuum_front_solid, vacuum_rear_solid, 0,
@@ -265,7 +270,8 @@ namespace nexus {
       new G4UnionSolid("EP_HOLE", vacuum_solid, vacuum_hut_solid, 0,
                        G4ThreeVector(0., 0., vacuum_front_length/2.+hole_length_rear_+hut_hole_length_/2.));
 
-    G4LogicalVolume* vacuum_logic = new G4LogicalVolume(vacuum_solid, vacuum, "EP_HOLE");
+    G4LogicalVolume* vacuum_logic =
+      new G4LogicalVolume(vacuum_solid, vacuum, "EP_HOLE");
 
     /// Sapphire window ///
     G4Tubs* sapphire_window_solid =
@@ -275,7 +281,8 @@ namespace nexus {
     G4LogicalVolume* sapphire_window_logic
       = new G4LogicalVolume(sapphire_window_solid, sapphire, "SAPPHIRE_WINDOW");
 
-    G4double window_posz = -vacuum_front_length/2. + (sapphire_window_thickn_ + tpb_thickn_)/2.;
+    G4double window_posz =
+      -vacuum_front_length/2. + (sapphire_window_thickn_ + tpb_thickn_)/2.;
 
     G4VPhysicalVolume* sapphire_window_phys =
       new G4PVPlacement(0, G4ThreeVector(0., 0., window_posz),
@@ -287,7 +294,8 @@ namespace nexus {
       new G4Tubs("SAPPHIRE_WDW_TPB", 0., hole_diam_front_/2, tpb_thickn_/2.,
                  0., twopi);
 
-    G4LogicalVolume* tpb_logic = new G4LogicalVolume(tpb_solid, tpb, "SAPPHIRE_WDW_TPB");
+    G4LogicalVolume* tpb_logic =
+      new G4LogicalVolume(tpb_solid, tpb, "SAPPHIRE_WDW_TPB");
 
     G4double tpb_posz = - (sapphire_window_thickn_ + tpb_thickn_)/2. + tpb_thickn_/2.;
 
@@ -305,7 +313,8 @@ namespace nexus {
 
     /// Optical pad ///
     G4Tubs* optical_pad_solid =
-      new G4Tubs("OPTICAL_PAD", 0., hole_diam_front_/2., optical_pad_thickn_/2., 0., twopi);
+      new G4Tubs("OPTICAL_PAD", 0., hole_diam_front_/2., optical_pad_thickn_/2.,
+                 0., twopi);
 
     G4LogicalVolume* optical_pad_logic =
       new G4LogicalVolume(optical_pad_solid, optical_coupler, "OPTICAL_PAD");
@@ -323,9 +332,8 @@ namespace nexus {
     pmt_->Construct();
     G4LogicalVolume* pmt_logic = pmt_->GetLogicalVolume();
     G4double pmt_rel_posz = pmt_->GetRelPosition().z();
-    pmt_zpos_ =
-      -vacuum_front_length/2. + sapphire_window_thickn_ + tpb_thickn_ +
-      optical_pad_thickn_ + pmt_rel_posz;
+    pmt_zpos_ = -vacuum_front_length/2. + sapphire_window_thickn_ +
+      tpb_thickn_ + optical_pad_thickn_ + pmt_rel_posz;
     G4ThreeVector pmt_pos = G4ThreeVector(0., 0., pmt_zpos_);
 
     pmt_rot_ = new G4RotationMatrix();
@@ -339,12 +347,12 @@ namespace nexus {
     G4Tubs* pmt_base_solid = new G4Tubs("PMT_BASE", 0., pmt_base_diam_/2.,
                                         pmt_base_thickn_/2., 0., twopi);
 
-    G4LogicalVolume* pmt_base_logic =
-      new G4LogicalVolume(pmt_base_solid,
-                          G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON"),
-                          "PMT_BASE");
+    G4LogicalVolume* pmt_base_logic
+      = new G4LogicalVolume(pmt_base_solid,
+                            G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON"), "PMT_BASE");
 
-    G4double pmt_base_posz = vacuum_front_length/2. + hole_length_rear_ + hut_hole_length_/2.;
+    G4double pmt_base_posz =
+      vacuum_front_length/2. + hole_length_rear_ + hut_hole_length_/2.;
 
     G4VPhysicalVolume* pmt_base_phys =
        new G4PVPlacement(0, G4ThreeVector(0., 0., pmt_base_posz),
@@ -353,8 +361,8 @@ namespace nexus {
 
     /// Placing the encapsulating volume with all internal components in place
     vacuum_posz_ = copper_plate_posz_ - copper_plate_thickn_/2.
-      + vacuum_front_length/2. - sapphire_window_thickn_ - tpb_thickn_
-      - optical_pad_thickn_ - pmt_stand_out_;
+      + vacuum_front_length/2. - sapphire_window_thickn_ -
+      tpb_thickn_ - optical_pad_thickn_ - pmt_stand_out_;
 
     G4ThreeVector pos;
     for (int i=0; i<num_PMTs_; i++) {

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -76,7 +76,7 @@ namespace nexus {
     /// 4. A vacuum volume that encapsulates the sapphire window,
     ///    the optical pad, the PMT and the internal part of the base is made;
     ///    this volume fits exactly the hole previously done in the copper.
-    /// 5. This volume is replicated by the number of the PMts and placed
+    /// 5. This volume is replicated by the number of the PMTs and placed
     ///    in the gas volume, inside the holes excavated in the copper.
 
 

--- a/source/geometries/Next100EnergyPlane.h
+++ b/source/geometries/Next100EnergyPlane.h
@@ -42,6 +42,9 @@ namespace nexus {
     /// Sets the z position of the surface of the sapphire windows
     void SetELtoSapphireWDWdistance(G4double z);
 
+    /// Returns the thickness of the copper plate
+    G4double GetCopperPlateThickness() const;
+
     /// Generate a vertex within a given region of the geometry
     G4ThreeVector GenerateVertex(const G4String& region) const;
 
@@ -110,6 +113,8 @@ namespace nexus {
   inline void Next100EnergyPlane::SetMotherLogicalVolume(G4LogicalVolume* mother_logic) { mother_logic_ = mother_logic;}
 
   inline std::vector<G4ThreeVector> Next100EnergyPlane::GetPMTPosInGas() const { return pmt_positions_;}
+
+  inline G4double Next100EnergyPlane::GetCopperPlateThickness() const {return copper_plate_thickn_;}
 
 } //end namespace nexus
 #endif

--- a/source/geometries/Next100EnergyPlane.h
+++ b/source/geometries/Next100EnergyPlane.h
@@ -42,8 +42,8 @@ namespace nexus {
     /// Sets the z position of the surface of the sapphire windows
     void SetELtoSapphireWDWdistance(G4double z);
 
-    /// Returns the thickness of the copper plate
-    G4double GetCopperPlateThickness() const;
+    /// Returns the position of the end of the copper plate
+    G4double GetCopperPlateEndZ() const;
 
     /// Generate a vertex within a given region of the geometry
     G4ThreeVector GenerateVertex(const G4String& region) const;
@@ -63,6 +63,7 @@ namespace nexus {
 
     // Mother Logical Volume of the whole Energy PLane
     G4LogicalVolume* mother_logic_;
+    G4double copper_plate_end_z_;
 
     // Dimensions
     const G4int num_PMTs_;
@@ -114,7 +115,7 @@ namespace nexus {
 
   inline std::vector<G4ThreeVector> Next100EnergyPlane::GetPMTPosInGas() const { return pmt_positions_;}
 
-  inline G4double Next100EnergyPlane::GetCopperPlateThickness() const {return copper_plate_thickn_;}
+  inline G4double Next100EnergyPlane::GetCopperPlateEndZ() const {return copper_plate_end_z_;}
 
 } //end namespace nexus
 #endif

--- a/source/geometries/Next100InnerElements.cc
+++ b/source/geometries/Next100InnerElements.cc
@@ -10,6 +10,7 @@
 #include "Next100InnerElements.h"
 #include "Next100FieldCage.h"
 #include "Next100EnergyPlane.h"
+#include "Honeycomb.h"
 #include "Next100TrackingPlane.h"
 
 #include <G4GenericMessenger.hh>
@@ -32,6 +33,7 @@ namespace nexus {
     gas_(nullptr),
     field_cage_    (new Next100FieldCage(grid_thickn)),
     energy_plane_  (new Next100EnergyPlane()),
+    honeycomb_     (new Honeycomb()),
     tracking_plane_(new Next100TrackingPlane()),
     msg_(nullptr)
   {
@@ -76,6 +78,15 @@ namespace nexus {
 
     pmt_pos_ = energy_plane_->GetPMTPosInGas();
 
+    /*
+    // Honeycomb support structure for EP
+    G4double el_end_of_EP_copper_plate_distance_ =
+      gate_sapphire_wdw_distance_ + energy_plane_->GetCopperPlateThickness();
+    honeycomb_->SetMotherLogicalVolume(mother_logic_);
+    honeycomb_->SetELzCoord(gate_zpos);
+    honeycomb_->SetELtoEndOfELCopperPlate(el_end_of_EP_copper_plate_distance_);
+    honeycomb_->Construct();    
+    */
     // Tracking plane
     tracking_plane_->SetMotherPhysicalVolume(mother_phys_);
     tracking_plane_->SetCoordOrigin(coord_origin);

--- a/source/geometries/Next100InnerElements.cc
+++ b/source/geometries/Next100InnerElements.cc
@@ -80,7 +80,7 @@ namespace nexus {
 
     // Honeycomb support structure for EP
     honeycomb_->SetMotherLogicalVolume(mother_logic_);
-    //honeycomb_->SetELzCoord(gate_zpos);
+    honeycomb_->SetELzCoord(gate_zpos);
     honeycomb_->SetEndOfCopperPlateZ(energy_plane_->GetCopperPlateEndZ());
     honeycomb_->Construct();
 
@@ -129,6 +129,10 @@ namespace nexus {
              (region == "PMT_BODY") ||
              (region == "PMT_BASE")) {
       vertex = energy_plane_->GenerateVertex(region);
+    }
+    // Honeycomb region
+    else if (region == "HONEYCOMB") {
+      vertex = honeycomb_->GenerateVertex(region);
     }
     // Tracking Plane regions
     else if ((region == "TP_COPPER_PLATE") ||

--- a/source/geometries/Next100InnerElements.cc
+++ b/source/geometries/Next100InnerElements.cc
@@ -78,15 +78,12 @@ namespace nexus {
 
     pmt_pos_ = energy_plane_->GetPMTPosInGas();
 
-    /*
     // Honeycomb support structure for EP
-    G4double el_end_of_EP_copper_plate_distance_ =
-      gate_sapphire_wdw_distance_ + energy_plane_->GetCopperPlateThickness();
     honeycomb_->SetMotherLogicalVolume(mother_logic_);
-    honeycomb_->SetELzCoord(gate_zpos);
-    honeycomb_->SetELtoEndOfELCopperPlate(el_end_of_EP_copper_plate_distance_);
-    honeycomb_->Construct();    
-    */
+    //honeycomb_->SetELzCoord(gate_zpos);
+    honeycomb_->SetEndOfCopperPlateZ(energy_plane_->GetCopperPlateEndZ());
+    honeycomb_->Construct();
+
     // Tracking plane
     tracking_plane_->SetMotherPhysicalVolume(mother_phys_);
     tracking_plane_->SetCoordOrigin(coord_origin);

--- a/source/geometries/Next100InnerElements.cc
+++ b/source/geometries/Next100InnerElements.cc
@@ -80,7 +80,7 @@ namespace nexus {
 
     // Honeycomb support structure for EP
     honeycomb_->SetMotherLogicalVolume(mother_logic_);
-    honeycomb_->SetELzCoord(gate_zpos);
+    honeycomb_->SetCoordOrigin(coord_origin);
     honeycomb_->SetEndOfCopperPlateZ(energy_plane_->GetCopperPlateEndZ());
     honeycomb_->Construct();
 

--- a/source/geometries/Next100InnerElements.h
+++ b/source/geometries/Next100InnerElements.h
@@ -25,6 +25,7 @@ namespace nexus {
 
   class Next100FieldCage;
   class Next100EnergyPlane;
+  class Honeycomb;
   class Next100TrackingPlane;
 
   class Next100InnerElements : public GeometryBase
@@ -75,6 +76,7 @@ namespace nexus {
     // Detector parts
     Next100FieldCage*     field_cage_;
     Next100EnergyPlane*   energy_plane_;
+    Honeycomb*            honeycomb_;
     Next100TrackingPlane* tracking_plane_;
 
     // Messenger for the definition of control commands


### PR DESCRIPTION
This PR adds the honeycomb support structure to the energy plane. 
The beams have the simplified geometry of a trapezoid solid, in three different sizes, following the technical drawings.
The most relevant drawings used for the simulation can be found [here](https://github.com/next-exp/nexus/files/12853954/honeycomb_drawings.zip).
