### PR TITLE
Add inner flange

### DIFF
--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -42,6 +42,7 @@ namespace nexus {
     //ep_fc_distance_ (24.8 * mm), /// this value was measured by Sara in the step file
     gate_tracking_plane_distance_(25. * mm + grid_thickness_), // Jordi = 1.5 (distance TP plate-anode ring) + 13.5 (anode ring thickness) + 10 (EL gap)
     gate_sapphire_wdw_distance_  (1458.8 * mm - grid_thickness_), // Jordi
+    ics_ep_lip_width_ (55. * mm),
 
     specific_vertex_{},
     lab_walls_(false)
@@ -65,10 +66,10 @@ namespace nexus {
   hallA_walls_ = new LSCHallA();
 
   // Vessel
-  vessel_ = new Next100Vessel();
+  vessel_ = new Next100Vessel(ics_ep_lip_width_);
 
   // Internal copper shielding
-  ics_ = new Next100Ics();
+  ics_ = new Next100Ics(ics_ep_lip_width_);
 
   // Inner Elements
   inner_elements_ = new Next100InnerElements(grid_thickness_);

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -42,7 +42,7 @@ namespace nexus {
     //ep_fc_distance_ (24.8 * mm), /// this value was measured by Sara in the step file
     gate_tracking_plane_distance_(25. * mm + grid_thickness_), // Jordi = 1.5 (distance TP plate-anode ring) + 13.5 (anode ring thickness) + 10 (EL gap)
     gate_sapphire_wdw_distance_  (1458.8 * mm - grid_thickness_), // Jordi
-    ics_ep_lip_width_ (55. * mm),
+    ics_ep_lip_width_ (55. * mm), // length of the step cut out in the ICS, in the EP side
 
     specific_vertex_{},
     lab_walls_(false)

--- a/source/geometries/Next100.h
+++ b/source/geometries/Next100.h
@@ -51,6 +51,8 @@ namespace nexus {
     //    const G4double ep_fc_distance_; /// Distance between the surface of the
     ///EP copper plate and the end of the staves/teflon panels/poly (a.k.a. FC)
     const G4double gate_tracking_plane_distance_, gate_sapphire_wdw_distance_;
+    const G4double ics_ep_lip_width_ ; ///< width of step of the ICS bars in the
+    /// energy plane side
 
     // Pointers to logical volumes
     G4LogicalVolume* lab_logic_;

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -160,7 +160,7 @@ namespace nexus {
     /// ICS step at the TP end.
     // This avoids overlap with sipm boards at high radius
     G4double step_width = 31. * mm; // step dim in y
-    G4double step_length = 53 * mm; // step dim in z
+    G4double step_length = 52 * mm; // step dim in z
     G4Tubs* tp_step_solid =
       new G4Tubs("TP_STEP", in_rad_ - offset, in_rad_ + step_width,
                  (step_length + offset)/2., 0.*deg, 360.*deg);

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -159,17 +159,20 @@ namespace nexus {
 
     /// ICS step at the TP end.
     // This avoids overlap with sipm boards at high radius
-    G4double step_width = 38. * mm; // step length in the y dimension
+    G4double step_width = 31. * mm; // step dim in y
+    G4double step_length = 53 * mm; // step dim in z
     G4Tubs* tp_step_solid =
-      new G4Tubs("TP_STEP", (in_rad_ - offset), in_rad_ + step_width,
-                 gate_tp_distance_, 0.*deg, 360.*deg);
+      new G4Tubs("TP_STEP", in_rad_ - offset, in_rad_ + step_width,
+                 (step_length + offset)/2., 0.*deg, 360.*deg);
 
     ics_solid =
       new G4SubtractionSolid("ICS", ics_solid, tp_step_solid, 0,
                              G4ThreeVector(0., 0.,
-                                           -length/2.+gate_tp_distance_/2.));
+                                           -length/2. + (step_length - offset)/2.));
 
     /// ICS lip at the EP end.
+    // It is necessary to avoid clashing with the internal part
+    // of the vessel flange.
     G4double lip_height = 47.85 * mm; // lip length in the y dimension
     G4Tubs* ep_lip_solid =
       new G4Tubs("EP_LIP", in_rad_ + lip_height, in_rad_ + thickness_ + offset,

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -28,11 +28,13 @@ namespace nexus {
 
   using namespace CLHEP;
 
-  Next100Ics::Next100Ics():
+  Next100Ics::Next100Ics(G4double ics_ep_lip_width):
     GeometryBase(),
 
     in_rad_   (55.465 * cm),
     thickness_(12.0   * cm),
+
+    ics_ep_lip_width_ (ics_ep_lip_width),
 
     visibility_ (0)
   {
@@ -54,9 +56,11 @@ namespace nexus {
 
   void Next100Ics::Construct()
   {
-    G4double length = 1468. * mm; // (Full length of copper bars) - (copper simulated in TP_COPPER_PLATE)
-    // defined for G4UnionSolids to ensure a common volume within the two joined solids
-    // and for G4SubtractionSolids to ensure surface subtraction
+    // (Full length of copper bars) - (copper simulated in TP_COPPER_PLATE)
+    G4double length = 1468. * mm;
+    // Defined for G4UnionSolids to ensure a common volume within the two
+    // joined solids and for G4SubtractionSolids to ensure surface subtraction
+
     G4double offset = 1.* mm;
 
     // ICS
@@ -79,20 +83,29 @@ namespace nexus {
     port_b_Rot->rotateX( 90. * deg);
     port_b_Rot->rotateY( 45. * deg);
 
-    G4Tubs* port_hole_solid = new G4Tubs("PORT_HOLE", 0., port_hole_rad,
-                                         (thickness_ + offset)/2., 0.*deg, 360.*deg);
+    G4Tubs* port_hole_solid =
+      new G4Tubs("PORT_HOLE", 0., port_hole_rad,
+                 (thickness_ + offset)/2., 0.*deg, 360.*deg);
 
-    ics_solid = new G4SubtractionSolid("ICS", ics_body, port_hole_solid,
-                port_a_Rot, G4ThreeVector(port_x, port_y, port_z_1a_-ics_z_pos));
+    ics_solid =
+      new G4SubtractionSolid("ICS", ics_body, port_hole_solid,
+                             port_a_Rot, G4ThreeVector(port_x, port_y,
+                                                       port_z_1a_-ics_z_pos));
 
-    ics_solid = new G4SubtractionSolid("ICS", ics_solid, port_hole_solid,
-                port_a_Rot, G4ThreeVector(port_x, port_y, port_z_2a_-ics_z_pos));
+    ics_solid =
+      new G4SubtractionSolid("ICS", ics_solid, port_hole_solid,
+                             port_a_Rot, G4ThreeVector(port_x, port_y,
+                                                       port_z_2a_-ics_z_pos));
 
-    ics_solid = new G4SubtractionSolid("ICS", ics_solid, port_hole_solid,
-                port_b_Rot, G4ThreeVector(-port_x, port_y, port_z_1b_-ics_z_pos));
+    ics_solid =
+      new G4SubtractionSolid("ICS", ics_solid, port_hole_solid,
+                             port_b_Rot, G4ThreeVector(-port_x, port_y,
+                                                       port_z_1b_-ics_z_pos));
 
-    ics_solid = new G4SubtractionSolid("ICS", ics_solid, port_hole_solid,
-                port_b_Rot, G4ThreeVector(-port_x, port_y, port_z_2b_-ics_z_pos));
+    ics_solid =
+      new G4SubtractionSolid("ICS", ics_solid, port_hole_solid,
+                             port_b_Rot, G4ThreeVector(-port_x, port_y,
+                                                       port_z_2b_-ics_z_pos));
 
     /// Upper holes
     // z distances measured with respect to TP plate, ie the start of ICS
@@ -104,41 +117,68 @@ namespace nexus {
     G4RotationMatrix* port_upp_Rot = new G4RotationMatrix;
     port_upp_Rot->rotateX( 90. * deg);
 
-    G4Tubs* upp_hole_solid_1 = new G4Tubs("UPP_HOLE", 0., upp_hole_1_rad,
-                                        (thickness_ + offset)/2., 0.*deg, 360.*deg);
+    G4Tubs* upp_hole_solid_1 =
+      new G4Tubs("UPP_HOLE", 0., upp_hole_1_rad,
+                 (thickness_ + offset)/2., 0.*deg, 360.*deg);
 
-    ics_solid = new G4SubtractionSolid("ICS", ics_solid, upp_hole_solid_1,
-                port_upp_Rot, G4ThreeVector(0, (in_rad_ + thickness_/2.), upp_hole_1_z-length/2.));
+    ics_solid =
+      new G4SubtractionSolid("ICS", ics_solid, upp_hole_solid_1,
+                             port_upp_Rot,
+                             G4ThreeVector(0, (in_rad_ + thickness_/2.),
+                                           upp_hole_1_z-length/2.));
 
-    G4Tubs* upp_hole_solid_2 = new G4Tubs("UPP_HOLE", 0., upp_hole_2_rad,
-                                        (thickness_ + offset)/2., 0.*deg, 360.*deg);
+    G4Tubs* upp_hole_solid_2 =
+      new G4Tubs("UPP_HOLE", 0., upp_hole_2_rad,
+                 (thickness_ + offset)/2., 0.*deg, 360.*deg);
 
-    ics_solid = new G4SubtractionSolid("ICS", ics_solid, upp_hole_solid_2,
-                port_upp_Rot, G4ThreeVector(0, (in_rad_ + thickness_/2.), upp_hole_2_z-length/2.));
+    ics_solid =
+      new G4SubtractionSolid("ICS", ics_solid, upp_hole_solid_2,
+                             port_upp_Rot,
+                             G4ThreeVector(0, (in_rad_ + thickness_/2.),
+                                           upp_hole_2_z-length/2.));
 
     /// Lateral holes (also known as feedthrough holes)
     G4double lat_hole_rad = upp_hole_1_rad;
     G4double lat_hole_z_1   = 55.5 * mm;
     G4double lat_hole_z_2   = 33.0 * mm;
 
-    G4Tubs* lat_hole_solid = new G4Tubs("LAT_HOLE", 0., lat_hole_rad,
-                                        (thickness_ + offset)/2., 0.*deg, 360.*deg);
+    G4Tubs* lat_hole_solid =
+      new G4Tubs("LAT_HOLE", 0., lat_hole_rad,
+                 (thickness_ + offset)/2., 0.*deg, 360.*deg);
 
-    ics_solid = new G4SubtractionSolid("ICS", ics_solid, lat_hole_solid,
-                port_a_Rot, G4ThreeVector(port_x, port_y, lat_hole_z_1-length/2.));
+    ics_solid =
+      new G4SubtractionSolid("ICS", ics_solid, lat_hole_solid,
+                             port_a_Rot, G4ThreeVector(port_x, port_y,
+                                                       lat_hole_z_1-length/2.));
 
-    ics_solid = new G4SubtractionSolid("ICS", ics_solid, lat_hole_solid,
-                port_b_Rot, G4ThreeVector(-port_x, port_y, lat_hole_z_2-length/2.));
+    ics_solid =
+      new G4SubtractionSolid("ICS", ics_solid, lat_hole_solid,
+                             port_b_Rot, G4ThreeVector(-port_x, port_y,
+                                                       lat_hole_z_2-length/2.));
 
 
     /// ICS step at the TP end.
     // This avoids overlap with sipm boards at high radius
     G4double step_width = 38. * mm; // step lenght in the y dimension
-    G4Tubs* tp_step_solid = new G4Tubs("TP_STEP", (in_rad_ - offset), in_rad_ + step_width,
-                                       gate_tp_distance_, 0.*deg, 360.*deg);
+    G4Tubs* tp_step_solid =
+      new G4Tubs("TP_STEP", (in_rad_ - offset), in_rad_ + step_width,
+                 gate_tp_distance_, 0.*deg, 360.*deg);
 
-    ics_solid = new G4SubtractionSolid("ICS", ics_solid, tp_step_solid,
-                                      0, G4ThreeVector(0., 0., -length/2.+gate_tp_distance_/2.));
+    ics_solid =
+      new G4SubtractionSolid("ICS", ics_solid, tp_step_solid, 0,
+                             G4ThreeVector(0., 0.,
+                                           -length/2.+gate_tp_distance_/2.));
+
+    /// ICS lip at the EP end.
+    G4double lip_height = 47.85 * mm;
+    G4Tubs* ep_lip_solid =
+      new G4Tubs("EP_LIP", in_rad_ + lip_height, in_rad_ + thickness_ + offset,
+                 (ics_ep_lip_width_ + offset)/2., 0.*deg, 360.*deg);
+
+    ics_solid =
+      new G4SubtractionSolid("ICS", ics_solid, ep_lip_solid, 0,
+                             G4ThreeVector(0., 0., length/2. -
+                                           (ics_ep_lip_width_ - offset)/2.));
 
     G4LogicalVolume* ics_logic =
       new G4LogicalVolume(ics_solid,
@@ -160,7 +200,8 @@ namespace nexus {
 
     // VERTEX GENERATOR
     ics_gen_ =
-      new CylinderPointSampler2020(in_rad_, in_rad_ + thickness_, length/2., 0.*deg, 360.*deg,
+      new CylinderPointSampler2020(in_rad_, in_rad_ + thickness_, length/2.,
+                                   0.*deg, 360.*deg,
                                    0, G4ThreeVector(0., 0., ics_z_pos));
   }
 
@@ -176,13 +217,14 @@ namespace nexus {
     G4ThreeVector vertex(0., 0., 0.);
 
     if (region=="ICS"){
-      G4VPhysicalVolume *VertexVolume;
+      G4VPhysicalVolume* VertexVolume;
       do {
         vertex = ics_gen_->GenerateVertex("VOLUME");
 
         G4ThreeVector glob_vtx(vertex);
         glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
-        VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
+        VertexVolume =
+          geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
       } while (VertexVolume->GetName() != "ICS");
     }
 

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -159,7 +159,7 @@ namespace nexus {
 
     /// ICS step at the TP end.
     // This avoids overlap with sipm boards at high radius
-    G4double step_width = 38. * mm; // step lenght in the y dimension
+    G4double step_width = 38. * mm; // step length in the y dimension
     G4Tubs* tp_step_solid =
       new G4Tubs("TP_STEP", (in_rad_ - offset), in_rad_ + step_width,
                  gate_tp_distance_, 0.*deg, 360.*deg);
@@ -170,7 +170,7 @@ namespace nexus {
                                            -length/2.+gate_tp_distance_/2.));
 
     /// ICS lip at the EP end.
-    G4double lip_height = 47.85 * mm;
+    G4double lip_height = 47.85 * mm; // lip length in the y dimension
     G4Tubs* ep_lip_solid =
       new G4Tubs("EP_LIP", in_rad_ + lip_height, in_rad_ + thickness_ + offset,
                  (ics_ep_lip_width_ + offset)/2., 0.*deg, 360.*deg);

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -56,6 +56,10 @@ namespace nexus {
 
   void Next100Ics::Construct()
   {
+    // This visualization of this geometry takes a long time, because of
+    // the subtraction of volumes. If needed, the user can comment by hand
+    // one of the two subtractions and visualize the other.
+
     // (Full length of copper bars) - (copper simulated in TP_COPPER_PLATE)
     G4double length = 1468. * mm;
     // Defined for G4UnionSolids to ensure a common volume within the two

--- a/source/geometries/Next100Ics.h
+++ b/source/geometries/Next100Ics.h
@@ -24,7 +24,7 @@ namespace nexus {
   {
   public:
     /// Constructor
-    Next100Ics();
+    Next100Ics(G4double ics_ep_lip_width);
 
     /// Destructor
     ~Next100Ics();
@@ -48,7 +48,8 @@ namespace nexus {
 
     // Dimensions
     G4double gate_tp_distance_, gate_sapphire_wdw_dist_;
-    G4double in_rad_, thickness_;
+    const G4double in_rad_, thickness_;
+    const G4double ics_ep_lip_width_;
     G4double port_z_1a_, port_z_2a_, port_z_1b_, port_z_2b_;
 
     // Visibility of the shielding

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -307,7 +307,7 @@ namespace nexus {
     // EP copper plate and the ICS bars
 
     G4double ep_int_flange_in_rad = flange_out_rad - 167 * mm;
-    G4double ep_int_flange_length = 77.5 * mm;
+    G4double ep_int_flange_length = 79.8 * mm;
     G4Tubs* ep_int_flange_full_solid =
       new G4Tubs("VESSEL_EP_INT_FLANGE_FULL", ep_int_flange_in_rad,
                  vessel_in_rad_, ep_int_flange_length/2.,

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -325,7 +325,7 @@ namespace nexus {
        new G4SubtractionSolid("VESSEL_EP_INT_FLANGE", ep_int_flange_full_solid,
                               ep_int_flange_lip_solid, 0, ep_int_flang_sub_pos);
 
-    G4LogicalVolume* ep_internal_flange_logic =
+    G4LogicalVolume* ep_int_flange_logic =
       new G4LogicalVolume(ep_internal_flange_solid, materials::Steel316Ti(),
                           "VESSEL_EP_INT_FLANGE");
 
@@ -333,7 +333,7 @@ namespace nexus {
       body_length_/2. - endcap_in_body_ - 41.5 * mm -
       ep_int_flange_length/2. - 7.*mm;
     new G4PVPlacement(0, G4ThreeVector(0., 0., ep_internal_flange_posz),
-                      ep_internal_flange_logic,
+                      ep_int_flange_logic,
                       "VESSEL_EP_INT_FLANGE", vessel_gas_logic, false, 0, false);
 
     // SETTING VISIBILITIES   //////////
@@ -342,15 +342,14 @@ namespace nexus {
       G4VisAttributes yellow = nexus::Yellow();
       grey  .SetForceSolid(true);
       yellow.SetForceSolid(true);
+      ep_int_flange_logic->SetVisAttributes(grey);
       vessel_logic       ->SetVisAttributes(grey);
       vessel_gas_logic   ->SetVisAttributes(G4VisAttributes::GetInvisible());
       port_tube_logic    ->SetVisAttributes(grey);
       port_tube_gas_logic->SetVisAttributes(yellow);
     }
     else {
-      G4VisAttributes grey = nexus::TitaniumGrey();
-      grey  .SetForceSolid(true);
-      ep_internal_flange_logic->SetVisAttributes(grey);
+      ep_int_flange_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
       vessel_logic       ->SetVisAttributes(G4VisAttributes::GetInvisible());
       vessel_gas_logic   ->SetVisAttributes(G4VisAttributes::GetInvisible());
       port_tube_logic    ->SetVisAttributes(G4VisAttributes::GetInvisible());

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -74,6 +74,19 @@ namespace nexus {
     helium_mass_num_(4),
     xe_perc_(100.)
   {
+    /// HOW THIS GEOMETRY IS BUILT ///
+    /// The vessel is a union of several volumes, as explained in
+    /// https://next.ific.uv.es/DocDB/0015/001522/001/next100vessel.pdf.
+    /// The flanges are simulated simply as external volumes;
+    /// however, the EP flange has a part that goes inside the vessel,
+    /// which holds the EP plate. To simulate this we do the following:
+    /// 1. We build a solid cylinder made of stainless steel.
+    /// 2. We build a smaller cylinder made of xenon.
+    /// 3. We cut out two thin cylinders from the xenon volume,
+    ///    in the place where the inner part of the EP flange goes.
+    /// 4. We place the xenon volume inside the stainless steel one.
+    /// This way, the inner part of the EP flange emerges as the part of
+    // the inner volume of the vessel which is not occupied by xenon.
 
     // Initializing the geometry navigator (used in vertex generation)
     geom_navigator_ =

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -331,10 +331,10 @@ namespace nexus {
 
     G4double ep_internal_flange_posz =
       body_length_/2. - endcap_in_body_ - 41.5 * mm -
-      ep_int_flange_length/2.;
+      ep_int_flange_length/2. - 7.*mm;
     new G4PVPlacement(0, G4ThreeVector(0., 0., ep_internal_flange_posz),
                       ep_internal_flange_logic,
-                      "VESSEL_EP_INT_FLANGE", vessel_gas_logic, false, true);
+                      "VESSEL_EP_INT_FLANGE", vessel_gas_logic, false, 0, false);
 
     // SETTING VISIBILITIES   //////////
     if (visibility_) {

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -53,7 +53,6 @@ namespace nexus {
     endcap_in_body_     (15.15  * cm),
     endcap_theta_       (29.1   * deg),
     endcap_in_z_width_  (15.6   * cm),
-    endcap_tp_distance_ (44.92  * cm),
 
     // Ports
     port_base_height_(37. * mm),

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -26,7 +26,7 @@ namespace nexus {
   {
   public:
     /// Constructor
-    Next100Vessel();
+    Next100Vessel(G4double ics_ep_lip_width);
 
     /// Destructor
     ~Next100Vessel();
@@ -47,14 +47,18 @@ namespace nexus {
 
   private:
     // Dimensions
-    G4double vessel_in_rad_, vessel_thickness_;
-    G4double body_length_;
-    G4double endcap_in_rad_, endcap_in_body_, endcap_theta_, endcap_in_z_width_;
-    G4double endcap_tp_distance_, gate_tp_distance_;
-    G4double port_base_height_, port_tube_height_, port_tube_tip_;
-    G4double port_x_, port_y_, source_height_, port_z_1a_, port_z_1b_, port_z_2a_, port_z_2b_;
+    const G4double vessel_in_rad_, vessel_thickness_;
+    const G4double ics_ep_lip_width_;
+    const G4double body_length_;
+    const G4double endcap_in_rad_, endcap_in_body_, endcap_theta_;
+    const G4double endcap_in_z_width_, endcap_tp_distance_;
+    const G4double port_base_height_, port_tube_height_, port_tube_tip_;
+
+    G4double port_x_, port_y_, source_height_, port_z_1a_, port_z_1b_;
+    G4double port_z_2a_, port_z_2b_;
     G4double sc_yield_, e_lifetime_;
     G4double pressure_, temperature_;
+    G4double gate_tp_distance_;
 
     // Visibility of the shielding
     G4bool visibility_;

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -51,7 +51,7 @@ namespace nexus {
     const G4double ics_ep_lip_width_;
     const G4double body_length_;
     const G4double endcap_in_rad_, endcap_in_body_, endcap_theta_;
-    const G4double endcap_in_z_width_, endcap_tp_distance_;
+    const G4double endcap_in_z_width_;
     const G4double port_base_height_, port_tube_height_, port_tube_tip_;
 
     G4double port_x_, port_y_, source_height_, port_z_1a_, port_z_1b_;


### PR DESCRIPTION
This PR adds a piece of the vessel flange on the side of the energy plane (EP), which was not simulated previously. 
Its sits between the EP copper plate and the inner copper shielding (ICS). 
In the space occupied by this new volume there were previously a part of the ICS bars and gas; therefore it may be relevant for the shielding of background.