### PR TITLE
Adjust/update Next100 geometry

### DIFF
--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -54,8 +54,7 @@ namespace nexus {
 
   void Next100Ics::Construct()
   {
-    G4double length = gate_tp_distance_ + gate_sapphire_wdw_dist_;
-
+    G4double length = 1468.2 * mm; // (Full length of copper bars) - (copper simulated in TP_COPPER_PLATE)
     // defined for G4UnionSolids to ensure a common volume within the two joined solids
     // and for G4SubtractionSolids to ensure surface subtraction
     G4double offset = 1.* mm;
@@ -117,18 +116,19 @@ namespace nexus {
     ics_solid = new G4SubtractionSolid("ICS", ics_solid, upp_hole_solid_2,
                 port_upp_Rot, G4ThreeVector(0, (in_rad_ + thickness_/2.), upp_hole_2_z-length/2.));
 
-    /// Lateral holes
+    /// Lateral holes (also known as feedthrough holes)
     G4double lat_hole_rad = upp_hole_1_rad;
-    G4double lat_hole_z   = 58.1 * mm;
+    G4double lat_hole_z_1   = 55.5 * mm;
+    G4double lat_hole_z_2   = 33.0 * mm;
 
     G4Tubs* lat_hole_solid = new G4Tubs("LAT_HOLE", 0., lat_hole_rad,
                                         (thickness_ + offset)/2., 0.*deg, 360.*deg);
 
     ics_solid = new G4SubtractionSolid("ICS", ics_solid, lat_hole_solid,
-                port_a_Rot, G4ThreeVector(port_x, port_y, lat_hole_z-length/2.));
+                port_a_Rot, G4ThreeVector(port_x, port_y, lat_hole_z_1-length/2.));
 
     ics_solid = new G4SubtractionSolid("ICS", ics_solid, lat_hole_solid,
-                port_b_Rot, G4ThreeVector(-port_x, port_y, lat_hole_z-length/2.));
+                port_b_Rot, G4ThreeVector(-port_x, port_y, lat_hole_z_2-length/2.));
 
 
     /// ICS step at the TP end.

--- a/source/geometries/Next100OpticalGeometry.cc
+++ b/source/geometries/Next100OpticalGeometry.cc
@@ -34,8 +34,8 @@ namespace nexus {
 
   Next100OpticalGeometry::Next100OpticalGeometry(): GeometryBase(),
                 // common used variables in geomety components
-                gate_tracking_plane_distance_(35. * mm), // to be confirmed
-                gate_sapphire_wdw_distance_  (1460.5 * mm),
+                gate_tracking_plane_distance_((26.1 + 0.1) * mm), // to be confirmed
+                gate_sapphire_wdw_distance_  ((1458.2 - 0.1) * mm),
 						    pressure_(15. * bar),
 						    temperature_ (300 * kelvin),
 						    sc_yield_(25510. * 1/MeV),

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -201,10 +201,10 @@ namespace nexus {
     G4double port_nozzle_y = port_nozzle_x;
 
     G4double port_reference_z = -body_length_/2. + endcap_in_body_;
-    port_z_1a_ = port_reference_z +   702. * mm;
-    port_z_2a_ = port_reference_z +  1292. * mm;
-    port_z_1b_ = port_reference_z +  533.6 * mm;
-    port_z_2b_ = port_reference_z + 1033.6 * mm;
+    port_z_1a_ = port_reference_z +   739.6 * mm;
+    port_z_2a_ = port_reference_z +  1329.6 * mm;
+    port_z_1b_ = port_reference_z +  570.3 * mm;
+    port_z_2b_ = port_reference_z + 1070.3 * mm;
 
     G4RotationMatrix* port_a_Rot = new G4RotationMatrix;
     port_a_Rot->rotateX( 90. * deg);


### PR DESCRIPTION
- Altered `Next100OpticalGeometry.cc` to match the more up to date distances between the sapphire windows, the EL gate, and the tracking plane that were introduced to `Next100.cc` in [this PR](https://github.com/next-exp/nexus/pull/121) but were not carried over.
- Changed length of inner copper shielding to match drawings (copper should not overlap beyond the staves on the energy plane-side of the detector).
- Adjusted positions of calibration and feed-through ports to match the expected locations in the detector.

On my machine both `pytest` and the Catch2 tests passed (with the pytest containing warnings that appeared unrelated to this change).

General summary of geometry changes can be seen here.
[geometry_changes.pdf](https://github.com/next-exp/nexus/files/13190745/geometry_changes.pdf)
