### PR TITLE
Change string to int in output file

### DIFF
--- a/macros/NEW_geantino.config.mac
+++ b/macros/NEW_geantino.config.mac
@@ -26,4 +26,5 @@
 # GEOMETRY
 /Geometry/NextNew/pressure 10. bar
 
+/nexus/persistency/save_strings true
 /nexus/persistency/output_file geantinos.next

--- a/macros/NEW_geantino.config.mac
+++ b/macros/NEW_geantino.config.mac
@@ -26,5 +26,5 @@
 # GEOMETRY
 /Geometry/NextNew/pressure 10. bar
 
-/nexus/persistency/save_strings true
+/nexus/persistency/save_strings false
 /nexus/persistency/output_file geantinos.next

--- a/macros/NEXT_options.config.mac
+++ b/macros/NEXT_options.config.mac
@@ -102,3 +102,4 @@
 /nexus/persistency/start_id 1000
 /nexus/persistency/output_file Next100.next
 /nexus/persistency/event_type background # bb0nu, bb2nu...
+/nexus/persistency/save_strings true

--- a/source/persistency/HDF5Writer.cc
+++ b/source/persistency/HDF5Writer.cc
@@ -119,13 +119,14 @@ void HDF5Writer::WriteHitInfo(int64_t evt_number, int particle_indx, int hit_ind
   ihit_++;
 }
 
-void HDF5Writer::WriteParticleInfo(int64_t evt_number, int particle_indx, const char* particle_name, char primary, int mother_id, float initial_vertex_x, float initial_vertex_y, float initial_vertex_z, float initial_vertex_t, float final_vertex_x, float final_vertex_y, float final_vertex_z, float final_vertex_t, const char* initial_volume, const char* final_volume, float ini_momentum_x, float ini_momentum_y, float ini_momentum_z, float final_momentum_x, float final_momentum_y, float final_momentum_z, float kin_energy, float length, const char* creator_proc, const char* final_proc)
+void HDF5Writer::WriteParticleInfo(int64_t evt_number, int particle_indx, int pdg, char primary, int mother_id, float initial_vertex_x, float initial_vertex_y, float initial_vertex_z, float initial_vertex_t, float final_vertex_x, float final_vertex_y, float final_vertex_z, float final_vertex_t, int initial_volume, int final_volume, float ini_momentum_x, float ini_momentum_y, float ini_momentum_z, float final_momentum_x, float final_momentum_y, float final_momentum_z, float kin_energy, float length, int creator_proc, int final_proc)
 {
   particle_info_t trueInfo;
   trueInfo.event_id = evt_number;
   trueInfo.particle_id = particle_indx;
-  memset(trueInfo.particle_name, 0, STRLEN);
-  strcpy(trueInfo.particle_name, particle_name);
+  //memset(trueInfo.particle_name, 0, STRLEN);
+  //strcpy(trueInfo.particle_name, particle_name);
+  trueInfo.pdg_id = pdg;
   trueInfo.primary = primary;
   trueInfo.mother_id = mother_id;
   trueInfo.initial_x = initial_vertex_x;
@@ -136,10 +137,12 @@ void HDF5Writer::WriteParticleInfo(int64_t evt_number, int particle_indx, const 
   trueInfo.final_y = final_vertex_y;
   trueInfo.final_z = final_vertex_z;
   trueInfo.final_t = final_vertex_t;
-  memset(trueInfo.initial_volume, 0, STRLEN);
-  strcpy(trueInfo.initial_volume, initial_volume);
-  memset(trueInfo.final_volume, 0, STRLEN);
-  strcpy(trueInfo.final_volume, final_volume);
+  //  memset(trueInfo.initial_volume, 0, STRLEN);
+  //  strcpy(trueInfo.initial_volume, initial_volume);
+  //  memset(trueInfo.final_volume, 0, STRLEN);
+  //  strcpy(trueInfo.final_volume, final_volume);
+  trueInfo.initial_volume = initial_volume;
+  trueInfo.final_volume = final_volume;
   trueInfo.initial_momentum_x = ini_momentum_x;
   trueInfo.initial_momentum_y = ini_momentum_y;
   trueInfo.initial_momentum_z = ini_momentum_z;
@@ -148,10 +151,12 @@ void HDF5Writer::WriteParticleInfo(int64_t evt_number, int particle_indx, const 
   trueInfo.final_momentum_z = final_momentum_z;
   trueInfo.kin_energy = kin_energy;
   trueInfo.length = length;
-  memset(trueInfo.creator_proc, 0, STRLEN);
-  strcpy(trueInfo.creator_proc, creator_proc);
-  memset(trueInfo.final_proc, 0, STRLEN);
-  strcpy(trueInfo.final_proc, final_proc);
+  // memset(trueInfo.creator_proc, 0, STRLEN);
+  // strcpy(trueInfo.creator_proc, creator_proc);
+  // memset(trueInfo.final_proc, 0, STRLEN);
+  // strcpy(trueInfo.final_proc, final_proc);
+  trueInfo.creator_proc = creator_proc;
+  trueInfo.final_proc = final_proc;
   writeParticle(&trueInfo,  particleInfoTable_, memtypeParticleInfo_, ipart_);
 
   ipart_++;

--- a/source/persistency/HDF5Writer.cc
+++ b/source/persistency/HDF5Writer.cc
@@ -59,9 +59,11 @@ void HDF5Writer::Open(std::string fileName, bool debug, bool save_str)
   memtypeSnsPos_ = createSensorPosType();
   snsPosTable_ = createTable(group, sns_pos_table_name, memtypeSnsPos_);
 
-  std::string str_map_table_name = "string_map";
-  memtypeStringMap_ = createStringMapType();
-  stringMapTable_ = createTable(group, str_map_table_name, memtypeStringMap_);
+  if (!save_str) {
+    std::string str_map_table_name = "string_map";
+    memtypeStringMap_ = createStringMapType();
+    stringMapTable_ = createTable(group, str_map_table_name, memtypeStringMap_);
+  }
 
   if (debug) {
     std::string debug_group_name = "/DEBUG";

--- a/source/persistency/HDF5Writer.cc
+++ b/source/persistency/HDF5Writer.cc
@@ -21,7 +21,7 @@ using namespace nexus;
 
 HDF5Writer::HDF5Writer():
   file_(0), irun_(0), ismp_(0), ihit_(0),
-  ipart_(0), ipos_(0), istep_(0)
+  ipart_(0), ipos_(0), istep_(0), istrmap_(0)
 {
 }
 
@@ -58,6 +58,10 @@ void HDF5Writer::Open(std::string fileName, bool debug)
   std::string sns_pos_table_name = "sns_positions";
   memtypeSnsPos_ = createSensorPosType();
   snsPosTable_ = createTable(group, sns_pos_table_name, memtypeSnsPos_);
+
+  std::string str_map_table_name = "string_map";
+  memtypeStringMap_ = createStringMapType();
+  stringMapTable_ = createTable(group, str_map_table_name, memtypeStringMap_);
 
   if (debug) {
     std::string debug_group_name = "/DEBUG";
@@ -209,4 +213,15 @@ void HDF5Writer::WriteStep(int64_t evt_number,
   writeStep(&step, stepTable_, memtypeStep_, istep_);
 
   istep_++;
+}
+
+void HDF5Writer::WriteStringMapInfo(const char* name, int name_id)
+{
+  string_map_t strmap;
+  memset(strmap.name, 0, STRLEN);
+  strcpy(strmap.name, name);
+  strmap.name_id = name_id;
+
+  writeStringMap(&strmap, stringMapTable_, memtypeStringMap_, istrmap_);
+  istrmap_++;
 }

--- a/source/persistency/HDF5Writer.h
+++ b/source/persistency/HDF5Writer.h
@@ -44,6 +44,7 @@ namespace nexus {
                    float initial_x, float initial_y, float initial_z,
                    float   final_x, float   final_y, float   final_z,
                    float time);
+    void WriteStringMapInfo(const char* name, int name_id);
 
   private:
     size_t file_; ///< HDF5 file
@@ -58,6 +59,7 @@ namespace nexus {
     size_t particleInfoTable_;
     size_t snsPosTable_;
     size_t stepTable_;
+    size_t stringMapTable_;
 
     size_t memtypeRun_;
     size_t memtypeSnsData_;
@@ -65,6 +67,7 @@ namespace nexus {
     size_t memtypeParticleInfo_;
     size_t memtypeSnsPos_;
     size_t memtypeStep_;
+    size_t memtypeStringMap_;
 
     size_t irun_; ///< counter for configuration parameters
     size_t ismp_; ///< counter for written waveform samples
@@ -72,6 +75,7 @@ namespace nexus {
     size_t ipart_; ///< counter for particle information
     size_t ipos_; ///< counter for sensor positions
     size_t istep_; ///< counter for steps
+    size_t istrmap_;  ///< counter for string map
 
   };
 

--- a/source/persistency/HDF5Writer.h
+++ b/source/persistency/HDF5Writer.h
@@ -33,7 +33,7 @@ namespace nexus {
     void WriteRunInfo(const char* param_key, const char* param_value);
     void WriteSensorDataInfo(int64_t evt_number, unsigned int sensor_id, unsigned int time_bin, unsigned int charge);
     void WriteHitInfo(int64_t evt_number, int particle_indx, int hit_indx, float hit_position_x, float hit_position_y, float hit_position_z, float hit_time, float hit_energy, const char* label);
-    void WriteParticleInfo(int64_t evt_number, int particle_indx, const char* particle_name, char primary, int mother_id, float initial_vertex_x, float initial_vertex_y, float initial_vertex_z, float initial_vertex_t, float final_vertex_x, float final_vertex_y, float final_vertex_z, float final_vertex_t, const char* initial_volume, const char* final_volume, float ini_momentum_x, float ini_momentum_y, float ini_momentum_z, float final_momentum_x, float final_momentum_y, float final_momentum_z, float kin_energy, float length, const char* creator_proc, const char* final_proc);
+    void WriteParticleInfo(int64_t evt_number, int particle_indx, int pdg, char primary, int mother_id, float initial_vertex_x, float initial_vertex_y, float initial_vertex_z, float initial_vertex_t, float final_vertex_x, float final_vertex_y, float final_vertex_z, float final_vertex_t, int initial_volume, int final_volume, float ini_momentum_x, float ini_momentum_y, float ini_momentum_z, float final_momentum_x, float final_momentum_y, float final_momentum_z, float kin_energy, float length, int creator_proc, int final_proc);
     void WriteSensorPosInfo(unsigned int sensor_id, const char* sensor_name, float x, float y, float z);
     void WriteStep(int64_t evt_number,
                    int particle_id, const char* particle_name,

--- a/source/persistency/HDF5Writer.h
+++ b/source/persistency/HDF5Writer.h
@@ -25,15 +25,15 @@ namespace nexus {
     ~HDF5Writer();
 
     /// open file
-    void Open(std::string filename, bool debug);
+    void Open(std::string filename, bool debug, bool save_str);
 
     /// close file
     void Close();
 
     void WriteRunInfo(const char* param_key, const char* param_value);
     void WriteSensorDataInfo(int64_t evt_number, unsigned int sensor_id, unsigned int time_bin, unsigned int charge);
-    void WriteHitInfo(int64_t evt_number, int particle_indx, int hit_indx, float hit_position_x, float hit_position_y, float hit_position_z, float hit_time, float hit_energy, const char* label);
-    void WriteParticleInfo(int64_t evt_number, int particle_indx, int pdg, char primary, int mother_id, float initial_vertex_x, float initial_vertex_y, float initial_vertex_z, float initial_vertex_t, float final_vertex_x, float final_vertex_y, float final_vertex_z, float final_vertex_t, int initial_volume, int final_volume, float ini_momentum_x, float ini_momentum_y, float ini_momentum_z, float final_momentum_x, float final_momentum_y, float final_momentum_z, float kin_energy, float length, int creator_proc, int final_proc);
+    void WriteHitInfo(bool str, int64_t evt_number, int particle_indx, int hit_indx, float hit_position_x, float hit_position_y, float hit_position_z, float hit_time, float hit_energy, const char* label_str, int label);
+    void WriteParticleInfo(bool str, int64_t evt_number, int particle_indx, const char* particle_name_str, int particle_name, char primary, int mother_id, float initial_vertex_x, float initial_vertex_y, float initial_vertex_z, float initial_vertex_t, float final_vertex_x, float final_vertex_y, float final_vertex_z, float final_vertex_t, const char* initial_volume_str, const char* final_volume_str, int initial_volume, int final_volume, float ini_momentum_x, float ini_momentum_y, float ini_momentum_z, float final_momentum_x, float final_momentum_y, float final_momentum_z, float kin_energy, float length, const char* creator_proc_str, const char* final_proc_str, int creator_proc, int final_proc);
     void WriteSensorPosInfo(unsigned int sensor_id, const char* sensor_name, float x, float y, float z);
     void WriteStep(int64_t evt_number,
                    int particle_id, const char* particle_name,

--- a/source/persistency/PersistencyManager.cc
+++ b/source/persistency/PersistencyManager.cc
@@ -156,47 +156,28 @@ void PersistencyManager::StoreTrajectories(G4TrajectoryContainer* tc)
     G4double length = trj->GetTrackLength();
 
     G4ThreeVector ini_xyz = trj->GetInitialPosition();
-    G4double ini_t = trj->GetInitialTime();
+    G4double ini_t        = trj->GetInitialTime();
 
     G4ThreeVector final_xyz = trj->GetFinalPosition();
-    G4double final_t = trj->GetFinalTime();
+    G4double final_t        = trj->GetFinalTime();
 
-    G4double mass = trj->GetParticleDefinition()->GetPDGMass();
-    G4ThreeVector ini_mom = trj->GetInitialMomentum();
-    G4double energy = sqrt(ini_mom.mag2() + mass*mass);
+    G4double mass           = trj->GetParticleDefinition()->GetPDGMass();
+    G4ThreeVector ini_mom   = trj->GetInitialMomentum();
+    G4double energy         = sqrt(ini_mom.mag2() + mass*mass);
     G4ThreeVector final_mom = trj->GetFinalMomentum();
 
-    G4String ini_volume = trj->GetInitialVolume();
+    G4String ini_volume   = trj->GetInitialVolume();
     G4String final_volume = trj->GetFinalVolume();
 
     G4String creator_proc = trj->GetCreatorProcess();
     G4String final_proc   = trj->GetFinalProcess();
 
-    G4int ini_id = FindVolumeInMap(vol_map_, ini_volume);
-    if (ini_id == -1) {
-      vol_map_[c_vol] = ini_volume;
-      ini_id = c_vol;
-      c_vol++;
-    }
-    G4int fin_id = FindVolumeInMap(vol_map_, final_volume);
-    if (fin_id == -1) {
-      vol_map_[c_vol] = final_volume;
-      fin_id = c_vol;
-      c_vol++;
-    }
+    G4int ini_id = FindVolumeIDInMap(vol_map_, ini_volume, c_vol);
+    G4int fin_id = FindVolumeIDInMap(vol_map_, final_volume, c_vol);
 
-    G4int creator_id = FindVolumeInMap(proc_map_, creator_proc);
-    if (creator_id == -1) {
-      proc_map_[c_proc] = creator_proc;
-      creator_id = c_proc;
-      c_proc++;
-    }
-    G4int destr_id = FindVolumeInMap(proc_map_, final_proc);
-    if (destr_id == -1) {
-      proc_map_[c_proc] = final_proc;
-      destr_id = c_proc;
-      c_proc++;
-    }
+    G4int creator_id = FindVolumeIDInMap(proc_map_, creator_proc, c_proc);
+    G4int destr_id   = FindVolumeIDInMap(proc_map_, final_proc, c_proc);
+
 
     float kin_energy = energy - mass;
     char primary = 0;
@@ -459,12 +440,15 @@ void PersistencyManager::SaveConfigurationInfo(G4String file_name)
   history.close();
 }
 
-G4int PersistencyManager::FindVolumeInMap(std::map<G4int, G4String>& vmap, G4String vol)
+G4int PersistencyManager::FindVolumeIDInMap(std::map<G4String, G4int>& vmap,
+                                            G4String vol, G4int& counter)
 {
-  for (auto& it : vmap) {
-    if (it.second == vol) {
-      return it.first;
-    }
+  auto found = vmap.find(vol);
+  if (found != vmap.end()) {
+    return found->second;
+  } else {
+    vmap[vol] = counter;
+    counter++;
+    return counter;
   }
-  return -1;
 }

--- a/source/persistency/PersistencyManager.cc
+++ b/source/persistency/PersistencyManager.cc
@@ -393,12 +393,14 @@ G4bool PersistencyManager::Store(const G4Run*)
     h5writer_->WriteRunInfo(key,  std::to_string(interacting_evts_).c_str());
   }
 
+  // Store sensor time binning
   std::map<G4String, G4double>::const_iterator it;
   for (it = sensdet_bin_.begin(); it != sensdet_bin_.end(); ++it) {
     h5writer_->WriteRunInfo((it->first + "_binning").c_str(),
                            (std::to_string(it->second/microsecond)+" mus").c_str());
   }
 
+  // Store configuration parameters
   SaveConfigurationInfo(init_macro_);
   for (unsigned long i=0; i<macros_.size(); i++) {
     SaveConfigurationInfo(macros_[i]);
@@ -410,13 +412,16 @@ G4bool PersistencyManager::Store(const G4Run*)
     SaveConfigurationInfo(secondary_macros_[i]);
   }
 
-  std::map<G4int, G4String> inv_map;
-  for (const auto& n : str_map_) {
-    inv_map[n.second] = n.first;
-  }
+  // Store map with string --> int correspondence
+  if (!save_str_) {
+    std::map<G4int, G4String> inv_map;
+    for (const auto& n : str_map_) {
+      inv_map[n.second] = n.first;
+    }
 
-  for (const auto& p : inv_map) {
-    h5writer_->WriteStringMapInfo(p.second, p.first);
+    for (const auto& p : inv_map) {
+      h5writer_->WriteStringMapInfo(p.second, p.first);
+    }
   }
 
 

--- a/source/persistency/PersistencyManager.cc
+++ b/source/persistency/PersistencyManager.cc
@@ -165,11 +165,15 @@ void PersistencyManager::StoreTrajectories(G4TrajectoryContainer* tc)
     G4double energy         = sqrt(ini_mom.mag2() + mass*mass);
     G4ThreeVector final_mom = trj->GetFinalMomentum();
 
+    G4String p_name = trj->GetParticleName();
+
     G4String ini_volume   = trj->GetInitialVolume();
     G4String final_volume = trj->GetFinalVolume();
 
     G4String creator_proc = trj->GetCreatorProcess();
     G4String final_proc   = trj->GetFinalProcess();
+
+    G4int pname_id = FindStringIDInMap(str_map_, p_name, str_counter_);
 
     G4int ini_id = FindStringIDInMap(str_map_, ini_volume, str_counter_);
     G4int fin_id = FindStringIDInMap(str_map_, final_volume, str_counter_);
@@ -186,7 +190,7 @@ void PersistencyManager::StoreTrajectories(G4TrajectoryContainer* tc)
     } else {
       mother_id = trj->GetParentID();
     }
-    h5writer_->WriteParticleInfo(nevt_, trackid, trj->GetPDGEncoding(),
+    h5writer_->WriteParticleInfo(nevt_, trackid, (int)pname_id,
 				 primary, mother_id,
 				 (float)ini_xyz.x(), (float)ini_xyz.y(),
                                  (float)ini_xyz.z(), (float)ini_t,

--- a/source/persistency/PersistencyManager.h
+++ b/source/persistency/PersistencyManager.h
@@ -69,6 +69,8 @@ namespace nexus {
 
     void SaveConfigurationInfo(G4String history);
 
+    G4int FindVolumeInMap(std::map<G4int, G4String>& vmap, G4String vol);
+
 
   private:
     G4GenericMessenger* msg_; ///< User configuration messenger
@@ -97,6 +99,9 @@ namespace nexus {
     std::vector<G4int>* ihits_;
     std::map<G4int, std::vector<G4int>* > hit_map_;
     std::vector<G4int> sns_posvec_;
+    //std::vector<G4String> vol_vec_;
+    std::map<G4int, G4String> vol_map_;
+    std::map<G4int, G4String> proc_map_;
 
     std::map<G4String, G4double> sensdet_bin_;
   };

--- a/source/persistency/PersistencyManager.h
+++ b/source/persistency/PersistencyManager.h
@@ -99,9 +99,10 @@ namespace nexus {
     std::vector<G4int>* ihits_;
     std::map<G4int, std::vector<G4int>* > hit_map_;
     std::vector<G4int> sns_posvec_;
-    std::map<G4String, G4int> str_map_;
+    std::map<G4String, G4int> str_map_; ///< map with string-int correspondence
 
-    G4int str_counter_;
+    G4int str_counter_; ///< incrementing counter for string map
+    G4bool save_str_; ///< Should we store strings as volume names etc.?
 
     std::map<G4String, G4double> sensdet_bin_;
   };

--- a/source/persistency/PersistencyManager.h
+++ b/source/persistency/PersistencyManager.h
@@ -69,7 +69,7 @@ namespace nexus {
 
     void SaveConfigurationInfo(G4String history);
 
-    G4int FindVolumeIDInMap(std::map<G4String, G4int>& vmap, G4String vol, G4int& counter);
+    G4int FindStringIDInMap(std::map<G4String, G4int>& vmap, G4String vol, G4int& counter);
 
 
   private:
@@ -99,8 +99,9 @@ namespace nexus {
     std::vector<G4int>* ihits_;
     std::map<G4int, std::vector<G4int>* > hit_map_;
     std::vector<G4int> sns_posvec_;
-    std::map<G4String, G4int> vol_map_;
-    std::map<G4String, G4int> proc_map_;
+    std::map<G4String, G4int> str_map_;
+
+    G4int str_counter_;
 
     std::map<G4String, G4double> sensdet_bin_;
   };

--- a/source/persistency/PersistencyManager.h
+++ b/source/persistency/PersistencyManager.h
@@ -69,7 +69,7 @@ namespace nexus {
 
     void SaveConfigurationInfo(G4String history);
 
-    G4int FindVolumeInMap(std::map<G4int, G4String>& vmap, G4String vol);
+    G4int FindVolumeIDInMap(std::map<G4String, G4int>& vmap, G4String vol, G4int& counter);
 
 
   private:
@@ -99,9 +99,8 @@ namespace nexus {
     std::vector<G4int>* ihits_;
     std::map<G4int, std::vector<G4int>* > hit_map_;
     std::vector<G4int> sns_posvec_;
-    //std::vector<G4String> vol_vec_;
-    std::map<G4int, G4String> vol_map_;
-    std::map<G4int, G4String> proc_map_;
+    std::map<G4String, G4int> vol_map_;
+    std::map<G4String, G4int> proc_map_;
 
     std::map<G4String, G4double> sensdet_bin_;
   };

--- a/source/persistency/hdf5_functions.cc
+++ b/source/persistency/hdf5_functions.cc
@@ -140,6 +140,19 @@ hsize_t createStepType()
   return memtype;
 }
 
+
+hsize_t createStringMapType()
+{
+  hid_t strtype = H5Tcopy(H5T_C_S1);
+  H5Tset_size (strtype, STRLEN);
+
+  //Create compound datatype for the table
+  hsize_t memtype = H5Tcreate (H5T_COMPOUND, sizeof(string_map_t));
+  H5Tinsert (memtype, "name"   , HOFFSET(string_map_t, name   ), strtype);
+  H5Tinsert (memtype, "name_id" , HOFFSET(string_map_t, name_id ), H5T_NATIVE_INT);
+  return memtype;
+}
+
 hid_t createTable(hid_t group, std::string& table_name, hsize_t memtype)
 {
   //Create 1D dataspace (evt number). First dimension is unlimited (initially 0)
@@ -295,6 +308,26 @@ void writeStep(step_info_t* step, hid_t dataset, hid_t memtype, hsize_t counter)
   hsize_t count[1] = {1};
   H5Sselect_hyperslab(file_space, H5S_SELECT_SET, start, NULL, count, NULL);
   H5Dwrite(dataset, memtype, memspace, file_space, H5P_DEFAULT, step);
+  H5Sclose(file_space);
+  H5Sclose(memspace);
+}
+
+void writeStringMap(string_map_t* strmap, hid_t dataset, hid_t memtype, hsize_t counter)
+{
+  hid_t memspace, file_space;
+
+  const hsize_t n_dims = 1;
+  hsize_t dims[n_dims] = {1};
+  memspace = H5Screate_simple(n_dims, dims, NULL);
+
+  dims[0] = counter + 1;
+  H5Dset_extent(dataset, dims);
+
+  file_space = H5Dget_space(dataset);
+  hsize_t start[1] = {counter};
+  hsize_t count[1] = {1};
+  H5Sselect_hyperslab(file_space, H5S_SELECT_SET, start, NULL, count, NULL);
+  H5Dwrite(dataset, memtype, memspace, file_space, H5P_DEFAULT, strmap);
   H5Sclose(file_space);
   H5Sclose(memspace);
 }

--- a/source/persistency/hdf5_functions.cc
+++ b/source/persistency/hdf5_functions.cc
@@ -65,7 +65,8 @@ hsize_t createParticleInfoType()
   hsize_t memtype = H5Tcreate (H5T_COMPOUND, sizeof (particle_info_t));
   H5Tinsert (memtype, "event_id", HOFFSET (particle_info_t, event_id), H5T_NATIVE_INT64);
   H5Tinsert (memtype, "particle_id", HOFFSET (particle_info_t, particle_id), H5T_NATIVE_INT);
-  H5Tinsert (memtype, "particle_name", HOFFSET (particle_info_t, particle_name),strtype);
+  //H5Tinsert (memtype, "particle_name", HOFFSET (particle_info_t, particle_name),strtype);
+  H5Tinsert (memtype, "pdg_id", HOFFSET (particle_info_t, pdg_id),H5T_NATIVE_INT);
   H5Tinsert (memtype, "primary", HOFFSET (particle_info_t, primary), H5T_NATIVE_CHAR);
   H5Tinsert (memtype, "mother_id", HOFFSET (particle_info_t, mother_id),H5T_NATIVE_INT);
   H5Tinsert (memtype, "initial_x", HOFFSET (particle_info_t, initial_x), H5T_NATIVE_FLOAT);
@@ -76,8 +77,10 @@ hsize_t createParticleInfoType()
   H5Tinsert (memtype, "final_y", HOFFSET (particle_info_t, final_y), H5T_NATIVE_FLOAT);
   H5Tinsert (memtype, "final_z", HOFFSET (particle_info_t, final_z), H5T_NATIVE_FLOAT);
   H5Tinsert (memtype, "final_t", HOFFSET (particle_info_t, final_t), H5T_NATIVE_FLOAT);
-  H5Tinsert (memtype, "initial_volume", HOFFSET (particle_info_t, initial_volume), strtype);
-  H5Tinsert (memtype, "final_volume", HOFFSET (particle_info_t, final_volume), strtype);
+  H5Tinsert (memtype, "initial_volume", HOFFSET (particle_info_t, initial_volume), H5T_NATIVE_INT);
+  H5Tinsert (memtype, "final_volume", HOFFSET (particle_info_t, final_volume), H5T_NATIVE_INT);
+  //H5Tinsert (memtype, "initial_volume", HOFFSET (particle_info_t, initial_volume), strtype);
+  //H5Tinsert (memtype, "final_volume", HOFFSET (particle_info_t, final_volume), strtype);
   H5Tinsert (memtype, "initial_momentum_x", HOFFSET (particle_info_t, initial_momentum_x), H5T_NATIVE_FLOAT);
   H5Tinsert (memtype, "initial_momentum_y", HOFFSET (particle_info_t, initial_momentum_y), H5T_NATIVE_FLOAT);
   H5Tinsert (memtype, "initial_momentum_z", HOFFSET (particle_info_t, initial_momentum_z), H5T_NATIVE_FLOAT);
@@ -86,8 +89,10 @@ hsize_t createParticleInfoType()
   H5Tinsert (memtype, "final_momentum_z", HOFFSET (particle_info_t, final_momentum_z), H5T_NATIVE_FLOAT);
   H5Tinsert (memtype, "kin_energy", HOFFSET (particle_info_t, kin_energy), H5T_NATIVE_FLOAT);
   H5Tinsert (memtype, "length", HOFFSET (particle_info_t, length), H5T_NATIVE_FLOAT);
-  H5Tinsert (memtype, "creator_proc", HOFFSET (particle_info_t, creator_proc), proc_strtype);
-  H5Tinsert (memtype, "final_proc", HOFFSET (particle_info_t, final_proc), proc_strtype);
+  //H5Tinsert (memtype, "creator_proc", HOFFSET (particle_info_t, creator_proc), proc_strtype);
+  //H5Tinsert (memtype, "final_proc", HOFFSET (particle_info_t, final_proc), proc_strtype);
+  H5Tinsert (memtype, "creator_proc", HOFFSET (particle_info_t, creator_proc), H5T_NATIVE_INT);
+  H5Tinsert (memtype, "final_proc", HOFFSET (particle_info_t, final_proc), H5T_NATIVE_INT);
   return memtype;
 }
 

--- a/source/persistency/hdf5_functions.cc
+++ b/source/persistency/hdf5_functions.cc
@@ -33,7 +33,7 @@ hsize_t createSensorDataType()
 }
 
 
-hsize_t createHitInfoType()
+hsize_t createHitInfoType(bool str)
 {
   hid_t strtype = H5Tcopy(H5T_C_S1);
   H5Tset_size (strtype, STRLEN);
@@ -46,27 +46,31 @@ hsize_t createHitInfoType()
   H5Tinsert (memtype, "z", HOFFSET (hit_info_t, z), H5T_NATIVE_FLOAT);
   H5Tinsert (memtype, "time", HOFFSET (hit_info_t, time), H5T_NATIVE_FLOAT);
   H5Tinsert (memtype, "energy", HOFFSET (hit_info_t, energy), H5T_NATIVE_FLOAT);
-  H5Tinsert (memtype, "label", HOFFSET (hit_info_t, label), strtype);
+  if (str) {
+    H5Tinsert (memtype, "label", HOFFSET (hit_info_t, label_str), strtype);
+  } else {
+    H5Tinsert (memtype, "label", HOFFSET (hit_info_t, label), H5T_NATIVE_INT);
+  }
   H5Tinsert (memtype, "particle_id", HOFFSET (hit_info_t, particle_id), H5T_NATIVE_INT);
   H5Tinsert (memtype, "hit_id", HOFFSET (hit_info_t, hit_id), H5T_NATIVE_INT);
   return memtype;
 }
 
 
-hsize_t createParticleInfoType()
+hsize_t createParticleInfoType(bool str)
 {
   hid_t strtype = H5Tcopy(H5T_C_S1);
   H5Tset_size (strtype, STRLEN);
-
-  hid_t proc_strtype = H5Tcopy(H5T_C_S1);
-  H5Tset_size (proc_strtype, STRLEN);
 
   //Create compound datatype for the table
   hsize_t memtype = H5Tcreate (H5T_COMPOUND, sizeof (particle_info_t));
   H5Tinsert (memtype, "event_id", HOFFSET (particle_info_t, event_id), H5T_NATIVE_INT64);
   H5Tinsert (memtype, "particle_id", HOFFSET (particle_info_t, particle_id), H5T_NATIVE_INT);
-  //H5Tinsert (memtype, "particle_name", HOFFSET (particle_info_t, particle_name),strtype);
-  H5Tinsert (memtype, "pdg_id", HOFFSET (particle_info_t, pdg_id),H5T_NATIVE_INT);
+  if (str) {
+    H5Tinsert (memtype, "particle_name", HOFFSET (particle_info_t, particle_name_str),strtype);
+  } else {
+    H5Tinsert (memtype, "particle_name", HOFFSET (particle_info_t, particle_name),H5T_NATIVE_INT);
+  }
   H5Tinsert (memtype, "primary", HOFFSET (particle_info_t, primary), H5T_NATIVE_CHAR);
   H5Tinsert (memtype, "mother_id", HOFFSET (particle_info_t, mother_id),H5T_NATIVE_INT);
   H5Tinsert (memtype, "initial_x", HOFFSET (particle_info_t, initial_x), H5T_NATIVE_FLOAT);
@@ -77,22 +81,34 @@ hsize_t createParticleInfoType()
   H5Tinsert (memtype, "final_y", HOFFSET (particle_info_t, final_y), H5T_NATIVE_FLOAT);
   H5Tinsert (memtype, "final_z", HOFFSET (particle_info_t, final_z), H5T_NATIVE_FLOAT);
   H5Tinsert (memtype, "final_t", HOFFSET (particle_info_t, final_t), H5T_NATIVE_FLOAT);
-  H5Tinsert (memtype, "initial_volume", HOFFSET (particle_info_t, initial_volume), H5T_NATIVE_INT);
-  H5Tinsert (memtype, "final_volume", HOFFSET (particle_info_t, final_volume), H5T_NATIVE_INT);
-  //H5Tinsert (memtype, "initial_volume", HOFFSET (particle_info_t, initial_volume), strtype);
-  //H5Tinsert (memtype, "final_volume", HOFFSET (particle_info_t, final_volume), strtype);
-  H5Tinsert (memtype, "initial_momentum_x", HOFFSET (particle_info_t, initial_momentum_x), H5T_NATIVE_FLOAT);
-  H5Tinsert (memtype, "initial_momentum_y", HOFFSET (particle_info_t, initial_momentum_y), H5T_NATIVE_FLOAT);
-  H5Tinsert (memtype, "initial_momentum_z", HOFFSET (particle_info_t, initial_momentum_z), H5T_NATIVE_FLOAT);
-  H5Tinsert (memtype, "final_momentum_x", HOFFSET (particle_info_t, final_momentum_x), H5T_NATIVE_FLOAT);
-  H5Tinsert (memtype, "final_momentum_y", HOFFSET (particle_info_t, final_momentum_y), H5T_NATIVE_FLOAT);
-  H5Tinsert (memtype, "final_momentum_z", HOFFSET (particle_info_t, final_momentum_z), H5T_NATIVE_FLOAT);
+  if (str) {
+    H5Tinsert (memtype, "initial_volume", HOFFSET (particle_info_t, initial_volume_str), strtype);
+    H5Tinsert (memtype, "final_volume", HOFFSET (particle_info_t, final_volume_str), strtype);
+  } else {
+    H5Tinsert (memtype, "initial_volume", HOFFSET (particle_info_t, initial_volume), H5T_NATIVE_INT);
+    H5Tinsert (memtype, "final_volume", HOFFSET (particle_info_t, final_volume), H5T_NATIVE_INT);
+  }
+  H5Tinsert (memtype, "initial_momentum_x", HOFFSET (particle_info_t, initial_momentum_x),
+             H5T_NATIVE_FLOAT);
+  H5Tinsert (memtype, "initial_momentum_y", HOFFSET (particle_info_t, initial_momentum_y),
+             H5T_NATIVE_FLOAT);
+  H5Tinsert (memtype, "initial_momentum_z", HOFFSET (particle_info_t, initial_momentum_z),
+             H5T_NATIVE_FLOAT);
+  H5Tinsert (memtype, "final_momentum_x", HOFFSET (particle_info_t, final_momentum_x),
+             H5T_NATIVE_FLOAT);
+  H5Tinsert (memtype, "final_momentum_y", HOFFSET (particle_info_t, final_momentum_y),
+             H5T_NATIVE_FLOAT);
+  H5Tinsert (memtype, "final_momentum_z", HOFFSET (particle_info_t, final_momentum_z),
+             H5T_NATIVE_FLOAT);
   H5Tinsert (memtype, "kin_energy", HOFFSET (particle_info_t, kin_energy), H5T_NATIVE_FLOAT);
   H5Tinsert (memtype, "length", HOFFSET (particle_info_t, length), H5T_NATIVE_FLOAT);
-  //H5Tinsert (memtype, "creator_proc", HOFFSET (particle_info_t, creator_proc), proc_strtype);
-  //H5Tinsert (memtype, "final_proc", HOFFSET (particle_info_t, final_proc), proc_strtype);
-  H5Tinsert (memtype, "creator_proc", HOFFSET (particle_info_t, creator_proc), H5T_NATIVE_INT);
-  H5Tinsert (memtype, "final_proc", HOFFSET (particle_info_t, final_proc), H5T_NATIVE_INT);
+  if (str) {
+    H5Tinsert (memtype, "creator_proc", HOFFSET (particle_info_t, creator_proc_str), strtype);
+    H5Tinsert (memtype, "final_proc", HOFFSET (particle_info_t, final_proc_str), strtype);
+  } else {
+    H5Tinsert (memtype, "creator_proc", HOFFSET (particle_info_t, creator_proc), H5T_NATIVE_INT);
+    H5Tinsert (memtype, "final_proc", HOFFSET (particle_info_t, final_proc), H5T_NATIVE_INT);
+  }
   return memtype;
 }
 

--- a/source/persistency/hdf5_functions.h
+++ b/source/persistency/hdf5_functions.h
@@ -97,12 +97,18 @@
     float        time;
   } step_info_t;
 
+typedef struct{
+  char name[STRLEN];
+  int32_t name_id;
+} string_map_t;
+
   hsize_t createRunType();
   hsize_t createSensorDataType();
   hsize_t createHitInfoType();
   hsize_t createParticleInfoType();
   hsize_t createSensorPosType();
   hsize_t createStepType();
+  hsize_t createStringMapType();
 
   hid_t createTable(hid_t group, std::string& table_name, hsize_t memtype);
   hid_t createGroup(hid_t file, std::string& groupName);
@@ -113,6 +119,7 @@
   void writeParticle(particle_info_t* particleInfo, hid_t dataset, hid_t memtype, hsize_t counter);
   void writeSnsPos(sns_pos_t* snsPos, hid_t dataset, hid_t memtype, hsize_t counter);
   void writeStep(step_info_t* step, hid_t dataset, hid_t memtype, hsize_t counter);
+  void writeStringMap(string_map_t* strmap, hid_t dataset, hid_t memtype, hsize_t counter);
 
 
 #endif

--- a/source/persistency/hdf5_functions.h
+++ b/source/persistency/hdf5_functions.h
@@ -42,7 +42,8 @@
   typedef struct{
         int64_t event_id;
 	int particle_id;
-	char particle_name[STRLEN];
+	//char particle_name[STRLEN];
+        int  pdg_id;
         char primary;
 	int mother_id;
 	float initial_x;
@@ -53,8 +54,10 @@
 	float final_y;
 	float final_z;
 	float final_t;
-        char initial_volume[STRLEN];
-        char final_volume[STRLEN];
+        //char initial_volume[STRLEN];
+        //char final_volume[STRLEN];
+        int initial_volume;
+        int final_volume;
 	float initial_momentum_x;
 	float initial_momentum_y;
 	float initial_momentum_z;
@@ -63,8 +66,10 @@
 	float final_momentum_z;
 	float kin_energy;
 	float length;
-        char creator_proc[STRLEN];
-	char final_proc[STRLEN];
+        //char creator_proc[STRLEN];
+	//char final_proc[STRLEN];
+        int creator_proc;
+        int final_proc;
   } particle_info_t;
 
   typedef struct{

--- a/source/persistency/hdf5_functions.h
+++ b/source/persistency/hdf5_functions.h
@@ -34,7 +34,8 @@
 	float z;
 	float time;
 	float energy;
-        char label[STRLEN];
+        char label_str[STRLEN];
+        int label;
         int particle_id;
         int hit_id;
   } hit_info_t;
@@ -42,8 +43,8 @@
   typedef struct{
         int64_t event_id;
 	int particle_id;
-	//char particle_name[STRLEN];
-        int  pdg_id;
+	char particle_name_str[STRLEN];
+        int  particle_name;
         char primary;
 	int mother_id;
 	float initial_x;
@@ -54,8 +55,8 @@
 	float final_y;
 	float final_z;
 	float final_t;
-        //char initial_volume[STRLEN];
-        //char final_volume[STRLEN];
+        char initial_volume_str[STRLEN];
+        char final_volume_str[STRLEN];
         int initial_volume;
         int final_volume;
 	float initial_momentum_x;
@@ -66,8 +67,8 @@
 	float final_momentum_z;
 	float kin_energy;
 	float length;
-        //char creator_proc[STRLEN];
-	//char final_proc[STRLEN];
+        char creator_proc_str[STRLEN];
+	char final_proc_str[STRLEN];
         int creator_proc;
         int final_proc;
   } particle_info_t;
@@ -104,8 +105,8 @@ typedef struct{
 
   hsize_t createRunType();
   hsize_t createSensorDataType();
-  hsize_t createHitInfoType();
-  hsize_t createParticleInfoType();
+  hsize_t createHitInfoType(bool str);
+  hsize_t createParticleInfoType(bool str);
   hsize_t createSensorPosType();
   hsize_t createStepType();
   hsize_t createStringMapType();

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -19,8 +19,6 @@ def output_tmpdir(tmpdir_factory):
 @pytest.fixture(scope = 'session')
 def full_base_name_new():
     return 'NEW_full_electron'
-
-
 @pytest.fixture(scope = 'session')
 def nexus_full_output_file_new(output_tmpdir, full_base_name_new):
     return os.path.join(output_tmpdir, full_base_name_new + '.h5')
@@ -29,8 +27,6 @@ def nexus_full_output_file_new(output_tmpdir, full_base_name_new):
 @pytest.fixture(scope = 'session')
 def full_base_name_next100():
     return 'NEXT100_full_electron'
-
-
 @pytest.fixture(scope = 'session')
 def nexus_full_output_file_next100(output_tmpdir, full_base_name_next100):
     return os.path.join(output_tmpdir, full_base_name_next100 + '.h5')
@@ -39,8 +35,6 @@ def nexus_full_output_file_next100(output_tmpdir, full_base_name_next100):
 @pytest.fixture(scope = 'session')
 def full_base_name_flex100():
     return 'FLEX100_full_electron'
-
-
 @pytest.fixture(scope = 'session')
 def nexus_full_output_file_flex100(output_tmpdir, full_base_name_flex100):
     return os.path.join(output_tmpdir, full_base_name_flex100 + '.h5')
@@ -49,11 +43,18 @@ def nexus_full_output_file_flex100(output_tmpdir, full_base_name_flex100):
 @pytest.fixture(scope = 'session')
 def full_base_name_demopp():
     return 'DEMOPP_full_electron_{run}'
-
-
 @pytest.fixture(scope = 'session')
 def nexus_full_output_file_demopp(output_tmpdir, full_base_name_demopp):
     return os.path.join(output_tmpdir, full_base_name_demopp + '.h5')
+
+
+@pytest.fixture(scope = 'session')
+def base_name_no_strings():
+    return 'NEXT100_no_strings'
+@pytest.fixture(scope = 'session')
+def nexus_output_file_no_strings(output_tmpdir, base_name_no_strings):
+    return os.path.join(output_tmpdir, base_name_no_strings + '.h5')
+
 
 
 @pytest.fixture(scope = 'session')

--- a/tests/pytest/persistency_test.py
+++ b/tests/pytest/persistency_test.py
@@ -184,3 +184,12 @@ def test_sensor_names_are_the_same_across_tables(detectors):
             test(filename.format(run=run))
     else:
         test(filename)
+
+
+def test_string_map(nexus_output_file_no_strings):
+    """Check that IDs and strings are not repeated in map table."""
+
+    str_map = pd.read_hdf(nexus_output_file_no_strings, 'MC/string_map')
+
+    assert str_map.name_id.nunique() == len(str_map)
+    assert str_map.name.nunique()    == len(str_map)

--- a/tests/pytest/persistency_test.py
+++ b/tests/pytest/persistency_test.py
@@ -186,10 +186,26 @@ def test_sensor_names_are_the_same_across_tables(detectors):
         test(filename)
 
 
-def test_string_map(nexus_output_file_no_strings):
+def test_keys_values_are_unique_in_string_map(nexus_output_file_no_strings):
     """Check that IDs and strings are not repeated in map table."""
 
     str_map = pd.read_hdf(nexus_output_file_no_strings, 'MC/string_map')
 
     assert str_map.name_id.nunique() == len(str_map)
     assert str_map.name.nunique()    == len(str_map)
+
+def test_string_map_ids_are_in_hits_particles_tables(nexus_output_file_no_strings):
+    """Check that all IDs of hit and particle tables appear in string map """
+
+    hits      = pd.read_hdf(nexus_output_file_no_strings, 'MC/hits')
+    particles = pd.read_hdf(nexus_output_file_no_strings, 'MC/particles')
+    str_map   = pd.read_hdf(nexus_output_file_no_strings, 'MC/string_map')
+
+    map_ids = str_map.name_id.values
+
+    assert np.all(np.isin(hits.label.values, map_ids))
+    assert np.all(np.isin(particles.particle_name.values, map_ids))
+    assert np.all(np.isin(particles.initial_volume.values, map_ids))
+    assert np.all(np.isin(particles.final_volume.values, map_ids))
+    assert np.all(np.isin(particles.creator_proc.values, map_ids))
+    assert np.all(np.isin(particles.final_proc.values, map_ids))

--- a/tests/pytest/produce_output_test.py
+++ b/tests/pytest/produce_output_test.py
@@ -206,7 +206,6 @@ def test_create_nexus_output_file_flex100(config_tmpdir, output_tmpdir, NEXUSDIR
 /Geometry/NextFlex/tp_sipm_time_binning  1. microsecond
 /Geometry/NextFlex/ics_thickness         12. cm
 
-/Generator/SingleParticle/region         CENTER
 /Generator/SingleParticle/region         AD_HOC
 /Geometry/NextFlex/specific_vertex       0. 0. 500. mm
 

--- a/tests/pytest/produce_output_test.py
+++ b/tests/pytest/produce_output_test.py
@@ -3,14 +3,7 @@ import pytest
 import os
 import subprocess
 
-
-@pytest.mark.order(1)
-def test_create_nexus_output_file_next100(config_tmpdir, output_tmpdir,
-                                          NEXUSDIR,
-                                          full_base_name_next100,
-                                          nexus_full_output_file_next100):
-    # Init file
-    init_text = f"""
+common_init_params = """
 /PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
 /PhysicsList/RegisterPhysics G4DecayPhysics
 /PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
@@ -18,24 +11,57 @@ def test_create_nexus_output_file_next100(config_tmpdir, output_tmpdir,
 /PhysicsList/RegisterPhysics NexusPhysics
 /PhysicsList/RegisterPhysics G4StepLimiterPhysics
 
-/nexus/RegisterGeometry Next100OpticalGeometry
-
-/nexus/RegisterGenerator SingleParticleGenerator
-
-/nexus/RegisterPersistencyManager PersistencyManager
-
 /nexus/RegisterTrackingAction DefaultTrackingAction
 /nexus/RegisterEventAction DefaultEventAction
 /nexus/RegisterRunAction DefaultRunAction
 
+/nexus/RegisterPersistencyManager PersistencyManager
+
+"""
+
+single_part_params = """
+/Generator/SingleParticle/particle e-
+/Generator/SingleParticle/min_energy 10. keV
+/Generator/SingleParticle/max_energy 10. keV
+
+"""
+
+next100_params = """
+/Geometry/Next100/elfield true
+/Geometry/Next100/EL_field 13 kV/cm
+/Geometry/Next100/max_step_size 1. mm
+/Geometry/Next100/pressure 15. bar
+/Geometry/Next100/sc_yield 10000 1/MeV
+
+"""
+
+def run_simulation(NEXUSDIR, init_path):
+    my_env    = os.environ
+    nexus_exe = NEXUSDIR + '/bin/nexus'
+    command   = [nexus_exe, '-b', '-n', '1', init_path]
+    p         = subprocess.run(command, check=True, env=my_env)
+
+@pytest.mark.order(1)
+def test_create_nexus_output_file_next100(config_tmpdir, output_tmpdir,
+                                          NEXUSDIR,
+                                          full_base_name_next100,
+                                          nexus_full_output_file_next100):
+    # Init file
+    init_text = f"""
+/nexus/RegisterGeometry Next100OpticalGeometry
+
+/nexus/RegisterGenerator SingleParticleGenerator
+
 /nexus/RegisterMacro {config_tmpdir}/{full_base_name_next100}.config.mac
 """
+
+    init_text = f'{common_init_params} {init_text}'
     init_path = os.path.join(config_tmpdir, full_base_name_next100+'.init.mac')
     init_file = open(init_path,'w')
     init_file.write(init_text)
     init_file.close()
 
-    #Config file
+    # Config file
     config_text = f"""
 /run/verbose 1
 /event/verbose 0
@@ -43,31 +69,20 @@ def test_create_nexus_output_file_next100(config_tmpdir, output_tmpdir,
 
 /process/em/verbose 0
 
-/Geometry/Next100/elfield true
-/Geometry/Next100/EL_field 13 kV/cm
-/Geometry/Next100/max_step_size 1. mm
-/Geometry/Next100/pressure 15. bar
-/Geometry/Next100/sc_yield 10000 1/MeV
-
-/Generator/SingleParticle/particle e-
-/Generator/SingleParticle/min_energy 10. keV
-/Generator/SingleParticle/max_energy 10. keV
 /Generator/SingleParticle/region CENTER
 
 /nexus/persistency/save_strings true
 /nexus/persistency/output_file {output_tmpdir}/{full_base_name_next100}
 /nexus/random_seed 21051817
 """
+    config_text = f'{config_text} {next100_params} {single_part_params}'
     config_path = os.path.join(config_tmpdir, full_base_name_next100+'.config.mac')
     config_file = open(config_path,'w')
     config_file.write(config_text)
     config_file.close()
 
-    # Running the simulation
-    my_env    = os.environ
-    nexus_exe = NEXUSDIR + '/bin/nexus'
-    command   = [nexus_exe, '-b', '-n', '1', init_path]
-    p         = subprocess.run(command, check=True, env=my_env)
+    # Running the simulation
+    run_simulation(NEXUSDIR, init_path)
 
     return nexus_full_output_file_next100
 
@@ -77,33 +92,21 @@ def test_create_nexus_output_file_next100(config_tmpdir, output_tmpdir,
 def test_create_nexus_output_file_new(config_tmpdir, output_tmpdir, NEXUSDIR,
                                       full_base_name_new,
                                       nexus_full_output_file_new):
-    # Init file
+    # Init file
     init_text = f"""
-/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
-/PhysicsList/RegisterPhysics G4DecayPhysics
-/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
-/PhysicsList/RegisterPhysics G4OpticalPhysics
-/PhysicsList/RegisterPhysics NexusPhysics
-/PhysicsList/RegisterPhysics G4StepLimiterPhysics
-
 /nexus/RegisterGeometry NextNew
 
 /nexus/RegisterGenerator SingleParticleGenerator
 
-/nexus/RegisterPersistencyManager PersistencyManager
-
-/nexus/RegisterTrackingAction DefaultTrackingAction
-/nexus/RegisterEventAction DefaultEventAction
-/nexus/RegisterRunAction DefaultRunAction
-
 /nexus/RegisterMacro {config_tmpdir}/{full_base_name_new}.config.mac
 """
+    init_text = f'{common_init_params} {init_text}'
     init_path = os.path.join(config_tmpdir, full_base_name_new+'.init.mac')
     init_file = open(init_path,'w')
     init_file.write(init_text)
     init_file.close()
 
-    #Config file
+    # Config file
     config_text = f"""
 /run/verbose 1
 /event/verbose 0
@@ -117,25 +120,20 @@ def test_create_nexus_output_file_new(config_tmpdir, output_tmpdir, NEXUSDIR,
 /Geometry/NextNew/pressure 15. bar
 /Geometry/NextNew/sc_yield 10000 1/MeV
 
-/Generator/SingleParticle/particle e-
-/Generator/SingleParticle/min_energy 10. keV
-/Generator/SingleParticle/max_energy 10. keV
 /Generator/SingleParticle/region CENTER
 
 /nexus/persistency/save_strings true
 /nexus/persistency/output_file {output_tmpdir}/{full_base_name_new}
 /nexus/random_seed 21051817
 """
+    config_text = f'{config_text} {single_part_params}'
     config_path = os.path.join(config_tmpdir, full_base_name_new+'.config.mac')
     config_file = open(config_path,'w')
     config_file.write(config_text)
     config_file.close()
 
-    # Running the simulation
-    my_env    = os.environ
-    nexus_exe = NEXUSDIR + '/bin/nexus'
-    command   = [nexus_exe, '-b', '-n', '1', init_path]
-    p         = subprocess.run(command, check=True, env=my_env)
+    # Running the simulation
+    run_simulation(NEXUSDIR, init_path)
 
     return nexus_full_output_file_new
 
@@ -145,33 +143,21 @@ def test_create_nexus_output_file_new(config_tmpdir, output_tmpdir, NEXUSDIR,
 def test_create_nexus_output_file_flex100(config_tmpdir, output_tmpdir, NEXUSDIR,
                                           full_base_name_flex100,
                                           nexus_full_output_file_flex100):
-    # Init file
+    # Init file
     init_text = f"""
-/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
-/PhysicsList/RegisterPhysics G4DecayPhysics
-/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
-/PhysicsList/RegisterPhysics G4OpticalPhysics
-/PhysicsList/RegisterPhysics NexusPhysics
-/PhysicsList/RegisterPhysics G4StepLimiterPhysics
-
 /nexus/RegisterGeometry NextFlex
 
 /nexus/RegisterGenerator SingleParticleGenerator
 
-/nexus/RegisterPersistencyManager PersistencyManager
-
-/nexus/RegisterTrackingAction DefaultTrackingAction
-/nexus/RegisterEventAction DefaultEventAction
-/nexus/RegisterRunAction DefaultRunAction
-
 /nexus/RegisterMacro {config_tmpdir}/{full_base_name_flex100}.config.mac
 """
+    init_text = f'{common_init_params} {init_text}'
     init_path = os.path.join(config_tmpdir, full_base_name_flex100+'.init.mac')
     init_file = open(init_path,'w')
     init_file.write(init_text)
     init_file.close()
 
-    #Config file
+    # Config file
     config_text = f"""
 /run/verbose 1
 /event/verbose 0
@@ -220,9 +206,7 @@ def test_create_nexus_output_file_flex100(config_tmpdir, output_tmpdir, NEXUSDIR
 /Geometry/NextFlex/tp_sipm_time_binning  1. microsecond
 /Geometry/NextFlex/ics_thickness         12. cm
 
-/Generator/SingleParticle/particle       e-
-/Generator/SingleParticle/min_energy     10. keV
-/Generator/SingleParticle/max_energy     10. keV
+/Generator/SingleParticle/region         CENTER
 /Generator/SingleParticle/region         AD_HOC
 /Geometry/NextFlex/specific_vertex       0. 0. 500. mm
 
@@ -230,16 +214,14 @@ def test_create_nexus_output_file_flex100(config_tmpdir, output_tmpdir, NEXUSDIR
 /nexus/persistency/output_file {output_tmpdir}/{full_base_name_flex100}
 /nexus/random_seed 21051817
 """
+    config_text = f'{config_text} {single_part_params}'
     config_path = os.path.join(config_tmpdir, full_base_name_flex100+'.config.mac')
     config_file = open(config_path,'w')
     config_file.write(config_text)
     config_file.close()
 
-    # Running the simulation
-    my_env    = os.environ
-    nexus_exe = NEXUSDIR + '/bin/nexus'
-    command   = [nexus_exe, '-b', '-n', '1', init_path]
-    p         = subprocess.run(command, check=True, env=my_env)
+    # Running the simulation
+    run_simulation(NEXUSDIR, init_path)
 
     return nexus_full_output_file_flex100
 
@@ -250,25 +232,13 @@ def test_create_nexus_output_file_demopp(config_tmpdir, output_tmpdir, NEXUSDIR,
     for run in ["run5", "run7", "run8", "run9", "run10"]:
 
         init_text = f"""
-    /PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
-    /PhysicsList/RegisterPhysics G4DecayPhysics
-    /PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
-    /PhysicsList/RegisterPhysics G4OpticalPhysics
-    /PhysicsList/RegisterPhysics NexusPhysics
-    /PhysicsList/RegisterPhysics G4StepLimiterPhysics
-
     /nexus/RegisterGeometry NextDemo
 
     /nexus/RegisterGenerator SingleParticleGenerator
 
-    /nexus/RegisterPersistencyManager PersistencyManager
-
-    /nexus/RegisterTrackingAction DefaultTrackingAction
-    /nexus/RegisterEventAction DefaultEventAction
-    /nexus/RegisterRunAction DefaultRunAction
-
     /nexus/RegisterMacro {config_tmpdir}/{full_base_name_demopp.format(run=run)}.config.mac
     """
+        init_text = f'{common_init_params} {init_text}'
         init_path = os.path.join(config_tmpdir, full_base_name_demopp.format(run=run) +'.init.mac')
         init_file = open(init_path,'w')
         init_file.write(init_text)
@@ -288,9 +258,6 @@ def test_create_nexus_output_file_demopp(config_tmpdir, output_tmpdir, NEXUSDIR,
 
     /Geometry/NextDemo/specific_vertex 0. 0. 10. cm
 
-    /Generator/SingleParticle/particle e-
-    /Generator/SingleParticle/min_energy 10. keV
-    /Generator/SingleParticle/max_energy 10. keV
     /Generator/SingleParticle/region AD_HOC
 
     /nexus/persistency/save_strings true
@@ -298,16 +265,14 @@ def test_create_nexus_output_file_demopp(config_tmpdir, output_tmpdir, NEXUSDIR,
     /nexus/random_seed 21051817
 
     """
-
+        config_text = f'{config_text} {single_part_params}'
         config_path = os.path.join(config_tmpdir, full_base_name_demopp.format(run=run) +'.config.mac')
         config_file = open(config_path,'w')
         config_file.write(config_text)
         config_file.close()
 
-        my_env    = os.environ
-        nexus_exe = NEXUSDIR + '/bin/nexus'
-        command   = [nexus_exe, '-b', '-n', '1', init_path]
-        p         = subprocess.run(command, check=True, env=my_env)
+        # Running the simulation
+        run_simulation(NEXUSDIR, init_path)
 
     return nexus_full_output_file_demopp
 
@@ -317,33 +282,21 @@ def test_create_nexus_output_file_no_strings(config_tmpdir, output_tmpdir,
                                              NEXUSDIR,
                                              base_name_no_strings,
                                              nexus_output_file_no_strings):
-    # Init file
+    # Init file
     init_text = f"""
-/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
-/PhysicsList/RegisterPhysics G4DecayPhysics
-/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
-/PhysicsList/RegisterPhysics G4OpticalPhysics
-/PhysicsList/RegisterPhysics NexusPhysics
-/PhysicsList/RegisterPhysics G4StepLimiterPhysics
-
 /nexus/RegisterGeometry Next100OpticalGeometry
 
 /nexus/RegisterGenerator SingleParticleGenerator
 
-/nexus/RegisterPersistencyManager PersistencyManager
-
-/nexus/RegisterTrackingAction DefaultTrackingAction
-/nexus/RegisterEventAction DefaultEventAction
-/nexus/RegisterRunAction DefaultRunAction
-
 /nexus/RegisterMacro {config_tmpdir}/{base_name_no_strings}.config.mac
 """
+    init_text = f'{common_init_params} {init_text}'
     init_path = os.path.join(config_tmpdir, base_name_no_strings+'.init.mac')
     init_file = open(init_path,'w')
     init_file.write(init_text)
     init_file.close()
 
-    #Config file
+    # Config file
     config_text = f"""
 /run/verbose 1
 /event/verbose 0
@@ -351,30 +304,19 @@ def test_create_nexus_output_file_no_strings(config_tmpdir, output_tmpdir,
 
 /process/em/verbose 0
 
-/Geometry/Next100/elfield true
-/Geometry/Next100/EL_field 13 kV/cm
-/Geometry/Next100/max_step_size 1. mm
-/Geometry/Next100/pressure 15. bar
-/Geometry/Next100/sc_yield 10000 1/MeV
-
-/Generator/SingleParticle/particle e-
-/Generator/SingleParticle/min_energy 10. keV
-/Generator/SingleParticle/max_energy 10. keV
 /Generator/SingleParticle/region CENTER
 
 /nexus/persistency/save_strings false
 /nexus/persistency/output_file {output_tmpdir}/{base_name_no_strings}
 /nexus/random_seed 21051817
 """
+    config_text = f'{config_text} {next100_params} {single_part_params}'
     config_path = os.path.join(config_tmpdir, base_name_no_strings+'.config.mac')
     config_file = open(config_path,'w')
     config_file.write(config_text)
     config_file.close()
 
-    # Running the simulation
-    my_env    = os.environ
-    nexus_exe = NEXUSDIR + '/bin/nexus'
-    command   = [nexus_exe, '-b', '-n', '1', init_path]
-    p         = subprocess.run(command, check=True, env=my_env)
+    # Running the simulation
+    run_simulation(NEXUSDIR, init_path)
 
     return nexus_output_file_no_strings

--- a/tests/pytest/produce_output_test.py
+++ b/tests/pytest/produce_output_test.py
@@ -54,6 +54,7 @@ def test_create_nexus_output_file_next100(config_tmpdir, output_tmpdir,
 /Generator/SingleParticle/max_energy 10. keV
 /Generator/SingleParticle/region CENTER
 
+/nexus/persistency/save_strings true
 /nexus/persistency/output_file {output_tmpdir}/{full_base_name_next100}
 /nexus/random_seed 21051817
 """
@@ -121,6 +122,7 @@ def test_create_nexus_output_file_new(config_tmpdir, output_tmpdir, NEXUSDIR,
 /Generator/SingleParticle/max_energy 10. keV
 /Generator/SingleParticle/region CENTER
 
+/nexus/persistency/save_strings true
 /nexus/persistency/output_file {output_tmpdir}/{full_base_name_new}
 /nexus/random_seed 21051817
 """
@@ -224,6 +226,7 @@ def test_create_nexus_output_file_flex100(config_tmpdir, output_tmpdir, NEXUSDIR
 /Generator/SingleParticle/region         AD_HOC
 /Geometry/NextFlex/specific_vertex       0. 0. 500. mm
 
+/nexus/persistency/save_strings true
 /nexus/persistency/output_file {output_tmpdir}/{full_base_name_flex100}
 /nexus/random_seed 21051817
 """
@@ -290,6 +293,7 @@ def test_create_nexus_output_file_demopp(config_tmpdir, output_tmpdir, NEXUSDIR,
     /Generator/SingleParticle/max_energy 10. keV
     /Generator/SingleParticle/region AD_HOC
 
+    /nexus/persistency/save_strings true
     /nexus/persistency/output_file {output_tmpdir}/{full_base_name_demopp.format(run=run)}
     /nexus/random_seed 21051817
 
@@ -306,3 +310,71 @@ def test_create_nexus_output_file_demopp(config_tmpdir, output_tmpdir, NEXUSDIR,
         p         = subprocess.run(command, check=True, env=my_env)
 
     return nexus_full_output_file_demopp
+
+
+@pytest.mark.order(5)
+def test_create_nexus_output_file_no_strings(config_tmpdir, output_tmpdir,
+                                             NEXUSDIR,
+                                             base_name_no_strings,
+                                             nexus_output_file_no_strings):
+    # Init file
+    init_text = f"""
+/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
+/PhysicsList/RegisterPhysics G4DecayPhysics
+/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
+/PhysicsList/RegisterPhysics G4OpticalPhysics
+/PhysicsList/RegisterPhysics NexusPhysics
+/PhysicsList/RegisterPhysics G4StepLimiterPhysics
+
+/nexus/RegisterGeometry Next100OpticalGeometry
+
+/nexus/RegisterGenerator SingleParticleGenerator
+
+/nexus/RegisterPersistencyManager PersistencyManager
+
+/nexus/RegisterTrackingAction DefaultTrackingAction
+/nexus/RegisterEventAction DefaultEventAction
+/nexus/RegisterRunAction DefaultRunAction
+
+/nexus/RegisterMacro {config_tmpdir}/{base_name_no_strings}.config.mac
+"""
+    init_path = os.path.join(config_tmpdir, base_name_no_strings+'.init.mac')
+    init_file = open(init_path,'w')
+    init_file.write(init_text)
+    init_file.close()
+
+    #Config file
+    config_text = f"""
+/run/verbose 1
+/event/verbose 0
+/tracking/verbose 0
+
+/process/em/verbose 0
+
+/Geometry/Next100/elfield true
+/Geometry/Next100/EL_field 13 kV/cm
+/Geometry/Next100/max_step_size 1. mm
+/Geometry/Next100/pressure 15. bar
+/Geometry/Next100/sc_yield 10000 1/MeV
+
+/Generator/SingleParticle/particle e-
+/Generator/SingleParticle/min_energy 10. keV
+/Generator/SingleParticle/max_energy 10. keV
+/Generator/SingleParticle/region CENTER
+
+/nexus/persistency/save_strings false
+/nexus/persistency/output_file {output_tmpdir}/{base_name_no_strings}
+/nexus/random_seed 21051817
+"""
+    config_path = os.path.join(config_tmpdir, base_name_no_strings+'.config.mac')
+    config_file = open(config_path,'w')
+    config_file.write(config_text)
+    config_file.close()
+
+    # Running the simulation
+    my_env    = os.environ
+    nexus_exe = NEXUSDIR + '/bin/nexus'
+    command   = [nexus_exe, '-b', '-n', '1', init_path]
+    p         = subprocess.run(command, check=True, env=my_env)
+
+    return nexus_output_file_no_strings


### PR DESCRIPTION
This PR adds the possibility of saving strings as int in the h5 file, to reduce the output size. Such strings are, in the `particles` table, the initial/final volume of a particle, its creator and final process and its name and, in the `hits` table, the label of the hits. The other strings saved in the output files appear in a much lower number of rows and do not affect the performance.

A table is added with the string --> int univocal correspondence for all the strings which are converted into int.

While this will be the default behaviour from now on, there's the possibility of still saving strings for debugging or to do small studies, via configuration parameter.