### PR TITLE
Review mask dimensions according to Sara's drawings

### DIFF
--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -33,9 +33,9 @@ using namespace nexus;
 
 Next100SiPMBoard::Next100SiPMBoard():
   GeometryBase     (),
-  size_            (123.40  * mm),
+  size_            (122.40  * mm),
   pitch_           ( 15.55  * mm),
-  margin_          (  7.275 * mm),
+  margin_          (  6.775 * mm),
   board_thickness_ (  0.2   * mm),
   mask_thickness_  (  6.0   * mm),
   time_binning_    (1. * microsecond),


### PR DESCRIPTION
It turned out that the mask dimensions were following an obsolete technical drawing with round holes. I attach the latest drawing, provided by Sara, which is implemented in this PR.
[03-95 Mask Hama 6 mm PASANTE - .pdf](https://github.com/next-exp/nexus/files/13277419/03-95.Mask.Hama.6.mm.PASANTE.-.pdf)
