### PR TITLE
Fix FusedSilica and FakeFusedSilica refractive indices

### DIFF
--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -50,7 +50,7 @@ namespace opticalprops {
     // The range is chosen to be up to ~10.7 eV because Sellmeier's equation
     // for fused silica is valid only in that range
     const G4int ri_entries = 200;
-    G4double eWidth = (optPhotMaxE_ - optPhotMinE_) / ri_entries;
+    G4double eWidth = (optPhotFusedSilicaMaxE_ - optPhotMinE_) / ri_entries;
 
     std::vector<G4double> ri_energy;
     for (int i=0; i<ri_entries; i++) {
@@ -83,6 +83,8 @@ namespace opticalprops {
       // G4cout << "* FusedSilica rIndex:  " << std::setw(5) << ri_energy[i]/eV
       //       << " eV -> " << rIndex[i] << G4endl;
     }
+    ri_energy.push_back(optPhotMaxE_);          // This sets the refractive index between optPhotFusedSilicaMaxE_ and
+    rIndex.push_back(rIndex[rIndex.size()-1]);  // optPhotMaxE_ to the value obtained at optPhotFusedSilicaMaxE_
     mpt->AddProperty("RINDEX", ri_energy, rIndex);
 
     // ABSORPTION LENGTH
@@ -163,6 +165,8 @@ namespace opticalprops {
       //G4cout << "* FakeFusedSilica rIndex:  " << std::setw(5)
       //       << ri_energy[i]/eV << " eV -> " << rIndex[i] << G4endl;
     }
+    ri_energy.push_back(optPhotMaxE_);          // This sets the refractive index between optPhotFusedSilicaMaxE_ and
+    rIndex.push_back(rIndex[rIndex.size()-1]);  // optPhotMaxE_ to the value obtained at optPhotFusedSilicaMaxE_
     mpt->AddProperty("RINDEX", ri_energy, rIndex);
 
     // ABSORPTION LENGTH (Set to match the transparency)
@@ -305,7 +309,7 @@ namespace opticalprops {
     // The range is chosen to be up to ~10.7 eV because Sellmeier's equation
     // for fused silica is valid only in that range
     const G4int ri_entries = 200;
-    G4double eWidth = (optPhotFusedSilicaMaxE_ - optPhotMinE_) / ri_entries;
+    G4double eWidth = (optPhotMaxE_ - optPhotMinE_) / ri_entries;
 
     std::vector<G4double> ri_energy;
     for (int i=0; i<ri_entries; i++) {

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -130,7 +130,7 @@ namespace opticalprops {
     // The range is chosen to be up to ~10.7 eV because Sellmeier's equation
     // for fused silica is valid only in that range
     const G4int ri_entries = 200;
-    G4double eWidth = (optPhotMaxE_ - optPhotMinE_) / ri_entries;
+    G4double eWidth = (optPhotFusedSilicaMaxE_ - optPhotMinE_) / ri_entries;
 
     std::vector<G4double> ri_energy;
     for (int i=0; i<ri_entries; i++) {
@@ -305,7 +305,7 @@ namespace opticalprops {
     // The range is chosen to be up to ~10.7 eV because Sellmeier's equation
     // for fused silica is valid only in that range
     const G4int ri_entries = 200;
-    G4double eWidth = (optPhotMaxE_ - optPhotMinE_) / ri_entries;
+    G4double eWidth = (optPhotFusedSilicaMaxE_ - optPhotMinE_) / ri_entries;
 
     std::vector<G4double> ri_energy;
     for (int i=0; i<ri_entries; i++) {

--- a/source/materials/OpticalMaterialProperties.h
+++ b/source/materials/OpticalMaterialProperties.h
@@ -86,6 +86,7 @@ namespace opticalprops {
 
   constexpr G4double optPhotMinE_ =  0.2  * eV;
   constexpr G4double optPhotMaxE_ = 11.5  * eV;
+  constexpr G4double optPhotFusedSilicaMaxE_ = 10.7  * eV; // formulas for fused silica are valid up to this energy
   constexpr G4double noAbsLength_ = 1.e8  * m;
 
   // Constant that allows to convert nm to eV:


### PR DESCRIPTION
This PR fixes issue #216. Now, the refractive indices for `FusedSilica` and `FakeFusedSilica` are calculated only up to 10.7 eV, which is the upper limit for the formula used in the code. 