### PR TITLE
Stop using bitwise operators with Booleans

### DIFF
--- a/source/geometries/GenericPhotosensor.cc
+++ b/source/geometries/GenericPhotosensor.cc
@@ -237,7 +237,7 @@ void GenericPhotosensor::Construct()
       G4Exception("[GenericPhotosensor]", "Construct()", FatalException,
                   "Sensor Depth must be set before constructing");
 
-    if ((naming_order_ > 0) & (mother_depth_ == 0))
+    if ((naming_order_ > 0) && (mother_depth_ == 0))
       G4Exception("[GenericPhotosensor]", "Construct()", FatalException,
                   "naming_order set without setting mother_depth");
 

--- a/source/geometries/Next100SiPM.cc
+++ b/source/geometries/Next100SiPM.cc
@@ -194,7 +194,7 @@ void Next100SiPM::Construct()
       G4Exception("[Next100SiPM]", "Construct()", FatalException,
                   "Sensor Depth must be set before constructing");
 
-    if ((naming_order_ > 0) & (mother_depth_ == 0))
+    if ((naming_order_ > 0) && (mother_depth_ == 0))
       G4Exception("[Next100SiPM]", "Construct()", FatalException,
                   "Naming Order set without setting Mother Depth");
 

--- a/source/geometries/NextDemoInnerElements.cc
+++ b/source/geometries/NextDemoInnerElements.cc
@@ -55,10 +55,10 @@ void NextDemoInnerElements::Construct()
   if (config_ == "")
     G4Exception("[NextDemoInnerElements]", "Construct()",
                 FatalException, "NextDemo configuration has not been set.");
-  else if ((config_ != "run5") &
-           (config_ != "run7") &
-           (config_ != "run8") &
-           (config_ != "run9") &
+  else if ((config_ != "run5") &&
+           (config_ != "run7") &&
+           (config_ != "run8") &&
+           (config_ != "run9") &&
            (config_ != "run10"))
     G4Exception("[NextDemoInnerElements]", "Construct()",
                 FatalException, "Wrong NextDemo configuration.");

--- a/source/geometries/SiPMSensl.cc
+++ b/source/geometries/SiPMSensl.cc
@@ -171,7 +171,7 @@ namespace nexus {
         G4Exception("[SiPMSensl]", "Construct()", FatalException,
                     "Sensor Depth must be set before constructing");
 
-      if ((naming_order_ > 0) & (mother_depth_ == 0))
+      if ((naming_order_ > 0) && (mother_depth_ == 0))
         G4Exception("[SiPMSensl]", "Construct()", FatalException,
                     "Naming Order set without setting Mother Depth");
 

--- a/source/tests/utils/BoxPointSamplerTests.cc
+++ b/source/tests/utils/BoxPointSamplerTests.cc
@@ -33,17 +33,17 @@ TEST_CASE("BoxPointSampler") {
     REQUIRE(z >= -c/2 - thick);
     REQUIRE(z <=  c/2 + thick);
 
-    if ((std::abs(x) < a/2) & (std::abs(y) < b/2)) {
+    if ((std::abs(x) < a/2) && (std::abs(y) < b/2)) {
       REQUIRE(std::abs(z) >= c/2);
       REQUIRE(std::abs(z) <= c/2 + thick);
     }
 
-    if ((std::abs(x) < a/2) & (std::abs(z) < c/2)) {
+    if ((std::abs(x) < a/2) && (std::abs(z) < c/2)) {
       REQUIRE(std::abs(y) >= b/2);
       REQUIRE(std::abs(y) <= b/2 + thick);
     }
 
-    if ((std::abs(y) < b/2) & (std::abs(z) < c/2)) {
+    if ((std::abs(y) < b/2) && (std::abs(z) < c/2)) {
       REQUIRE(std::abs(x) >= a/2);
       REQUIRE(std::abs(x) <= a/2 + thick);
     }


### PR DESCRIPTION
This PR fixes the use of bitwise operators with booleans. Although in nexus the behaviour was the expected one, it could be misleading, and it raised compilation warnings.