### PR TITLE
Update Field Cage class

### DIFF
--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -37,7 +37,7 @@ namespace nexus {
     // Lab dimensions
     lab_size_ (5. * m),
 
-    // common used variables in geometry components
+    // common variables used in geometry components
     grid_thickness_ (0.1 * mm),
     //ep_fc_distance_ (24.8 * mm), /// this value was measured by Sara in the step file
     gate_tracking_plane_distance_(25. * mm + grid_thickness_), // Jordi = 1.5 (distance TP plate-anode ring) + 13.5 (anode ring thickness) + 10 (EL gap)

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -37,11 +37,10 @@ namespace nexus {
     // Lab dimensions
     lab_size_ (5. * m),
 
-    // common used variables in geomety components
-    // 0.1 mm grid thickness
-    // note that if grid thickness change it must be also changed in Next100FieldCage.cc
-    gate_tracking_plane_distance_((26.1 + 0.1)   * mm),
-    gate_sapphire_wdw_distance_  ((1458.2 - 0.1) * mm),
+    // common used variables in geometry components
+    grid_thickness_ (0.1 * mm),
+    gate_tracking_plane_distance_((26.1 + grid_thickness_)   * mm),
+    gate_sapphire_wdw_distance_  ((1458.2 - grid_thickness_ - 1.351) * mm),
 
     specific_vertex_{},
     lab_walls_(false)
@@ -71,7 +70,7 @@ namespace nexus {
   ics_ = new Next100Ics();
 
   // Inner Elements
-  inner_elements_ = new Next100InnerElements();
+  inner_elements_ = new Next100InnerElements(grid_thickness_);
 
   }
 
@@ -100,13 +99,16 @@ namespace nexus {
       G4double hallA_length = hallA_walls_->GetLSCHallALength();
       // Since the walls will be displaced need to make the
       // "lab" double sized to be sure.
-      G4Box* lab_solid = new G4Box("LAB", hallA_length, hallA_length, hallA_length);
-      G4Material *vacuum = G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic");
+      G4Box* lab_solid =
+        new G4Box("LAB", hallA_length, hallA_length, hallA_length);
+      G4Material* vacuum =
+        G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic");
       lab_logic_ = new G4LogicalVolume(lab_solid, vacuum, "LAB");
       this->SetSpan(2 * hallA_length);
     }
     else {
-      G4Box* lab_solid = new G4Box("LAB", lab_size_/2., lab_size_/2., lab_size_/2.);
+      G4Box* lab_solid =
+        new G4Box("LAB", lab_size_/2., lab_size_/2., lab_size_/2.);
       lab_logic_ = new G4LogicalVolume(lab_solid,
         G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"), "LAB");
     }
@@ -120,9 +122,12 @@ namespace nexus {
     vessel_->SetELtoTPdistance(gate_tracking_plane_distance_);
     vessel_->Construct();
     G4LogicalVolume* vessel_logic = vessel_->GetLogicalVolume();
-    G4LogicalVolume* vessel_internal_logic  = vessel_->GetInternalLogicalVolume();
-    G4VPhysicalVolume* vessel_internal_phys = vessel_->GetInternalPhysicalVolume();
-    G4ThreeVector vessel_displacement = shielding_->GetAirDisplacement(); // explained below
+    G4LogicalVolume* vessel_internal_logic  =
+      vessel_->GetInternalLogicalVolume();
+    G4VPhysicalVolume* vessel_internal_phys =
+      vessel_->GetInternalPhysicalVolume();
+    G4ThreeVector vessel_displacement =
+      shielding_->GetAirDisplacement(); // explained below
     gate_zpos_in_vessel_ = vessel_->GetELzCoord();
 
     // SHIELDING
@@ -132,7 +137,8 @@ namespace nexus {
     G4LogicalVolume* shielding_air_logic = shielding_->GetAirLogicalVolume();
 
     // Recall that airbox is slighly displaced in Y dimension. In order to avoid
-    // mistmatch with vertex generators, we place the vessel in the center of the world volume
+    // mistmatch with vertex generators, we place the vessel i
+    // n the center of the world volume
     new G4PVPlacement(0, -vessel_displacement, vessel_logic,
                       "VESSEL", shielding_air_logic, false, 0);
 
@@ -163,12 +169,14 @@ namespace nexus {
                         "Hall_A", lab_logic_, false, 0, false);
     }
     else {
-      new G4PVPlacement(0, gate_pos, shielding_logic, "LEAD_BOX", lab_logic_, false, 0);
+      new G4PVPlacement(0, gate_pos, shielding_logic, "LEAD_BOX", lab_logic_,
+                        false, 0);
     }
 
     //// VERTEX GENERATORS
     lab_gen_ =
-      new BoxPointSampler(lab_size_ - 1.*m, lab_size_ - 1.*m, lab_size_  - 1.*m, 1.*m,
+      new BoxPointSampler(lab_size_ - 1.*m, lab_size_ - 1.*m,
+                          lab_size_  - 1.*m, 1.*m,
                           G4ThreeVector(0., 0., 0.), 0);
   }
 

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -39,8 +39,8 @@ namespace nexus {
 
     // common used variables in geometry components
     grid_thickness_ (0.1 * mm),
-    gate_tracking_plane_distance_((26.1 + grid_thickness_)   * mm),
-    gate_sapphire_wdw_distance_  ((1458.2 - grid_thickness_ - 1.351) * mm),
+    gate_tracking_plane_distance_(26.1 * mm + grid_thickness_),
+    gate_sapphire_wdw_distance_  ((1458.2 - 1.3) * mm - grid_thickness_),
 
     specific_vertex_{},
     lab_walls_(false)

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -42,8 +42,6 @@ namespace nexus {
     //ep_fc_distance_ (24.8 * mm), /// this value was measured by Sara in the step file
     gate_tracking_plane_distance_(25. * mm + grid_thickness_), // Jordi = 1.5 (distance TP plate-anode ring) + 13.5 (anode ring thickness) + 10 (EL gap)
     gate_sapphire_wdw_distance_  (1458.8 * mm - grid_thickness_), // Jordi
-    //gate_sapphire_wdw_distance_  ((1458.2 - 1.3) * mm - grid_thickness_),
-    //gate_sapphire_wdw_distance_  (1432.1 * mm + ep_fc_distance_ - grid_thickness_),
 
     specific_vertex_{},
     lab_walls_(false)

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -39,8 +39,10 @@ namespace nexus {
 
     // common used variables in geometry components
     grid_thickness_ (0.1 * mm),
+    //ep_fc_distance_ (24.8 * mm), /// this value was measured by Sara in the step file
     gate_tracking_plane_distance_(26.1 * mm + grid_thickness_),
     gate_sapphire_wdw_distance_  ((1458.2 - 1.3) * mm - grid_thickness_),
+    //gate_sapphire_wdw_distance_  (1432.1 * mm + ep_fc_distance_ - grid_thickness_),
 
     specific_vertex_{},
     lab_walls_(false)

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -41,7 +41,8 @@ namespace nexus {
     grid_thickness_ (0.1 * mm),
     //ep_fc_distance_ (24.8 * mm), /// this value was measured by Sara in the step file
     gate_tracking_plane_distance_(26.1 * mm + grid_thickness_),
-    gate_sapphire_wdw_distance_  ((1458.2 - 1.3) * mm - grid_thickness_),
+    gate_sapphire_wdw_distance_  (1458.8 * mm - grid_thickness_), // Jordi
+    //gate_sapphire_wdw_distance_  ((1458.2 - 1.3) * mm - grid_thickness_),
     //gate_sapphire_wdw_distance_  (1432.1 * mm + ep_fc_distance_ - grid_thickness_),
 
     specific_vertex_{},

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -40,7 +40,7 @@ namespace nexus {
     // common used variables in geometry components
     grid_thickness_ (0.1 * mm),
     //ep_fc_distance_ (24.8 * mm), /// this value was measured by Sara in the step file
-    gate_tracking_plane_distance_(26.1 * mm + grid_thickness_),
+    gate_tracking_plane_distance_(25. * mm + grid_thickness_), // Jordi = 1.5 (distance TP plate-anode ring) + 13.5 (anode ring thickness) + 10 (EL gap)
     gate_sapphire_wdw_distance_  (1458.8 * mm - grid_thickness_), // Jordi
     //gate_sapphire_wdw_distance_  ((1458.2 - 1.3) * mm - grid_thickness_),
     //gate_sapphire_wdw_distance_  (1432.1 * mm + ep_fc_distance_ - grid_thickness_),

--- a/source/geometries/Next100.h
+++ b/source/geometries/Next100.h
@@ -48,6 +48,8 @@ namespace nexus {
     // Detector dimensions
     const G4double lab_size_; /// Size of the air box containing the detector
     const G4double grid_thickness_; /// Width of grids simulated as dielectric
+    //    const G4double ep_fc_distance_; /// Distance between the surface of the
+    ///EP copper plate and the end of the staves/teflon panels/poly (a.k.a. FC)
     const G4double gate_tracking_plane_distance_, gate_sapphire_wdw_distance_;
 
     // Pointers to logical volumes

--- a/source/geometries/Next100.h
+++ b/source/geometries/Next100.h
@@ -46,7 +46,8 @@ namespace nexus {
 
   private:
     // Detector dimensions
-    const G4double lab_size_;          /// Size of the air box containing the detector
+    const G4double lab_size_; /// Size of the air box containing the detector
+    const G4double grid_thickness_; /// Width of grids simulated as dielectric
     const G4double gate_tracking_plane_distance_, gate_sapphire_wdw_distance_;
 
     // Pointers to logical volumes

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -59,7 +59,7 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   teflon_thickn_       (5. * mm),
   n_panels_            (18),
 
-  el_gap_length_ (10. * mm),
+  el_gap_length_ (9.7 * mm),
 
   gate_teflon_dist_ (10.2 * mm - grid_thickn_), //distance from gate-grid to teflon
   gate_ext_diam_    (1042. * mm), //preliminary

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -51,7 +51,6 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   cathode_int_diam_    (965. * mm),
   cathode_ext_diam_    (1020.* mm),
   cathode_thickn_      (10.  * mm),
-  // Caution: updating grid-thickn_ will require updating gate-tp and gate-sapphire-window distances
   grid_thickn_         (grid_thickn),
 
   //  teflon_drift_length_ (1178.*mm), //distance from the gate to the beginning of the cathode volume.

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -52,8 +52,10 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   // Caution: updating grid-thickn_ will require updating gate-tp and gate-sapphire-window distances
   grid_thickn_         (grid_thickn),
 
-  teflon_drift_length_ (1178.*mm), //distance from the gate to the beginning of the cathode volume.
-  teflon_total_length_ (1431. * mm),
+  //  teflon_drift_length_ (1178.*mm), //distance from the gate to the beginning of the cathode volume.
+  teflon_long_length_   (467.5 * mm), //(465. * mm), from drawings
+  teflon_buffer_length_ (243. * mm), //(241. * mm), from drawings
+  // teflon_total_length_ (1431. * mm),
   teflon_thickn_       (5. * mm),
   n_panels_            (18),
 
@@ -198,12 +200,12 @@ void Next100FieldCage::SetMotherPhysicalVolume(G4VPhysicalVolume* mother_phys)
 
 void Next100FieldCage::Construct()
 {
+  /// Calculate different lengths of teflon
+  teflon_drift_length_ = 2 * teflon_long_length_ + teflon_buffer_length_;
+  teflon_total_length_ = teflon_drift_length_ + cathode_thickn_ + teflon_buffer_length_;
   /// Calculate lengths of active and buffer regions
   active_length_ = gate_teflon_dist_ + teflon_drift_length_;
   buffer_length_ = gate_sapphire_wdw_dist_ - active_length_ - grid_thickn_;
-
-  /// Calculate length of teflon in the buffer region
-  teflon_buffer_length_ = teflon_total_length_ - cathode_thickn_ - teflon_drift_length_;
 
   /// Calculate radial position of the ring holders.
   holder_r_ = (active_diam_+2.*teflon_thickn_+holder_long_y_)/2.;

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -65,9 +65,9 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   gate_ring_thickn_ (9.9   * mm), // maximum possible value to avoid overlap with sipm board masks
 
   // external to teflon (hdpe + rings + holders)
-  hdpe_tube_int_diam_ (1080. * mm),
+  hdpe_tube_int_diam_ (1093. * mm),
   hdpe_tube_ext_diam_ (1105.4 * mm),
-  hdpe_length_        (1192. * mm),
+  hdpe_length_        (1115. * mm),
 
   ring_ext_diam_ (1038. * mm),
   ring_int_diam_ (1014. * mm),

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -199,7 +199,7 @@ void Next100FieldCage::SetMotherPhysicalVolume(G4VPhysicalVolume* mother_phys)
 void Next100FieldCage::Construct()
 {
   /// Calculate lengths of active and buffer regions
-  active_length_ = (cathode_thickn_ - grid_thickn_)/2. + teflon_drift_length_ + gate_teflon_dist_;
+  active_length_ = gate_teflon_dist_ + teflon_drift_length_;
   buffer_length_ = gate_sapphire_wdw_dist_ - active_length_ - grid_thickn_;
 
   /// Calculate length of teflon in the buffer region
@@ -213,8 +213,8 @@ void Next100FieldCage::Construct()
   /// of the beginning of the ACTIVE volume and the end of the gate grid.
   gate_grid_zpos_  = GetELzCoord() - grid_thickn_/2.;
   active_zpos_     = GetELzCoord() + active_length_/2.;
-  cathode_zpos_    = GetELzCoord() + active_length_ + grid_thickn_/2.;
-  gate_zpos_       = GetELzCoord() + gate_ring_thickn_/2. - grid_thickn_;
+  cathode_zpos_    = GetELzCoord() + active_length_ + cathode_thickn_/2.;
+  gate_zpos_       = GetELzCoord() - grid_thickn_ + gate_ring_thickn_/2.;
   el_gap_zpos_     = GetELzCoord() - grid_thickn_ - el_gap_length_/2.;
   anode_zpos_      = el_gap_zpos_ - el_gap_length_/2. - gate_ring_thickn_/2.;
   anode_grid_zpos_ = el_gap_zpos_ - el_gap_length_/2. - grid_thickn_/2.;
@@ -380,7 +380,8 @@ void Next100FieldCage::BuildCathode()
   G4LogicalVolume* diel_grid_logic =
     new G4LogicalVolume(diel_grid_solid, fgrid_mat, "CATHODE_GRID");
 
-  new G4PVPlacement(0, G4ThreeVector(0., 0., cathode_zpos_),
+  G4double cathode_grid_zpos = cathode_zpos_ - cathode_thickn_/2. + grid_thickn_/2.;
+  new G4PVPlacement(0, G4ThreeVector(0., 0., cathode_grid_zpos),
                     diel_grid_logic, "CATHODE_GRID", mother_logic_,
                     false, 0, false);
 
@@ -418,7 +419,7 @@ void Next100FieldCage::BuildBuffer()
   G4double buffer_zpos = active_zpos_ + active_length_/2. + grid_thickn_ + buffer_length_/2.;
 
   /// Position of z planes
-  G4double zplane[2] = {-buffer_length_/2.+(cathode_thickn_-grid_thickn_)/2., buffer_length_/2.};
+  G4double zplane[2] = {-buffer_length_/2. - grid_thickn_ + cathode_thickn_, buffer_length_/2.};
   /// Inner radius
   G4double rinner[2] = {0., 0.};
   /// Outer radius
@@ -429,10 +430,11 @@ void Next100FieldCage::BuildBuffer()
 
   G4Tubs* buffer_cathode_solid =
     new G4Tubs("BUFF_CATHODE_RING", 0, cathode_int_diam_/2.,
-              (cathode_thickn_/2. - grid_thickn_/2.)/2. +  overlap_/2., 0, twopi);
+               (cathode_thickn_ - grid_thickn_)/2. +  overlap_/2., 0, twopi);
+
 
   G4ThreeVector buff_cathode_pos =
-  G4ThreeVector(0., 0., -buffer_length_/2. + (cathode_thickn_/2.-grid_thickn_/2.)/2. +overlap_/2.);
+    G4ThreeVector(0., 0., -buffer_length_/2. + (cathode_thickn_ - grid_thickn_)/2. + overlap_/2.);
 
   G4UnionSolid* union_buffer =
     new G4UnionSolid("BUFFER", buffer_solid, buffer_cathode_solid, 0, buff_cathode_pos);

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -77,8 +77,8 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   drift_ring_dist_  (24. * mm),
   buffer_ring_dist_ (48. * mm),
   holder_x_         (60. * mm),  //x dimension of the holders
-  holder_long_y_    (9.  * mm),  // y dim of the base of the ring holders
-  holder_short_y_   (33.15 * mm),// y dim of the pieces added over the base of the ring holders
+  holder_long_y_    (9.1 * mm), //(9.  * mm),  // y dim of the base of the ring holders
+  holder_short_y_   (33.9 * mm), //(33.15 * mm),// y dim of the pieces added over the base of the ring holders
 
   tpb_thickn_ (1 * micrometer),
   overlap_    (0.001*mm), //defined for G4UnionSolids to ensure a common volume within the two joined solids
@@ -868,7 +868,7 @@ void Next100FieldCage::BuildFieldCage()
 
   // CATHODE holders.
   // They are placed at the same z position as the cathode ring.
-  G4double cathode_long_y = 29.*mm;
+  G4double cathode_long_y = 28.15 * mm;// 29.*mm (previous) - 0.85 * mm (what has been removed);
   G4double cathode_long_z = 61*mm;
   G4double cathode_short_z = 24.5*mm;
   G4Box* cathode_large_solid =
@@ -916,9 +916,11 @@ void Next100FieldCage::BuildFieldCage()
     hdpe_tube_logic->SetVisAttributes(hdpe_col);
     G4VisAttributes hold_col = nexus::LightGrey();
     hold_col.SetForceSolid(true);
+    G4VisAttributes hold_col_cath = nexus::Lilla();
+    hold_col_cath.SetForceSolid(true);
     act_holder_logic->SetVisAttributes(hold_col);
     buff_holder_logic->SetVisAttributes(hold_col);
-    cathode_holder_logic->SetVisAttributes(hold_col);
+    cathode_holder_logic->SetVisAttributes(hold_col_cath);
   } else {
     ring_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
     hdpe_tube_logic->SetVisAttributes(G4VisAttributes::GetInvisible());

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -60,7 +60,7 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   teflon_thickn_       (5. * mm),
   n_panels_            (18),
 
-  el_gap_length_ (9.7 * mm),
+  el_gap_length_ (10. * mm),
 
   gate_ext_diam_    (1050. * mm),
   gate_int_diam_    (995. * mm),

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -50,7 +50,7 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
 
   cathode_int_diam_    (965. * mm),
   cathode_ext_diam_    (1020.* mm),
-  cathode_thickn_      (10.  * mm),
+  cathode_thickn_      (13.5  * mm),
   grid_thickn_         (grid_thickn),
 
   //  teflon_drift_length_ (1178.*mm), //distance from the gate to the beginning of the cathode volume.

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -203,6 +203,7 @@ void Next100FieldCage::Construct()
   /// Calculate different lengths of teflon
   teflon_drift_length_ = 2 * teflon_long_length_ + teflon_buffer_length_;
   teflon_total_length_ = teflon_drift_length_ + cathode_thickn_ + teflon_buffer_length_;
+
   /// Calculate lengths of active and buffer regions
   active_length_ = gate_teflon_dist_ + teflon_drift_length_;
   buffer_length_ = gate_sapphire_wdw_dist_ - active_length_ - grid_thickn_;
@@ -348,7 +349,7 @@ void Next100FieldCage::BuildActive()
 
   /// Visibilities
   active_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
-  
+
   /// Verbosity
   if (verbosity_) {
     G4cout << "Active starts in " << (active_zpos_ - active_length_/2.)/mm
@@ -722,6 +723,8 @@ void Next100FieldCage::BuildLightTube()
 void Next100FieldCage::BuildFieldCage()
 {
   // HDPE cylinder.
+  // It is placed in such a way that it ends at the same z
+  // as the teflon buffer reflector, in the side of the EP.
   G4double hdpe_tube_z_pos = teflon_buffer_zpos_ - (hdpe_length_ - teflon_buffer_length_)/2.;
 
   G4Tubs* hdpe_tube_solid =
@@ -756,7 +759,7 @@ void Next100FieldCage::BuildFieldCage()
   G4LogicalVolume* ring_logic =
     new G4LogicalVolume(ring_solid, copper_, "FIELD_RING");
 
-  //Placement of the drift rings.
+  // Placement of the drift rings.
   for (G4int i=0; i<num_drift_rings; i++) {
     posz = first_ring_drift_z_pos + i*drift_ring_dist_;
     new G4PVPlacement(0, G4ThreeVector(0., 0., posz),
@@ -764,7 +767,7 @@ void Next100FieldCage::BuildFieldCage()
                       false, i, false);
   }
 
-  //Placement of the buffer rings.
+  // Placement of the buffer rings.
   for (G4int i=0; i<num_buffer_rings; i++) {
     posz = first_ring_buff_z_pos + i*buffer_ring_dist_;
     new G4PVPlacement(0, G4ThreeVector(0., 0., posz),
@@ -772,7 +775,7 @@ void Next100FieldCage::BuildFieldCage()
                       false, i, false);
   }
 
-  // ring vertex generator
+  // Ring vertex generator
   G4double ring_gen_lenght =   first_ring_buff_z_pos + (num_buffer_rings-1)*buffer_ring_dist_
                              - first_ring_drift_z_pos + ring_thickn_;
   G4double ring_gen_zpos = first_ring_drift_z_pos + ring_gen_lenght/2. - ring_thickn_/2.;
@@ -780,8 +783,11 @@ void Next100FieldCage::BuildFieldCage()
                                            0., twopi, nullptr,
                                            G4ThreeVector(0., 0., ring_gen_zpos));
 
-  // Ring holders.
+  // Ring holders (a.k.a. staves).
+
   // ACTIVE holders.
+  // They are placed in such a way that they begin at the same z position
+  // as the teflon drift reflector, in the side of the TP.
   G4Box* active_short_solid =
     new G4Box("ACT_SHORT", holder_x_/2., holder_short_y_/2.+overlap_/2., active_short_z/2.);
 
@@ -815,6 +821,8 @@ void Next100FieldCage::BuildFieldCage()
     numbering +=1;}
 
   // BUFFER holders.
+  // They are placed in such a way that they end at the same z position
+  // as the teflon buffer reflector, in the side of the EP.
   G4Box* buffer_short_solid =
     new G4Box("BUFF_SHORT", holder_x_/2., holder_short_y_/2.+overlap_/2., buffer_short_z/2.);
 
@@ -859,6 +867,7 @@ void Next100FieldCage::BuildFieldCage()
     numbering +=1;}
 
   // CATHODE holders.
+  // They are placed at the same z position as the cathode ring.
   G4double cathode_long_y = 29.*mm;
   G4double cathode_long_z = 61*mm;
   G4double cathode_short_z = 24.5*mm;

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -7,6 +7,7 @@
 // ----------------------------------------------------------------------------
 
 #include "Next100FieldCage.h"
+#include "Next100Stave.h"
 #include "MaterialsList.h"
 #include "Visibilities.h"
 #include "IonizationSD.h"
@@ -79,10 +80,11 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   ring_int_diam_ (1014. * mm),
   ring_thickn_   (10. * mm),
   drift_ring_dist_  (24. * mm),
-  buffer_ring_dist_ (48. * mm),
-  holder_x_         (60. * mm),  //x dimension of the holders
-  holder_long_y_    (9.1 * mm), //(9.  * mm),  // y dim of the base of the ring holders
-  holder_short_y_   (33.9 * mm), //(33.15 * mm),// y dim of the pieces added over the base of the ring holders
+  buffer_ring_dist_ (48. * mm), // distance between buffer rings
+  buffer_first_ring_dist_ (69. * mm), // distance of first ring from end of the stave
+  ring_drift_buffer_dist_ (72. * mm), // distance between last ring of buffer and first ring of drift part.
+  num_drift_rings_ (48),
+  num_buffer_rings_ (4),
 
   tpb_thickn_ (1 * micrometer),
   overlap_    (0.001*mm), //defined for G4UnionSolids to ensure a common volume within the two joined solids
@@ -211,9 +213,6 @@ void Next100FieldCage::Construct()
   active_length_ = gate_cathode_dist_;
   buffer_length_ = gate_sapphire_wdw_dist_ - gate_cathode_dist_ - grid_thickn_;
 
-  /// Calculate radial position of the ring holders.
-  holder_r_ = (active_diam_+2.*teflon_thickn_+holder_long_y_)/2.;
-
   /// Calculate relative z positions in mother volume
   /// All of them are calculated from GetELzCoord(), which is the position
   /// of the beginning of the ACTIVE volume and the end of the gate grid.
@@ -256,9 +255,6 @@ void Next100FieldCage::DefineMaterials()
 
   /// High density polyethylene for the field cage
   hdpe_ = materials::HDPE();
-
-  /// PE500 for the holders
-  pe500_ = materials::PE500();
 
   /// Copper for field rings
   copper_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
@@ -743,24 +739,15 @@ void Next100FieldCage::BuildFieldCage()
   G4LogicalVolume* ring_logic =
     new G4LogicalVolume(ring_solid, copper_, "FIELD_RING");
 
-  G4double buffer_short_z = 37. * mm; // Thickness of holders in the buffer volume.
-  // Distance between the last ring of the buffer and the first ring of the drift part.
-  G4double ring_drift_buffer_dist = 72. * mm;
-  G4int    num_drift_rings = 48;
-  G4int    num_buffer_rings = 4;
-
 
   // Placement of the buffer rings, in such a way that the holder ends
   // at the same z position as the teflon buffer reflector.
-  // The placements go from higher to lower z.
-
-  // Distance of first ring from the end of the stave.
-  G4double buffer_first_ring_dist = 69. * mm;
+  // The placements go from higher to lower z.  
   G4double first_ring_buff_z_pos =
-    teflon_buffer_zpos_ + teflon_buffer_length_/2. - buffer_first_ring_dist;
+    teflon_buffer_zpos_ + teflon_buffer_length_/2. - buffer_first_ring_dist_;
 
   G4double posz;
-  for (G4int i=0; i<num_buffer_rings; i++) {
+  for (G4int i=0; i<num_buffer_rings_; i++) {
     posz = first_ring_buff_z_pos - i*buffer_ring_dist_;
     new G4PVPlacement(0, G4ThreeVector(0., 0., posz),
                       ring_logic, "FIELD_RING", mother_logic_,
@@ -768,8 +755,8 @@ void Next100FieldCage::BuildFieldCage()
   }
 
   // Placement of the drift rings.
-  G4double first_ring_drift_z_pos = posz - ring_drift_buffer_dist;
-  for (G4int i=0; i<num_drift_rings; i++) {
+  G4double first_ring_drift_z_pos = posz - ring_drift_buffer_dist_;
+  for (G4int i=0; i<num_drift_rings_; i++) {
     posz = first_ring_drift_z_pos - i*drift_ring_dist_;
     new G4PVPlacement(0, G4ThreeVector(0., 0., posz),
                       ring_logic, "FIELD_RING", mother_logic_,
@@ -783,159 +770,47 @@ void Next100FieldCage::BuildFieldCage()
                                            0., twopi, nullptr,
                                            G4ThreeVector(0., 0., ring_gen_zpos));
 
-  // Ring holders (a.k.a. staves).
-  G4double cathode_opening = 15.5 * mm;
+  // Ring holders (a.k.a. staves)
 
-  // BUFFER holders.
   // They are placed in such a way that they end at the same z position
   // as the teflon buffer reflector, in the side of the EP.
-  // The unions of volumes go from lower to higher z.
-  G4double buffer_long_length = 241.3 * mm;
-  G4Box* buffer_short_solid =
-    new G4Box("BUFF_SHORT", holder_x_/2., holder_short_y_/2.+overlap_/2., buffer_short_z/2.);
+  Next100Stave stave = Next100Stave(ring_drift_buffer_dist_, num_drift_rings_, num_buffer_rings_);
+  stave.Construct();
+  G4LogicalVolume* stave_logic = stave.GetLogicalVolume();
 
-  G4Box* buffer_long_solid =
-    new G4Box("BUFF_LONG", holder_x_/2., holder_long_y_/2., buffer_long_length/2.);
+  G4double holder_long_y      = stave.GetHolderLongY();
+  G4double holder_short_y     = stave.GetHolderShortY();
+  G4double cathode_long_y     = stave.GetCathodeLongY();
+  G4double buffer_long_length = stave.GetBufferLongLength();
+  G4double cathode_opening    = stave.GetCathodeOpening();
 
-  G4double first_buff_short_z = -buffer_long_length/2. +
-    (ring_drift_buffer_dist/2.-cathode_opening/2.) + buffer_ring_dist_/2.;
-
-  G4UnionSolid* buff_holder_solid =
-    new G4UnionSolid ("BUFF_HOLDER", buffer_long_solid, buffer_short_solid, 0,
-                      G4ThreeVector(0.,holder_long_y_/2.+holder_short_y_/2.-overlap_/2.,
-                                    first_buff_short_z));
-
-  for (G4int j=1; j<num_buffer_rings-1; j++) {
-    posz = first_buff_short_z + j*buffer_ring_dist_;
-
-    buff_holder_solid =
-      new G4UnionSolid("BUFF_HOLDER", buff_holder_solid, buffer_short_solid, 0,
-                       G4ThreeVector(0.,holder_long_y_/2.+holder_short_y_/2.-overlap_/2.,posz));
-    }
-
-  G4double buffer_last_z  = 63.5 *mm;
-  G4Box* buffer_last_solid =
-    new G4Box("BUFF_LAST", holder_x_/2., holder_short_y_/2.+overlap_/2., buffer_last_z/2.);
-
-  buff_holder_solid =
-    new G4UnionSolid("BUFF_HOLDER", buff_holder_solid, buffer_last_solid, 0,
-                     G4ThreeVector(0.,holder_long_y_/2. + holder_short_y_/2.-overlap_/2.,
-                                   teflon_buffer_length_/2. - buffer_last_z/2.));
-
-  G4LogicalVolume* buff_holder_logic =
-    new G4LogicalVolume(buff_holder_solid, pe500_, "BUFF_HOLDER");
-
-  G4double stave_buffer_zpos =
-    teflon_buffer_zpos_ + teflon_buffer_length_/2. - buffer_long_length/2.;
+  G4double stave_r =
+    active_diam_/2. + teflon_thickn_ + holder_long_y + holder_short_y - cathode_long_y/2.;
+  G4double stave_zpos =
+    teflon_buffer_zpos_ + teflon_buffer_length_/2. - buffer_long_length - cathode_opening/2.;
 
   G4int numbering = 0;
   for (G4int i=10; i<360; i +=20){
     G4RotationMatrix* rot = new G4RotationMatrix();
     rot -> rotateZ((90-i) * deg);
-    new G4PVPlacement(rot, G4ThreeVector(holder_r_*cos(i*deg), holder_r_*sin(i*deg),
-                      stave_buffer_zpos), buff_holder_logic, "BUFF_HOLDER", mother_logic_,
+    new G4PVPlacement(rot, G4ThreeVector(stave_r*cos(i*deg), stave_r *sin(i*deg),
+                      stave_zpos), stave_logic, "STAVE", mother_logic_,
                       false, numbering, false);
     numbering +=1;
   }
 
-  // ACTIVE holders.
-  G4double active_long_length = 1170.2 * mm;
-  G4double active_short_first_length = 8.5 * mm; // Thickness of first holder in the active volume.
-  G4double active_short_length = 13. * mm; // Thickness of holders in the active volume.
-  G4Box* active_short_first_solid =
-    new G4Box("ACT_SHORT", holder_x_/2., holder_short_y_/2.+overlap_/2., active_short_first_length/2.);
-
-  G4double first_act_short_z = -active_long_length/2. + active_short_first_length/2.;
-
-  G4Box* active_long_solid =
-    new G4Box("ACT_LONG", holder_x_/2., holder_long_y_/2., active_long_length/2.);
-
-  G4UnionSolid* act_holder_solid =
-    new G4UnionSolid ("ACT_HOLDER", active_long_solid, active_short_first_solid, 0,
-                      G4ThreeVector(0., holder_long_y_/2.+holder_short_y_/2.-overlap_/2.,
-                                    first_act_short_z));
-
-  G4Box* active_short_solid =
-    new G4Box("ACT_SHORT", holder_x_/2., holder_short_y_/2.+overlap_/2., active_short_length/2.);
-
-  for (G4int j=0; j<num_drift_rings-1; j++) {
-    posz = -active_long_length/2. + active_short_first_length + drift_ring_dist_ -
-      active_short_length /2 + j*drift_ring_dist_;
-
-    act_holder_solid =
-      new G4UnionSolid("ACT_HOLDER", act_holder_solid, active_short_solid, 0,
-                       G4ThreeVector(0.,holder_long_y_/2.+holder_short_y_/2.-overlap_/2., posz));
-    }
-
-  G4LogicalVolume* act_holder_logic =
-    new G4LogicalVolume(act_holder_solid, pe500_, "ACT_HOLDER");
-
-  // It is placed relatively to the buffer and the cathode holders
-  G4double stave_drift_zpos =
-    stave_buffer_zpos - buffer_long_length/2. - cathode_opening - active_long_length/2.;
-
-  numbering = 0;
-  for (G4int i=10; i<360; i +=20){
-    G4RotationMatrix* rot = new G4RotationMatrix();
-    rot -> rotateZ((90-i) *deg);
-    new G4PVPlacement(rot,G4ThreeVector(holder_r_*cos(i*deg),holder_r_*sin(i*deg), stave_drift_zpos),
-                      act_holder_logic, "ACT_HOLDER", mother_logic_,
-                      false, numbering, false);
-    numbering +=1;
-  }
-
-
-  // CATHODE holders.
-  // They are placed at the same z position as the cathode ring.
-  G4double cathode_long_y = 28.15 * mm;// 29.*mm (previous) - 0.85 * mm (what has been removed);
-  G4double cathode_long_length = 61 * mm;
-  G4double cathode_short_length = 22.75 * mm; // 24.5*mm
-  G4Box* cathode_large_solid =
-    new G4Box("CATHODE_LARGE", holder_x_/2., cathode_long_y/2., cathode_long_length/2.);
-
-  G4Box* cathode_short_solid =
-    new G4Box("CATHODE_SHORT", holder_x_/2., holder_short_y_/2., cathode_short_length/2.);
-
-  G4UnionSolid* cathode_holder_solid =
-    new G4UnionSolid ("CATHODE_HOLDER", cathode_large_solid, cathode_short_solid, 0,
-                      G4ThreeVector(0.,-(holder_short_y_/2.-cathode_long_y/2),
-                                    cathode_long_length/2.-cathode_short_length/2.));
-
-  cathode_holder_solid =
-    new G4UnionSolid("CATHODE_HOLDER", cathode_holder_solid, cathode_short_solid, 0,
-                      G4ThreeVector(0.,-(holder_short_y_/2.-cathode_long_y/2),
-                                    -(cathode_long_length/2.-cathode_short_length/2.)));
-
-  G4LogicalVolume* cathode_holder_logic =
-    new G4LogicalVolume(cathode_holder_solid, pe500_, "CATHODE_HOLDER");
-
-  numbering=0;
-  G4double cathode_holder_r = (active_diam_+2*teflon_thickn_+ 2*holder_long_y_+
-                              2*holder_short_y_)/2.-cathode_long_y/2.;
-  G4double cathode_holder_zpos =
-    stave_buffer_zpos - buffer_long_length/2. - cathode_opening/2.;
-  for (G4int i=10; i<360; i +=20){
-    G4RotationMatrix* rot = new G4RotationMatrix();
-    rot -> rotateZ((90-i) *deg);
-    new G4PVPlacement(rot, G4ThreeVector(cathode_holder_r*cos(i*deg), cathode_holder_r*sin(i*deg),
-                      cathode_holder_zpos), cathode_holder_logic, "CATHODE_HOLDER", mother_logic_,
-                      false, numbering, false);
-    numbering +=1;
-  }
-
-  G4double total_stave_length = buffer_long_length + active_long_length + cathode_opening;
-  assert(total_stave_length == 1427. * mm);
-  G4double holder_gen_zpos =
-    (buffer_long_length*stave_buffer_zpos + active_long_length*stave_drift_zpos +
-     cathode_opening*cathode_zpos_)/total_stave_length;
-
+  // Stave vertex generator
+  // Length is approximated to avoid complicated calculations.
+  // The correct positioning of vertices is checked at run time anyway.
+  G4double stave_gen_length =
+    teflon_buffer_zpos_ - GetELzCoord() + teflon_buffer_length_/2;
   holder_gen_ =
-    new CylinderPointSampler2020(holder_r_ - holder_long_y_/2.,
-                                 holder_r_ + holder_long_y_/2. + holder_short_y_,
-                                 total_stave_length/2., 0., twopi, nullptr,
-                                 G4ThreeVector(0., 0., holder_gen_zpos));
+    new CylinderPointSampler2020(active_diam_/2. + teflon_thickn_ ,
+                                 active_diam_/2. + teflon_thickn_ + holder_long_y + holder_short_y,
+                                 stave_gen_length/2., 0., twopi, nullptr,
+                                 G4ThreeVector(0., 0., GetELzCoord() + stave_gen_length/2.));
 
-  /// Visibilities
+   /// Visibilities
   if (visibility_) {
     G4VisAttributes ring_col = nexus::CopperBrown();
     ring_col.SetForceSolid(true);
@@ -943,19 +818,13 @@ void Next100FieldCage::BuildFieldCage()
     G4VisAttributes hdpe_col =nexus::WhiteAlpha();
     hdpe_col.SetForceSolid(true);
     hdpe_tube_logic->SetVisAttributes(hdpe_col);
-    G4VisAttributes hold_col = nexus::LightGrey();
-    hold_col.SetForceSolid(true);
-    G4VisAttributes hold_col_cath = nexus::Lilla();
-    hold_col_cath.SetForceSolid(true);
-    act_holder_logic->SetVisAttributes(hold_col);
-    buff_holder_logic->SetVisAttributes(hold_col);
-    cathode_holder_logic->SetVisAttributes(hold_col_cath);
+    G4VisAttributes stave_col = nexus::LightGrey();
+    stave_col.SetForceSolid(true);
+    stave_logic->SetVisAttributes(stave_col);
   } else {
     ring_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
     hdpe_tube_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
-    act_holder_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
-    buff_holder_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
-    cathode_holder_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
+    stave_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
   }
 }
 
@@ -1079,9 +948,7 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
       glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
       VertexVolume =
         geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
-    } while ((VertexVolume->GetName() != "ACT_HOLDER")  &&
-             (VertexVolume->GetName() != "BUFF_HOLDER") &&
-             (VertexVolume->GetName() != "CATHODE_HOLDER"));
+    } while (VertexVolume->GetName() != "STAVE");
  }
 
   else {

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -41,7 +41,7 @@
 using namespace nexus;
 
 
-Next100FieldCage::Next100FieldCage():
+Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   GeometryBase(),
   // Dimensions
   active_diam_         (984. * mm), // distance between the centers of two opposite panels
@@ -50,7 +50,7 @@ Next100FieldCage::Next100FieldCage():
   cathode_ext_diam_    (1020.* mm),
   cathode_thickn_      (10.  * mm),
   // Caution: updating grid-thickn_ will require updating gate-tp and gate-sapphire-window distances
-  grid_thickn_         (0.1  * mm),
+  grid_thickn_         (grid_thickn),
 
   teflon_drift_length_ (1178.*mm), //distance from the gate to the beginning of the cathode volume.
   teflon_total_length_ (1431. * mm),

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -284,34 +284,24 @@ void Next100FieldCage::BuildActive()
 {
   /// Position of z planes
   G4double zplane[2] = {-active_length_/2. + gate_teflon_dist_ - overlap_,
-                         active_length_/2.-(cathode_thickn_-grid_thickn_)/2.};
+                         active_length_/2.};
   /// Inner radius
   G4double rinner[2] = {0., 0.};
   /// Outer radius
   G4double router[2] = {active_diam_/2., active_diam_/2.};
 
   G4Polyhedra* active_solid =
-    new G4Polyhedra("ACTIVE_POLY", 0., twopi, n_panels_, 2, zplane, rinner, router);
-
-  G4Tubs* active_cathode_solid =
-    new G4Tubs("ACT_CATHODE_RING", 0, cathode_int_diam_/2.,
-              ((cathode_thickn_ - grid_thickn_)/2. + overlap_)/2., 0, twopi);
-
-  G4ThreeVector act_cathode_pos =
-  G4ThreeVector(0., 0., active_length_/2.-((cathode_thickn_ - grid_thickn_)/2.)/2. - overlap_/2.);
-
-  G4UnionSolid* union_active =
-    new G4UnionSolid ("ACTIVE", active_solid, active_cathode_solid, 0, act_cathode_pos);
+    new G4Polyhedra("ACTIVE_TEFLON", 0., twopi, n_panels_, 2, zplane, rinner, router);
 
   //This volume is added as an extension of the active volume that reaches the gate grid.
   G4Tubs* active_gate_solid =
     new G4Tubs("ACT_GATE_GAS", 0, gate_int_diam_/2., gate_teflon_dist_/2., 0, twopi);
 
   G4ThreeVector act_gate_pos =
-  G4ThreeVector(0., 0., -active_length_/2.+ gate_teflon_dist_/2.);
+    G4ThreeVector(0., 0., -active_length_/2. + gate_teflon_dist_/2.);
 
-  union_active =
-    new G4UnionSolid ("ACTIVE", union_active, active_gate_solid, 0, act_gate_pos);
+  G4UnionSolid* union_active =
+    new G4UnionSolid ("ACTIVE", active_solid, active_gate_solid, 0, act_gate_pos);
 
   G4LogicalVolume* active_logic =
     new G4LogicalVolume(union_active, gas_, "ACTIVE");
@@ -878,7 +868,7 @@ void Next100FieldCage::BuildFieldCage()
   G4LogicalVolume* act_holder_logic =
     new G4LogicalVolume(act_holder_solid, pe500_, "ACT_HOLDER");
 
-  // It is placed relatively to the buffer and the cathode holder holders.
+  // It is placed relatively to the buffer and the cathode holders
   G4double stave_drift_zpos =
     stave_buffer_zpos - buffer_long_length/2. - cathode_opening - active_long_length/2.;
 

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -48,7 +48,7 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   // Dimensions
   active_diam_         (984. * mm), // distance between the centers of two opposite panels
 
-  cathode_int_diam_    (960. * mm),
+  cathode_int_diam_    (965. * mm),
   cathode_ext_diam_    (1020.* mm),
   cathode_thickn_      (10.  * mm),
   // Caution: updating grid-thickn_ will require updating gate-tp and gate-sapphire-window distances
@@ -63,10 +63,10 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
 
   el_gap_length_ (9.7 * mm),
 
-  gate_teflon_dist_ (10.2 * mm - grid_thickn_), //distance from gate-grid to teflon
-  gate_ext_diam_    (1042. * mm), //preliminary
-  gate_int_diam_    (1009. * mm), //preliminary
-  gate_ring_thickn_ (9.9   * mm), // maximum possible value to avoid overlap with sipm board masks
+  gate_ext_diam_    (1050. * mm),
+  gate_int_diam_    (995. * mm),
+  gate_ring_thickn_ (13.5   * mm),
+  gate_teflon_dist_ (.5*mm + gate_ring_thickn_ - grid_thickn_), //(10.2 * mm - grid_thickn_), //distance from gate-grid to teflon (its seems that gate ring and teflon are almost touching
 
   // external to teflon (hdpe + rings + holders)
   hdpe_tube_int_diam_ (1093. * mm),
@@ -293,7 +293,7 @@ void Next100FieldCage::BuildActive()
   G4Polyhedra* active_solid =
     new G4Polyhedra("ACTIVE_TEFLON", 0., twopi, n_panels_, 2, zplane, rinner, router);
 
-  //This volume is added as an extension of the active volume that reaches the gate grid.
+  // This volume is added as an extension of the active volume that reaches the gate grid.
   G4Tubs* active_gate_solid =
     new G4Tubs("ACT_GATE_GAS", 0, gate_int_diam_/2., gate_teflon_dist_/2., 0, twopi);
 

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -502,13 +502,19 @@ void Next100FieldCage::BuildELRegion()
                     false, 0, false);
 
   /// ANODE ring.
+  // We simulate a thinner ring to avoid cutting the teflon masks,
+  // which would overlap with it. 4.7 mm is the difference between
+  // the thickness of sipm board+mask (6.2 mm) and the real distance
+  // between the anode ring and the TP, measured by Jordi (1.5 mm).
+  G4double anode_ring_thickn = gate_ring_thickn_ - 4.7 * mm;
   G4Tubs* anode_solid =
-    new G4Tubs("ANODE_RING", gate_int_diam_/2., gate_ext_diam_/2., gate_ring_thickn_/2., 0, twopi);
+    new G4Tubs("ANODE_RING", gate_int_diam_/2., gate_ext_diam_/2., anode_ring_thickn/2., 0, twopi);
 
   G4LogicalVolume* anode_logic =
     new G4LogicalVolume(anode_solid, steel_, "ANODE_RING");
 
-  new G4PVPlacement(0, G4ThreeVector(0., 0., anode_zpos_),
+  G4double anode_sim_zpos = el_gap_zpos_ - el_gap_length_/2. - anode_ring_thickn/2.;
+  new G4PVPlacement(0, G4ThreeVector(0., 0., anode_sim_zpos),
                     anode_logic, "ANODE_RING", mother_logic_,
                     false, 0, false);
 

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -47,6 +47,8 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   GeometryBase(),
   // Dimensions
   active_diam_         (984. * mm), // distance between the centers of two opposite panels
+  n_panels_            (18),
+  active_ext_radius_   (active_diam_/2. / cos(pi/n_panels_)),
 
   cathode_int_diam_    (965. * mm),
   cathode_ext_diam_    (1020.* mm),
@@ -57,7 +59,6 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   teflon_long_length_   (465. * mm),
   teflon_buffer_length_ (241. * mm),
   teflon_thickn_       (5. * mm),
-  n_panels_            (18),
 
   el_gap_length_ (10. * mm),
 
@@ -333,12 +334,10 @@ void Next100FieldCage::BuildActive()
   drift_region->SetUserInformation(field);
   drift_region->AddRootLogicalVolume(active_logic);
 
-
   /// Vertex generator
-  active_gen_ = new CylinderPointSampler2020(0., active_diam_/2., active_length_/2.,
+  active_gen_ = new CylinderPointSampler2020(0., active_ext_radius_, active_length_/2.,
                                              0., twopi, nullptr,
                                              G4ThreeVector(0., 0., active_zpos_));
-
 
   /// Visibilities
   active_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
@@ -451,8 +450,7 @@ void Next100FieldCage::BuildBuffer()
 
 
   /// Vertex generator
-  G4double active_ext_radius = active_diam_/2. / cos(pi/n_panels_);
-  buffer_gen_ = new CylinderPointSampler2020(0., active_ext_radius, buffer_length_/2.,
+  buffer_gen_ = new CylinderPointSampler2020(0., active_ext_radius_, buffer_length_/2.,
                                              0., twopi, nullptr,
                                              G4ThreeVector(0., 0., buffer_zpos));
 
@@ -463,7 +461,7 @@ void Next100FieldCage::BuildBuffer()
                           active_length_ * active_zpos_ +
                           grid_thickn_ * cathode_zpos_ +
                           buffer_length_ * buffer_zpos) / xenon_length;
-  xenon_gen_ = new CylinderPointSampler2020(0., active_ext_radius, xenon_length,
+  xenon_gen_ = new CylinderPointSampler2020(0., active_ext_radius_, xenon_length,
                                             0., twopi, nullptr,
                                             G4ThreeVector(0., 0., xenon_zpos));
 

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -66,7 +66,7 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   gate_int_diam_    (995. * mm),
   gate_ring_thickn_ (13.5   * mm),
 
-  gate_teflon_dist_         (.5 * mm + gate_ring_thickn_ - grid_thickn_), //distance from gate-grid to teflon (it seems that gate ring and teflon are almost touching)
+  gate_teflon_dist_         (0.7 * mm + gate_ring_thickn_ - grid_thickn_), //distance from gate-grid to teflon
   gate_cathode_dist_        (1174. * mm + gate_ring_thickn_ - grid_thickn_),
   // cathode_sapphire_wdw_dist_(257.8 * mm),
 

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -990,14 +990,7 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
   }
 
   else if (region == "CATHODE_RING") {
-    G4VPhysicalVolume *VertexVolume;
-    do {
-      vertex = cathode_gen_->GenerateVertex("VOLUME");
-      G4ThreeVector glob_vtx(vertex);
-      glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
-      VertexVolume =
-        geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
-    } while (VertexVolume->GetName() != region);
+    vertex = cathode_gen_->GenerateVertex("VOLUME");
   }
 
   else if (region == "BUFFER") {
@@ -1039,14 +1032,7 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
   }
 
   else if (region == "HDPE_TUBE") {
-    G4VPhysicalVolume *VertexVolume;
-    do {
-      vertex = hdpe_gen_->GenerateVertex("VOLUME");
-      G4ThreeVector glob_vtx(vertex);
-      glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
-      VertexVolume =
-        geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
-    } while (VertexVolume->GetName() != region);
+    vertex = hdpe_gen_->GenerateVertex("VOLUME");
   }
 
   else if (region == "EL_GAP") {
@@ -1072,25 +1058,11 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
   }
 
   else if (region == "GATE_RING") {
-    G4VPhysicalVolume *VertexVolume;
-    do {
-      vertex = gate_gen_->GenerateVertex("VOLUME");
-      G4ThreeVector glob_vtx(vertex);
-      glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
-      VertexVolume =
-        geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
-    } while (VertexVolume->GetName() != region);
+    vertex = gate_gen_->GenerateVertex("VOLUME");
   }
 
   else if (region == "ANODE_RING") {
-    G4VPhysicalVolume *VertexVolume;
-    do {
-      vertex = anode_gen_->GenerateVertex("VOLUME");
-      G4ThreeVector glob_vtx(vertex);
-      glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
-      VertexVolume =
-        geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
-    } while (VertexVolume->GetName() != region);
+    vertex = anode_gen_->GenerateVertex("VOLUME");
   }
 
   else if (region == "RING_HOLDER"){

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -221,7 +221,6 @@ void Next100FieldCage::Construct()
   cathode_zpos_    = GetELzCoord() + gate_cathode_dist_ + cathode_thickn_/2.;
   gate_zpos_       = GetELzCoord() - grid_thickn_ + gate_ring_thickn_/2.;
   el_gap_zpos_     = GetELzCoord() - grid_thickn_ - el_gap_length_/2.;
-  anode_zpos_      = el_gap_zpos_ - el_gap_length_/2. - gate_ring_thickn_/2.;
   anode_grid_zpos_ = el_gap_zpos_ - el_gap_length_/2. - grid_thickn_/2.;
 
   teflon_drift_zpos_  = GetELzCoord() + gate_teflon_dist_ + teflon_drift_length_/2.;
@@ -572,8 +571,8 @@ void Next100FieldCage::BuildELRegion()
   gate_gen_ = new CylinderPointSampler2020(gate_int_diam_/2., gate_ext_diam_/2., gate_ring_thickn_/2.,
                                            0., twopi, nullptr, G4ThreeVector(0., 0., gate_zpos_));
   // Anode ring vertex generator
-  anode_gen_ = new CylinderPointSampler2020(gate_int_diam_/2., gate_ext_diam_/2., gate_ring_thickn_/2.,
-                                            0., twopi, nullptr, G4ThreeVector(0., 0., anode_zpos_));
+  anode_gen_ = new CylinderPointSampler2020(gate_int_diam_/2., gate_ext_diam_/2.,anode_ring_thickn/2.,
+                                            0., twopi, nullptr, G4ThreeVector(0., 0., anode_sim_zpos));
 
   /// Visibilities
   if (visibility_) {

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -686,13 +686,10 @@ void Next100FieldCage::BuildLightTube()
 
   // Vertex generator
   G4double teflon_ext_radius = (active_diam_ + 2.*teflon_thickn_)/2. / cos(pi/n_panels_);
-  G4double cathode_gap_zpos  = teflon_drift_zpos_ + teflon_drift_length_/2. + cathode_thickn_/2.;
-  G4double teflon_zpos = (teflon_drift_length_ * teflon_drift_zpos_ +
-                         cathode_thickn_ * cathode_gap_zpos +
-                         teflon_buffer_length_ * teflon_buffer_zpos_) / teflon_total_length_;
+  G4double teflon_zpos       = GetELzCoord() + gate_sapphire_wdw_dist_/2.;
 
   teflon_gen_ = new CylinderPointSampler2020(active_diam_/2., teflon_ext_radius,
-                                             teflon_total_length_/2., 0., twopi,
+                                             gate_sapphire_wdw_dist_/2., 0., twopi,
                                              nullptr, G4ThreeVector (0., 0., teflon_zpos));
 
   // Visibilities

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -208,16 +208,18 @@ void Next100FieldCage::Construct()
   /// Calculate radial position of the ring holders.
   holder_r_ = (active_diam_+2.*teflon_thickn_+holder_long_y_)/2.;
 
-  /// Calculate relative positions in mother volume
+  /// Calculate relative z positions in mother volume
+  /// All of them are calculated from GetELzCoord(), which is the position
+  /// of the beginning of the ACTIVE volume and the end of the gate grid.
   gate_grid_zpos_  = GetELzCoord() - grid_thickn_/2.;
-  active_zpos_     = gate_grid_zpos_ + grid_thickn_/2. + active_length_/2.;
-  cathode_zpos_    = gate_grid_zpos_ + grid_thickn_/2. + active_length_ + grid_thickn_/2.;
-  gate_zpos_       = gate_grid_zpos_ + grid_thickn_/2. + gate_ring_thickn_/2. - grid_thickn_;
-  el_gap_zpos_     = gate_grid_zpos_ - grid_thickn_/2. - el_gap_length_/2.;
+  active_zpos_     = GetELzCoord() + active_length_/2.;
+  cathode_zpos_    = GetELzCoord() + active_length_ + grid_thickn_/2.;
+  gate_zpos_       = GetELzCoord() + gate_ring_thickn_/2. - grid_thickn_;
+  el_gap_zpos_     = GetELzCoord() - grid_thickn_ - el_gap_length_/2.;
   anode_zpos_      = el_gap_zpos_ - el_gap_length_/2. - gate_ring_thickn_/2.;
-  anode_grid_zpos_ = anode_zpos_ + gate_ring_thickn_/2. - grid_thickn_/2.;
+  anode_grid_zpos_ = el_gap_zpos_ - el_gap_length_/2. - grid_thickn_/2.;
 
-  teflon_drift_zpos_  = gate_grid_zpos_ + grid_thickn_/2. + gate_teflon_dist_ + teflon_drift_length_/2.;
+  teflon_drift_zpos_  = GetELzCoord() + gate_teflon_dist_ + teflon_drift_length_/2.;
   teflon_buffer_zpos_ = cathode_zpos_ + cathode_thickn_/2. + teflon_buffer_length_/2.;
 
   if (verbosity_) {

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -53,10 +53,9 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   cathode_thickn_      (13.5  * mm),
   grid_thickn_         (grid_thickn),
 
-  //  teflon_drift_length_ (1178.*mm), //distance from the gate to the beginning of the cathode volume.
-  teflon_long_length_   (467.5 * mm), //(465. * mm), from drawings
-  teflon_buffer_length_ (243. * mm), //(241. * mm), from drawings
-  // teflon_total_length_ (1431. * mm),
+  //  teflon_drift_length_ (1178.*mm), //distance from the gate to the beginning of the cathode volume
+  teflon_long_length_   (465. * mm),
+  teflon_buffer_length_ (241. * mm),
   teflon_thickn_       (5. * mm),
   n_panels_            (18),
 
@@ -65,7 +64,10 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   gate_ext_diam_    (1050. * mm),
   gate_int_diam_    (995. * mm),
   gate_ring_thickn_ (13.5   * mm),
-  gate_teflon_dist_ (.5*mm + gate_ring_thickn_ - grid_thickn_), //(10.2 * mm - grid_thickn_), //distance from gate-grid to teflon (its seems that gate ring and teflon are almost touching
+
+  gate_teflon_dist_         (.5 * mm + gate_ring_thickn_ - grid_thickn_), //distance from gate-grid to teflon (it seems that gate ring and teflon are almost touching)
+  gate_cathode_dist_        (1174. * mm + gate_ring_thickn_ - grid_thickn_),
+  // cathode_sapphire_wdw_dist_(257.8 * mm),
 
   // external to teflon (hdpe + rings + holders)
   hdpe_tube_int_diam_ (1093. * mm),
@@ -201,13 +203,12 @@ void Next100FieldCage::SetMotherPhysicalVolume(G4VPhysicalVolume* mother_phys)
 
 void Next100FieldCage::Construct()
 {
-  /// Calculate different lengths of teflon
+  /// Calculate drift lengths of teflon
   teflon_drift_length_ = 2 * teflon_long_length_ + teflon_buffer_length_;
-  teflon_total_length_ = teflon_drift_length_ + cathode_thickn_ + teflon_buffer_length_;
 
   /// Calculate lengths of active and buffer regions
-  active_length_ = gate_teflon_dist_ + teflon_drift_length_;
-  buffer_length_ = gate_sapphire_wdw_dist_ - active_length_ - grid_thickn_;
+  active_length_ = gate_cathode_dist_;
+  buffer_length_ = gate_sapphire_wdw_dist_ - gate_cathode_dist_ - grid_thickn_;
 
   /// Calculate radial position of the ring holders.
   holder_r_ = (active_diam_+2.*teflon_thickn_+holder_long_y_)/2.;
@@ -217,14 +218,15 @@ void Next100FieldCage::Construct()
   /// of the beginning of the ACTIVE volume and the end of the gate grid.
   gate_grid_zpos_  = GetELzCoord() - grid_thickn_/2.;
   active_zpos_     = GetELzCoord() + active_length_/2.;
-  cathode_zpos_    = GetELzCoord() + active_length_ + cathode_thickn_/2.;
+  cathode_zpos_    = GetELzCoord() + gate_cathode_dist_ + cathode_thickn_/2.;
   gate_zpos_       = GetELzCoord() - grid_thickn_ + gate_ring_thickn_/2.;
   el_gap_zpos_     = GetELzCoord() - grid_thickn_ - el_gap_length_/2.;
   anode_zpos_      = el_gap_zpos_ - el_gap_length_/2. - gate_ring_thickn_/2.;
   anode_grid_zpos_ = el_gap_zpos_ - el_gap_length_/2. - grid_thickn_/2.;
 
   teflon_drift_zpos_  = GetELzCoord() + gate_teflon_dist_ + teflon_drift_length_/2.;
-  teflon_buffer_zpos_ = cathode_zpos_ + cathode_thickn_/2. + teflon_buffer_length_/2.;
+  // 15.6 mm = value used to obtain 24.8 mm as EP plate-teflon distance
+  teflon_buffer_zpos_ = GetELzCoord() + gate_sapphire_wdw_dist_ - 15.6*mm - teflon_buffer_length_/2.;
 
   if (verbosity_) {
     G4cout << "Active length = " << active_length_/mm << " mm" << G4endl;

--- a/source/geometries/Next100FieldCage.h
+++ b/source/geometries/Next100FieldCage.h
@@ -26,7 +26,7 @@ namespace nexus {
   class Next100FieldCage: public GeometryBase
   {
   public:
-    Next100FieldCage();
+    Next100FieldCage(G4double grid_thickn);
     ~Next100FieldCage();
     void Construct() override;
     G4ThreeVector GenerateVertex(const G4String& region) const override;

--- a/source/geometries/Next100FieldCage.h
+++ b/source/geometries/Next100FieldCage.h
@@ -83,7 +83,7 @@ namespace nexus {
 
     G4double active_length_, buffer_length_;
     G4double teflon_drift_length_, teflon_drift_zpos_,teflon_buffer_zpos_;
-    G4double active_zpos_, cathode_zpos_, gate_zpos_, el_gap_zpos_, anode_zpos_;
+    G4double active_zpos_, cathode_zpos_, gate_zpos_, el_gap_zpos_;
     G4double gate_grid_zpos_, anode_grid_zpos_;
 
 

--- a/source/geometries/Next100FieldCage.h
+++ b/source/geometries/Next100FieldCage.h
@@ -53,7 +53,8 @@ namespace nexus {
     const G4double teflon_long_length_, teflon_buffer_length_;
     const G4double teflon_thickn_, n_panels_;
     const G4double el_gap_length_;
-    const G4double gate_teflon_dist_, gate_ext_diam_, gate_int_diam_, gate_ring_thickn_;
+    const G4double gate_ext_diam_, gate_int_diam_, gate_ring_thickn_;
+    const G4double gate_teflon_dist_;
     const G4double hdpe_tube_int_diam_, hdpe_tube_ext_diam_, hdpe_length_;
     const G4double ring_ext_diam_, ring_int_diam_, ring_thickn_, drift_ring_dist_, buffer_ring_dist_;
     const G4double holder_x_, holder_long_y_, holder_short_y_;

--- a/source/geometries/Next100FieldCage.h
+++ b/source/geometries/Next100FieldCage.h
@@ -56,8 +56,10 @@ namespace nexus {
     const G4double gate_ext_diam_, gate_int_diam_, gate_ring_thickn_;
     const G4double gate_teflon_dist_, gate_cathode_dist_; //cathode_sapphire_wdw_dist_;
     const G4double hdpe_tube_int_diam_, hdpe_tube_ext_diam_, hdpe_length_;
-    const G4double ring_ext_diam_, ring_int_diam_, ring_thickn_, drift_ring_dist_, buffer_ring_dist_;
-    const G4double holder_x_, holder_long_y_, holder_short_y_;
+    const G4double ring_ext_diam_, ring_int_diam_, ring_thickn_;
+    const G4double drift_ring_dist_, buffer_ring_dist_;
+    const G4double buffer_first_ring_dist_, ring_drift_buffer_dist_;
+    const G4int num_drift_rings_, num_buffer_rings_;
     const G4double tpb_thickn_;
     const G4double overlap_;
 
@@ -81,7 +83,6 @@ namespace nexus {
 
     G4double active_length_, buffer_length_;
     G4double teflon_drift_length_, teflon_drift_zpos_,teflon_buffer_zpos_;
-    G4double holder_r_;
     G4double active_zpos_, cathode_zpos_, gate_zpos_, el_gap_zpos_, anode_zpos_;
     G4double gate_grid_zpos_, anode_grid_zpos_;
 
@@ -116,7 +117,6 @@ namespace nexus {
 
     // Pointers to materials definition
     G4Material* hdpe_;
-    G4Material* pe500_;
     G4Material* tpb_;
     G4Material* teflon_;
     G4Material* copper_;

--- a/source/geometries/Next100FieldCage.h
+++ b/source/geometries/Next100FieldCage.h
@@ -48,10 +48,10 @@ namespace nexus {
 
     // Dimensions
     G4double gate_sapphire_wdw_dist_;
-    const G4double active_diam_;
+    const G4double active_diam_, n_panels_, active_ext_radius_;
     const G4double cathode_int_diam_, cathode_ext_diam_, cathode_thickn_, grid_thickn_;
     const G4double teflon_long_length_, teflon_buffer_length_;
-    const G4double teflon_thickn_, n_panels_;
+    const G4double teflon_thickn_;
     const G4double el_gap_length_;
     const G4double gate_ext_diam_, gate_int_diam_, gate_ring_thickn_;
     const G4double gate_teflon_dist_, gate_cathode_dist_; //cathode_sapphire_wdw_dist_;

--- a/source/geometries/Next100FieldCage.h
+++ b/source/geometries/Next100FieldCage.h
@@ -54,7 +54,7 @@ namespace nexus {
     const G4double teflon_thickn_, n_panels_;
     const G4double el_gap_length_;
     const G4double gate_ext_diam_, gate_int_diam_, gate_ring_thickn_;
-    const G4double gate_teflon_dist_;
+    const G4double gate_teflon_dist_, gate_cathode_dist_; //cathode_sapphire_wdw_dist_;
     const G4double hdpe_tube_int_diam_, hdpe_tube_ext_diam_, hdpe_length_;
     const G4double ring_ext_diam_, ring_int_diam_, ring_thickn_, drift_ring_dist_, buffer_ring_dist_;
     const G4double holder_x_, holder_long_y_, holder_short_y_;

--- a/source/geometries/Next100FieldCage.h
+++ b/source/geometries/Next100FieldCage.h
@@ -50,7 +50,8 @@ namespace nexus {
     G4double gate_sapphire_wdw_dist_;
     const G4double active_diam_;
     const G4double cathode_int_diam_, cathode_ext_diam_, cathode_thickn_, grid_thickn_;
-    const G4double teflon_drift_length_, teflon_total_length_, teflon_thickn_, n_panels_;
+    const G4double teflon_long_length_, teflon_buffer_length_;
+    const G4double teflon_thickn_, n_panels_;
     const G4double el_gap_length_;
     const G4double gate_teflon_dist_, gate_ext_diam_, gate_int_diam_, gate_ring_thickn_;
     const G4double hdpe_tube_int_diam_, hdpe_tube_ext_diam_, hdpe_length_;
@@ -78,8 +79,7 @@ namespace nexus {
     G4bool verbosity_;
 
     G4double active_length_, buffer_length_;
-    G4double teflon_buffer_length_;
-    G4double teflon_drift_zpos_,teflon_buffer_zpos_;
+    G4double teflon_drift_length_, teflon_total_length_, teflon_drift_zpos_,teflon_buffer_zpos_;
     G4double holder_r_;
     G4double active_zpos_, cathode_zpos_, gate_zpos_, el_gap_zpos_, anode_zpos_;
     G4double gate_grid_zpos_, anode_grid_zpos_;

--- a/source/geometries/Next100FieldCage.h
+++ b/source/geometries/Next100FieldCage.h
@@ -80,7 +80,7 @@ namespace nexus {
     G4bool verbosity_;
 
     G4double active_length_, buffer_length_;
-    G4double teflon_drift_length_, teflon_total_length_, teflon_drift_zpos_,teflon_buffer_zpos_;
+    G4double teflon_drift_length_, teflon_drift_zpos_,teflon_buffer_zpos_;
     G4double holder_r_;
     G4double active_zpos_, cathode_zpos_, gate_zpos_, el_gap_zpos_, anode_zpos_;
     G4double gate_grid_zpos_, anode_grid_zpos_;

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -54,7 +54,7 @@ namespace nexus {
 
   void Next100Ics::Construct()
   {
-    G4double length = 1468.2 * mm; // (Full length of copper bars) - (copper simulated in TP_COPPER_PLATE)
+    G4double length = 1468. * mm; // (Full length of copper bars) - (copper simulated in TP_COPPER_PLATE)
     // defined for G4UnionSolids to ensure a common volume within the two joined solids
     // and for G4SubtractionSolids to ensure surface subtraction
     G4double offset = 1.* mm;

--- a/source/geometries/Next100InnerElements.cc
+++ b/source/geometries/Next100InnerElements.cc
@@ -25,12 +25,12 @@ using namespace CLHEP;
 namespace nexus {
 
 
-  Next100InnerElements::Next100InnerElements():
+  Next100InnerElements::Next100InnerElements(G4double grid_thickn):
     GeometryBase(),
     mother_logic_(nullptr),
     mother_phys_ (nullptr),
     gas_(nullptr),
-    field_cage_    (new Next100FieldCage()),
+    field_cage_    (new Next100FieldCage(grid_thickn)),
     energy_plane_  (new Next100EnergyPlane()),
     tracking_plane_(new Next100TrackingPlane()),
     msg_(nullptr)

--- a/source/geometries/Next100InnerElements.h
+++ b/source/geometries/Next100InnerElements.h
@@ -31,7 +31,7 @@ namespace nexus {
 
   public:
     ///Constructor
-    Next100InnerElements();
+    Next100InnerElements(G4double grid_thickn);
 
     /// Destructor
     ~Next100InnerElements();

--- a/source/geometries/Next100OpticalGeometry.cc
+++ b/source/geometries/Next100OpticalGeometry.cc
@@ -33,8 +33,8 @@ namespace nexus {
     GeometryBase(),
     // common used variables in geometry components
     grid_thickness_ (0.1 * mm),
-    gate_tracking_plane_distance_((26.1 + grid_thickness_) * mm),
-    gate_sapphire_wdw_distance_  ((1458.2 - grid_thickness_ - 1.351) * mm),
+    gate_tracking_plane_distance_(26.1 * mm + grid_thickness_),
+    gate_sapphire_wdw_distance_  ((1458.2 - 1.3) * mm - grid_thickness_),
     pressure_(15. * bar),
     temperature_ (300 * kelvin),
     sc_yield_(25510. * 1/MeV),

--- a/source/geometries/Next100OpticalGeometry.cc
+++ b/source/geometries/Next100OpticalGeometry.cc
@@ -31,10 +31,10 @@ namespace nexus {
 
   Next100OpticalGeometry::Next100OpticalGeometry():
     GeometryBase(),
-    // common used variables in geometry components
+    // common variables used in geometry components
     grid_thickness_ (0.1 * mm),
-    gate_tracking_plane_distance_(26.1 * mm + grid_thickness_),
-    gate_sapphire_wdw_distance_  ((1458.2 - 1.3) * mm - grid_thickness_),
+    gate_tracking_plane_distance_(25. * mm + grid_thickness_),
+    gate_sapphire_wdw_distance_  ((1458.8 - 1.3) * mm - grid_thickness_),
     pressure_(15. * bar),
     temperature_ (300 * kelvin),
     sc_yield_(25510. * 1/MeV),

--- a/source/geometries/Next100OpticalGeometry.cc
+++ b/source/geometries/Next100OpticalGeometry.cc
@@ -23,25 +23,24 @@
 #include <G4NistManager.hh>
 #include <G4UnitsTable.hh>
 
-#include <CLHEP/Units/SystemOfUnits.h>
-#include <CLHEP/Units/PhysicalConstants.h>
-
 using namespace CLHEP;
 
 namespace nexus {
 
   REGISTER_CLASS(Next100OpticalGeometry, GeometryBase)
 
-  Next100OpticalGeometry::Next100OpticalGeometry(): GeometryBase(),
-                // common used variables in geomety components
-                gate_tracking_plane_distance_((26.1 + 0.1) * mm), // to be confirmed
-                gate_sapphire_wdw_distance_  ((1458.2 - 0.1) * mm),
-						    pressure_(15. * bar),
-						    temperature_ (300 * kelvin),
-						    sc_yield_(25510. * 1/MeV),
-                e_lifetime_(1000. * ms),
-                specific_vertex_{},
-						    gas_("naturalXe")
+  Next100OpticalGeometry::Next100OpticalGeometry():
+    GeometryBase(),
+    // common used variables in geometry components
+    grid_thickness_ (0.1 * mm),
+    gate_tracking_plane_distance_((26.1 + grid_thickness_) * mm),
+    gate_sapphire_wdw_distance_  ((1458.2 - grid_thickness_ - 1.351) * mm),
+    pressure_(15. * bar),
+    temperature_ (300 * kelvin),
+    sc_yield_(25510. * 1/MeV),
+    e_lifetime_(1000. * ms),
+    specific_vertex_{},
+    gas_("naturalXe")
   {
     /// Messenger
     msg_ = new G4GenericMessenger(this, "/Geometry/Next100/",
@@ -74,7 +73,7 @@ namespace nexus {
     msg_->DeclareProperty("gas", gas_, "Gas being used");
 
 
-    inner_elements_ = new Next100InnerElements();
+    inner_elements_ = new Next100InnerElements(grid_thickness_);
   }
 
 
@@ -107,21 +106,21 @@ namespace nexus {
   if (gas_ == "naturalXe") {
     gas_mat = materials::GXe(pressure_, temperature_);
     gas_mat->SetMaterialPropertiesTable(opticalprops::GXe(pressure_,
-								       temperature_,
-								       sc_yield_,
-                                                                       e_lifetime_));
+                                                          temperature_,
+                                                          sc_yield_,
+                                                          e_lifetime_));
   } else if (gas_ == "enrichedXe") {
     gas_mat =  materials::GXeEnriched(pressure_, temperature_);
     gas_mat->SetMaterialPropertiesTable(opticalprops::GXe(pressure_,
-								       temperature_,
-								       sc_yield_,
-                                                                       e_lifetime_));
+                                                          temperature_,
+                                                          sc_yield_,
+                                                          e_lifetime_));
   } else if  (gas_ == "depletedXe") {
     gas_mat =  materials::GXeDepleted(pressure_, temperature_);
     gas_mat->SetMaterialPropertiesTable(opticalprops::GXe(pressure_,
-								       temperature_,
-								       sc_yield_,
-                                                                       e_lifetime_));
+                                                          temperature_,
+                                                          sc_yield_,
+                                                          e_lifetime_));
   }  else {
     G4Exception("[Next100OpticalGeometry]", "Construct()", FatalException,
                 "Unknown kind of gas, valid options are: naturalXe, enrichedXe, depletedXe.");

--- a/source/geometries/Next100OpticalGeometry.h
+++ b/source/geometries/Next100OpticalGeometry.h
@@ -42,7 +42,8 @@ namespace nexus {
     // Messenger for the definition of control commands
     G4GenericMessenger* msg_;
 
-    G4double gate_tracking_plane_distance_, gate_sapphire_wdw_distance_;
+    const G4double grid_thickness_;
+    const G4double gate_tracking_plane_distance_, gate_sapphire_wdw_distance_;
     G4double pressure_;
     G4double temperature_;
     G4double sc_yield_;

--- a/source/geometries/Next100Stave.cc
+++ b/source/geometries/Next100Stave.cc
@@ -1,0 +1,193 @@
+// ----------------------------------------------------------------------------
+// nexus | Next100Stave.cc
+//
+// Geometry of the staves that support the field rings
+// in the NEXT-100 field cage.
+//
+// The NEXT Collaboration
+// ----------------------------------------------------------------------------
+
+#include "Next100Stave.h"
+#include "MaterialsList.h"
+#include "Visibilities.h"
+
+#include <G4GenericMessenger.hh>
+#include <G4UnionSolid.hh>
+#include <G4Box.hh>
+#include <G4LogicalVolume.hh>
+#include <G4PVPlacement.hh>
+#include <G4VisAttributes.hh>
+
+using namespace nexus;
+
+Next100Stave::Next100Stave(G4double ring_drift_buffer_dist,
+                           G4int num_drift_rings,
+                           G4int num_buffer_rings):
+  GeometryBase(),
+  visibility_(0),
+  num_drift_rings_ (num_drift_rings),
+  num_buffer_rings_ (num_buffer_rings),
+  ring_drift_buffer_dist_ (ring_drift_buffer_dist), // Distance between last ring of buffer and first ring of drift part
+
+  holder_x_         (60. * mm),  // x dimension of the staves
+  holder_long_y_    (9.1 * mm),  // y dim of the base of the ring staves
+  holder_short_y_   (33.9 * mm), // y dim of the pieces added over the base of the ring staves
+
+  buffer_ring_dist_ (48. * mm),
+  buffer_long_length_ (241.3 * mm),
+  buffer_short_length_ (37. * mm),  // Thickness of staves in buffer volume
+  buffer_last_z_ (63.5 *mm),
+
+  drift_ring_dist_  (24. * mm),
+  drift_long_length_ (1170.2 * mm),
+  drift_short_first_length_ (8.5 * mm), // Thickness of first stave in the active volume
+  drift_short_length_ (13. * mm), // Thickness of staves in the active volume
+
+  cathode_opening_  (15.5 * mm),
+  cathode_long_y_ (28.15 * mm),
+  cathode_long_length_ (61 * mm),
+  cathode_short_length_ (22.75 * mm),
+
+  overlap_ (0.001*mm) // defined to ensure a common volume within two joined solids
+{
+  /// Messenger
+  msg_ = new G4GenericMessenger(this, "/Geometry/Next100/",
+                                "Control commands of geometry Next100.");
+  msg_->DeclareProperty("stave_vis", visibility_, "Stave Visibility");
+}
+
+Next100Stave::~Next100Stave()
+{
+}
+
+void Next100Stave::Construct()
+{
+  G4Material* pe500 = materials::PE500();
+
+  // BUFFER staves.
+  // The unions of volumes go from lower to higher z.
+  G4Box* buffer_short_solid =
+    new G4Box("BUFF_SHORT", holder_x_/2., holder_short_y_/2. + overlap_/2.,
+              buffer_short_length_/2.);
+
+  G4Box* buffer_long_solid =
+    new G4Box("BUFF_LONG", holder_x_/2., holder_long_y_/2.,
+              buffer_long_length_/2.);
+
+  G4double first_buff_short_z = -buffer_long_length_/2. +
+    (ring_drift_buffer_dist_/2.-cathode_opening_/2.) + buffer_ring_dist_/2.;
+
+  G4UnionSolid* buff_holder_solid =
+    new G4UnionSolid ("BUFF_HOLDER", buffer_long_solid, buffer_short_solid, 0,
+                      G4ThreeVector(0., holder_long_y_/2. + holder_short_y_/2. -
+                                    overlap_/2., first_buff_short_z));
+
+  G4double posz;
+  for (G4int j=1; j<num_buffer_rings_-1; j++) {
+    posz = first_buff_short_z + j*buffer_ring_dist_;
+
+    buff_holder_solid =
+      new G4UnionSolid("BUFF_HOLDER", buff_holder_solid, buffer_short_solid, 0,
+                       G4ThreeVector(0., holder_long_y_/2. + holder_short_y_/2.
+                                     -overlap_/2., posz));
+    }
+
+  G4Box* buffer_last_solid =
+    new G4Box("BUFF_LAST", holder_x_/2., holder_short_y_/2.+overlap_/2.,
+              buffer_last_z_/2.);
+
+  buff_holder_solid =
+    new G4UnionSolid("BUFF_HOLDER", buff_holder_solid, buffer_last_solid, 0,
+                     G4ThreeVector(0.,holder_long_y_/2. + holder_short_y_/2. -
+                                   overlap_/2.,
+                                   buffer_long_length_/2. - buffer_last_z_/2.));
+
+  // DRIFT staves.
+  G4Box* drift_short_first_solid =
+    new G4Box("DRIFT_SHORT", holder_x_/2., holder_short_y_/2. + overlap_/2.,
+              drift_short_first_length_/2.);
+
+  G4double first_drift_short_z =
+    -drift_long_length_/2. + drift_short_first_length_/2.;
+
+  G4Box* drift_long_solid =
+    new G4Box("DRIFT_LONG", holder_x_/2., holder_long_y_/2.,
+              drift_long_length_/2.);
+
+  G4UnionSolid* drift_holder_solid =
+    new G4UnionSolid ("DRIFT_HOLDER", drift_long_solid,
+                      drift_short_first_solid, 0,
+                      G4ThreeVector(0., holder_long_y_/2. + holder_short_y_/2. -
+                                    overlap_/2., first_drift_short_z));
+
+  G4Box* drift_short_solid =
+    new G4Box("DRIFT_SHORT", holder_x_/2., holder_short_y_/2.+overlap_/2.,
+              drift_short_length_/2.);
+
+  for (G4int j=0; j<num_drift_rings_-1; j++) {
+    posz = -drift_long_length_/2. + drift_short_first_length_ + drift_ring_dist_
+      - drift_short_length_/2 + j*drift_ring_dist_;
+
+    drift_holder_solid =
+      new G4UnionSolid("DRIFT_HOLDER", drift_holder_solid, drift_short_solid, 0,
+                       G4ThreeVector(0.,holder_long_y_/2. + holder_short_y_/2. -
+                                     overlap_/2., posz));
+    }
+
+  // CATHODE staves.
+  // They are placed at the same z position as the cathode ring.
+  G4Box* cathode_large_solid =
+    new G4Box("CATHODE_LARGE", holder_x_/2., cathode_long_y_/2.,
+              cathode_long_length_/2.);
+
+  G4Box* cathode_short_solid =
+    new G4Box("CATHODE_SHORT", holder_x_/2., holder_short_y_/2. + overlap_/2.,
+              cathode_short_length_/2.);
+
+  G4UnionSolid* cathode_holder_solid =
+    new G4UnionSolid ("CATHODE_HOLDER", cathode_large_solid,
+                      cathode_short_solid, 0,
+                      G4ThreeVector(0., -(holder_short_y_/2. + overlap_/2. -
+                                          cathode_long_y_/2),
+                                    cathode_long_length_/2. -
+                                    cathode_short_length_/2.));
+
+  cathode_holder_solid =
+    new G4UnionSolid("CATHODE_HOLDER", cathode_holder_solid,
+                     cathode_short_solid, 0,
+                     G4ThreeVector(0.,-(holder_short_y_/2. - cathode_long_y_/2),
+                                    -(cathode_long_length_/2. -
+                                      cathode_short_length_/2.)));
+
+  // Union of the three parts
+  G4double cathode_drift_ypos =
+    -cathode_long_y_/2. - (holder_short_y_ - cathode_long_y_) -
+    holder_long_y_/2.;
+  G4double cathode_drift_zpos =
+    - (cathode_long_length_/2. - cathode_short_length_ + drift_long_length_/2.);
+
+  G4UnionSolid* full_stave_solid =
+    new G4UnionSolid("STAVE", cathode_holder_solid, drift_holder_solid, 0,
+                     G4ThreeVector(0., cathode_drift_ypos, cathode_drift_zpos));
+
+  G4double cathode_buff_zpos =
+    (cathode_long_length_/2. - cathode_short_length_ + buffer_long_length_/2.);
+
+  full_stave_solid =
+    new G4UnionSolid("STAVE", full_stave_solid, buff_holder_solid, 0,
+                     G4ThreeVector(0., cathode_drift_ypos, cathode_buff_zpos));
+
+  G4LogicalVolume* full_stave_logic =
+    new G4LogicalVolume(full_stave_solid, pe500, "STAVE");
+
+  SetLogicalVolume(full_stave_logic);
+
+
+  /// Visibilities
+  if (visibility_) {
+    G4VisAttributes hold_col = nexus::LightGrey();
+    full_stave_logic->SetVisAttributes(hold_col);
+  } else {
+    full_stave_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
+  }
+}

--- a/source/geometries/Next100Stave.h
+++ b/source/geometries/Next100Stave.h
@@ -1,0 +1,62 @@
+// ----------------------------------------------------------------------------
+// nexus | Next100Stave.h
+//
+// Geometry of the staves that support the field rings
+// in the NEXT-100 field cage.
+//
+// The NEXT Collaboration
+// ----------------------------------------------------------------------------
+
+#ifndef NEXT100_STAVE_H
+#define NEXT100_STAVE_H
+
+#include "GeometryBase.h"
+
+class G4GenericMessenger;
+
+namespace nexus {
+
+  class Next100Stave: public GeometryBase
+  {
+  public:
+    Next100Stave(G4double ring_drift_buffer_dist_,
+                 G4int num_drift_rings,
+                 G4int num_buffer_rings);
+    ~Next100Stave();
+
+    void Construct() override;
+
+    G4double GetHolderShortY() const;
+    G4double GetHolderLongY() const;
+    G4double GetCathodeLongY() const;
+    G4double GetBufferLongLength() const;
+    G4double GetCathodeOpening() const;
+
+  private:
+    G4double visibility_;
+    const G4int num_drift_rings_, num_buffer_rings_;
+    const G4double ring_drift_buffer_dist_;
+    const G4double holder_x_, holder_long_y_, holder_short_y_;
+    const G4double buffer_ring_dist_, buffer_long_length_;
+    const G4double buffer_short_length_, buffer_last_z_;
+    const G4double drift_ring_dist_, drift_long_length_;
+    const G4double drift_short_first_length_;
+    const G4double drift_short_length_;
+    const G4double cathode_opening_, cathode_long_y_, cathode_long_length_;
+    const G4double cathode_short_length_;
+    const G4double overlap_;
+
+    // Messenger for the definition of control commands
+    G4GenericMessenger* msg_;
+
+  };
+
+  inline G4double Next100Stave::GetHolderShortY() const {return holder_short_y_;};
+  inline G4double Next100Stave::GetHolderLongY() const {return holder_long_y_;};
+  inline G4double Next100Stave::GetCathodeLongY() const {return cathode_long_y_;};
+  inline G4double Next100Stave::GetBufferLongLength() const {return buffer_long_length_;};
+  inline G4double Next100Stave::GetCathodeOpening() const {return cathode_opening_;};
+
+}
+
+#endif


### PR DESCRIPTION
This PR reviews the field cage thoroughly, using the latest drawings as a reference, with measurements taken by Sara C. and Jordi T.
The main changes compared with the previous version are the following:
- Move the cathode grid to the edge of the cathode ring, facing the active volume (following pictures taken during the installation).  
- Use real dimensions and placements of the staves (ring holders), decoupling them from the teflon reflector panels.
- Encapsulate the stave code in one class, glueing together the 3 parts that makes it up (drift, buffer and cathode parts).
- Update dimensions of poly wrap, teflon reflector panels and cathode, gate and anode ring (the latter is simplified).
- Fix the distances between gate and tracking plane and between gate and teflon panels.
