### PR TITLE
FC displacement

### DIFF
--- a/source/geometries/GeometryBase.h
+++ b/source/geometries/GeometryBase.h
@@ -55,6 +55,12 @@ namespace nexus {
     /// Setter for the starting point of EL generation in z
     void SetELzCoord(G4double z);
 
+    /// Getter for the origin of coordinates
+    G4ThreeVector GetCoordOrigin() const;
+
+    /// Setter for the origin of coordinates
+    void SetCoordOrigin(G4ThreeVector origin);
+
     /// Translates position to G4 global position
     void CalculateGlobalPos(G4ThreeVector& vertex) const;
 
@@ -90,12 +96,13 @@ namespace nexus {
     G4ThreeVector dimensions_; ///< XYZ dimensions of a regular geometry
     G4bool drift_; ///< True if geometry contains a drift field (for hit coordinates)
     G4double el_z_; ///< Starting point of EL generation in z
+    G4ThreeVector coord_origin_; ///< Origin of coordinates of the mother volume
   };
 
 
   // Inline definitions ///////////////////////////////////
 
-  inline GeometryBase::GeometryBase(): logicVol_(0), span_(25.*m), drift_(false), el_z_(0.*mm) {}
+  inline GeometryBase::GeometryBase(): logicVol_(0), span_(25.*m),  el_z_(0.*mm), coord_origin_(G4ThreeVector(0., 0., 0.)) {}
 
   inline GeometryBase::~GeometryBase() {}
 
@@ -128,6 +135,10 @@ namespace nexus {
   inline G4double GeometryBase::GetELzCoord() const {return el_z_;}
 
   inline void GeometryBase::SetELzCoord(G4double z) {el_z_ = z;}
+
+  inline G4ThreeVector GeometryBase::GetCoordOrigin() const {return coord_origin_;}
+
+  inline void GeometryBase::SetCoordOrigin(G4ThreeVector origin) {coord_origin_ = origin;}
 
   // This methods is to be used only in the Next1EL and NEW geometries
   inline void GeometryBase::CalculateGlobalPos(G4ThreeVector& vertex) const

--- a/source/geometries/GeometryBase.h
+++ b/source/geometries/GeometryBase.h
@@ -46,9 +46,6 @@ namespace nexus {
     /// Returns the 3 dimensions of the geometry (x, y, z)
     G4ThreeVector GetDimensions();
 
-    /// Returns true if geometry has a drift field
-    G4bool GetDrift() const;
-
     // Getter for the starting point of EL generation in z
     G4double GetELzCoord() const;
 
@@ -78,9 +75,6 @@ namespace nexus {
     /// Sets the span (maximum dimension) of the geometry
     void SetSpan(G4double);
 
-    /// Sets the drift variable to true if a drift field exists
-    void SetDrift(G4bool);
-
     /// Sets the 3 dimensions of the geometry (x, y, z)
     void SetDimensions(G4ThreeVector dim);
 
@@ -94,7 +88,6 @@ namespace nexus {
     G4LogicalVolume* logicVol_; ///< Pointer to the logical volume
     G4double span_; ///< Maximum dimension of the geometry
     G4ThreeVector dimensions_; ///< XYZ dimensions of a regular geometry
-    G4bool drift_; ///< True if geometry contains a drift field (for hit coordinates)
     G4double el_z_; ///< Starting point of EL generation in z
     G4ThreeVector coord_origin_; ///< Origin of coordinates of the mother volume
   };
@@ -127,10 +120,6 @@ namespace nexus {
   inline void GeometryBase::SetDimensions(G4ThreeVector dim) {  dimensions_ = dim; }
 
   inline  G4ThreeVector GeometryBase::GetDimensions()  { return dimensions_; }
-
-  inline void GeometryBase::SetDrift(G4bool drift) { drift_ = drift; }
-
-  inline G4bool GeometryBase::GetDrift() const { return drift_; }
 
   inline G4double GeometryBase::GetELzCoord() const {return el_z_;}
 

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -123,7 +123,11 @@ namespace nexus {
     this->SetLogicalVolume(lab_logic_);
 
     // VESSEL (initialize first since it defines EL position)
+    // The z coord origin is not set, because it is not defined, yet
     vessel_->SetELtoTPdistance(gate_tracking_plane_distance_);
+    vessel_->SetCoordOrigin(G4ThreeVector(fc_displ_x_,
+                                          fc_displ_y_,
+                                          0.));
     vessel_->Construct();
     G4LogicalVolume* vessel_logic = vessel_->GetLogicalVolume();
     G4LogicalVolume* vessel_internal_logic  =

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -318,7 +318,7 @@ namespace nexus {
 		  "Unknown vertex generation region!");
     }
 
-    return vertex + G4ThreeVector(0., 0., -gate_zpos_in_vessel_);
+    return vertex - coord_origin_;
   }
 
 } //end namespace nexus

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -47,7 +47,8 @@ namespace nexus {
     fc_displ_y_ (-6.4 * mm), // displacement of the field cage volumes from 0
 
     specific_vertex_{},
-    lab_walls_(false)
+    lab_walls_(false),
+    print_(false)
   {
 
     msg_ = new G4GenericMessenger(this, "/Geometry/Next100/",
@@ -56,7 +57,9 @@ namespace nexus {
     msg_->DeclarePropertyWithUnit("specific_vertex", "mm",  specific_vertex_,
       "Set generation vertex.");
 
-    msg_->DeclareProperty("lab_walls", lab_walls_, "Placement of Hall A walls");
+    msg_->DeclareProperty("lab_walls", lab_walls_, "Placement of Hall A walls.");
+
+    msg_->DeclareProperty("print_sipms", print_, "Print SiPM positions.");
 
   // The following methods must be invoked in this particular
   // order since some of them depend on the previous ones
@@ -181,11 +184,28 @@ namespace nexus {
                         "LEAD_BOX", lab_logic_, false, 0);
     }
 
+    if (print_) {
+      std::vector<G4ThreeVector> sipm_pos = inner_elements_->GetSiPMPosInGas();
+      G4int n_sipm = 0;
+      G4int b = 1;
+      for (unsigned int i=0; i<sipm_pos.size(); i++) {
+        G4ThreeVector pos = sipm_pos[i] - coord_origin_;;
+        G4int id = 1000 * b + n_sipm;
+        G4cout << "SiPM " << id << ": " << pos.x() << ", "<< pos.y() << G4endl;
+        n_sipm++;
+        if (id % 1000 == 63) {
+          n_sipm = 0;
+          b++;
+        }
+      }
+    }
+
     //// VERTEX GENERATORS
     lab_gen_ =
       new BoxPointSampler(lab_size_ - 1.*m, lab_size_ - 1.*m,
                           lab_size_  - 1.*m, 1.*m,
                           G4ThreeVector(0., 0., 0.), 0);
+
   }
 
 

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -136,13 +136,11 @@ namespace nexus {
       vessel_->GetInternalPhysicalVolume();
     G4ThreeVector vessel_displacement =
       shielding_->GetAirDisplacement(); // explained below
-    displ_from_origin_ =
-      G4ThreeVector(-fc_displ_x_, -fc_displ_y_, -vessel_->GetGateZpos());
+
+    coord_origin_ = G4ThreeVector(fc_displ_x_, fc_displ_y_, vessel_->GetGateZpos());
 
     // SHIELDING
-    shielding_->SetCoordOrigin(G4ThreeVector(fc_displ_x_,
-                                             fc_displ_y_,
-                                             vessel_->GetGateZpos()));
+    shielding_->SetCoordOrigin(coord_origin_);
     shielding_->Construct();
     G4LogicalVolume* shielding_logic     = shielding_->GetLogicalVolume();
     G4LogicalVolume* shielding_air_logic = shielding_->GetAirLogicalVolume();
@@ -156,18 +154,14 @@ namespace nexus {
     // INNER ELEMENTS
     inner_elements_->SetLogicalVolume(vessel_internal_logic);
     inner_elements_->SetPhysicalVolume(vessel_internal_phys);
-    inner_elements_->SetCoordOrigin(G4ThreeVector(fc_displ_x_,
-                                                  fc_displ_y_,
-                                                  vessel_->GetGateZpos()));
+    inner_elements_->SetCoordOrigin(coord_origin_);
     inner_elements_->SetELtoSapphireWDWdistance(gate_sapphire_wdw_distance_);
     inner_elements_->SetELtoTPdistance         (gate_tracking_plane_distance_);
     inner_elements_->Construct();
 
     // INNER COPPER SHIELDING
     ics_->SetLogicalVolume(vessel_internal_logic);
-    ics_->SetCoordOrigin(G4ThreeVector(fc_displ_x_,
-                                       fc_displ_y_,
-                                       vessel_->GetGateZpos()));
+    ics_->SetCoordOrigin(coord_origin_);
     ics_->SetELtoSapphireWDWdistance(gate_sapphire_wdw_distance_);
     ics_->SetELtoTPdistance         (gate_tracking_plane_distance_);
     ics_->SetPortZpositions(vessel_->GetPortZpositions());
@@ -179,11 +173,11 @@ namespace nexus {
 
       new G4PVPlacement(0, castle_pos, shielding_logic,
                         "LEAD_BOX", hallA_logic_, false, 0);
-      new G4PVPlacement(0, displ_from_origin_ - castle_pos, hallA_logic_,
+      new G4PVPlacement(0, -coord_origin_ - castle_pos, hallA_logic_,
                         "Hall_A", lab_logic_, false, 0, false);
     }
     else {
-      new G4PVPlacement(0, displ_from_origin_, shielding_logic,
+      new G4PVPlacement(0, -coord_origin_, shielding_logic,
                         "LEAD_BOX", lab_logic_, false, 0);
     }
 
@@ -277,7 +271,7 @@ namespace nexus {
 		  "Unknown vertex generation region!");
     }
 
-    vertex = vertex + displ_from_origin_;
+    vertex = vertex - coord_origin_;
 
     return vertex;
   }

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -43,6 +43,8 @@ namespace nexus {
     gate_tracking_plane_distance_(25. * mm + grid_thickness_), // Jordi = 1.5 (distance TP plate-anode ring) + 13.5 (anode ring thickness) + 10 (EL gap)
     gate_sapphire_wdw_distance_  (1458.8 * mm - grid_thickness_), // Jordi
     ics_ep_lip_width_ (55. * mm), // length of the step cut out in the ICS, in the EP side
+    fc_displ_x_ (-3.7 * mm), // displacement of the field cage volumes from 0
+    fc_displ_y_ (-6.4 * mm), // displacement of the field cage volumes from 0
 
     specific_vertex_{},
     lab_walls_(false)
@@ -130,10 +132,13 @@ namespace nexus {
       vessel_->GetInternalPhysicalVolume();
     G4ThreeVector vessel_displacement =
       shielding_->GetAirDisplacement(); // explained below
-    displ_from_origin_ = G4ThreeVector(0., 0., -vessel_->GetGateZpos());
+    displ_from_origin_ =
+      G4ThreeVector(-fc_displ_x_, -fc_displ_y_, -vessel_->GetGateZpos());
 
     // SHIELDING
-    shielding_->SetCoordOrigin(G4ThreeVector(0., 0., vessel_->GetGateZpos()));
+    shielding_->SetCoordOrigin(G4ThreeVector(fc_displ_x_,
+                                             fc_displ_y_,
+                                             vessel_->GetGateZpos()));
     shielding_->Construct();
     G4LogicalVolume* shielding_logic     = shielding_->GetLogicalVolume();
     G4LogicalVolume* shielding_air_logic = shielding_->GetAirLogicalVolume();
@@ -147,14 +152,18 @@ namespace nexus {
     // INNER ELEMENTS
     inner_elements_->SetLogicalVolume(vessel_internal_logic);
     inner_elements_->SetPhysicalVolume(vessel_internal_phys);
-    inner_elements_->SetCoordOrigin(G4ThreeVector(0., 0., vessel_->GetGateZpos()));
+    inner_elements_->SetCoordOrigin(G4ThreeVector(fc_displ_x_,
+                                                  fc_displ_y_,
+                                                  vessel_->GetGateZpos()));
     inner_elements_->SetELtoSapphireWDWdistance(gate_sapphire_wdw_distance_);
     inner_elements_->SetELtoTPdistance         (gate_tracking_plane_distance_);
     inner_elements_->Construct();
 
     // INNER COPPER SHIELDING
     ics_->SetLogicalVolume(vessel_internal_logic);
-    ics_->SetCoordOrigin(G4ThreeVector(0., 0., vessel_->GetGateZpos()));
+    ics_->SetCoordOrigin(G4ThreeVector(fc_displ_x_,
+                                       fc_displ_y_,
+                                       vessel_->GetGateZpos()));
     ics_->SetELtoSapphireWDWdistance(gate_sapphire_wdw_distance_);
     ics_->SetELtoTPdistance         (gate_tracking_plane_distance_);
     ics_->SetPortZpositions(vessel_->GetPortZpositions());

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -130,49 +130,48 @@ namespace nexus {
       vessel_->GetInternalPhysicalVolume();
     G4ThreeVector vessel_displacement =
       shielding_->GetAirDisplacement(); // explained below
-    gate_zpos_in_vessel_ = vessel_->GetELzCoord();
+    displ_from_origin_ = G4ThreeVector(0., 0., -vessel_->GetGateZpos());
 
     // SHIELDING
+    shielding_->SetCoordOrigin(G4ThreeVector(0., 0., vessel_->GetGateZpos()));
     shielding_->Construct();
-    shielding_->SetELzCoord(gate_zpos_in_vessel_);
     G4LogicalVolume* shielding_logic     = shielding_->GetLogicalVolume();
     G4LogicalVolume* shielding_air_logic = shielding_->GetAirLogicalVolume();
 
-    // Recall that airbox is slighly displaced in Y dimension. In order to avoid
-    // mistmatch with vertex generators, we place the vessel i
-    // n the center of the world volume
+    // Recall that air box is slightly displaced in Y dimension.
+    // In order to avoid mistmatch with vertex generators,
+    // we place the vessel in the center of the world volume
     new G4PVPlacement(0, -vessel_displacement, vessel_logic,
                       "VESSEL", shielding_air_logic, false, 0);
 
     // INNER ELEMENTS
     inner_elements_->SetLogicalVolume(vessel_internal_logic);
     inner_elements_->SetPhysicalVolume(vessel_internal_phys);
-    inner_elements_->SetELzCoord(gate_zpos_in_vessel_);
+    inner_elements_->SetCoordOrigin(G4ThreeVector(0., 0., vessel_->GetGateZpos()));
     inner_elements_->SetELtoSapphireWDWdistance(gate_sapphire_wdw_distance_);
     inner_elements_->SetELtoTPdistance         (gate_tracking_plane_distance_);
     inner_elements_->Construct();
 
     // INNER COPPER SHIELDING
     ics_->SetLogicalVolume(vessel_internal_logic);
-    ics_->SetELzCoord(gate_zpos_in_vessel_);
+    ics_->SetCoordOrigin(G4ThreeVector(0., 0., vessel_->GetGateZpos()));
     ics_->SetELtoSapphireWDWdistance(gate_sapphire_wdw_distance_);
     ics_->SetELtoTPdistance         (gate_tracking_plane_distance_);
     ics_->SetPortZpositions(vessel_->GetPortZpositions());
     ics_->Construct();
 
-    G4ThreeVector gate_pos(0., 0., -gate_zpos_in_vessel_);
     if (lab_walls_){
       G4ThreeVector castle_pos(0., hallA_walls_->GetLSCHallACastleY(),
                                hallA_walls_->GetLSCHallACastleZ());
 
       new G4PVPlacement(0, castle_pos, shielding_logic,
                         "LEAD_BOX", hallA_logic_, false, 0);
-      new G4PVPlacement(0, gate_pos - castle_pos, hallA_logic_,
+      new G4PVPlacement(0, displ_from_origin_ - castle_pos, hallA_logic_,
                         "Hall_A", lab_logic_, false, 0, false);
     }
     else {
-      new G4PVPlacement(0, gate_pos, shielding_logic, "LEAD_BOX", lab_logic_,
-                        false, 0);
+      new G4PVPlacement(0, displ_from_origin_, shielding_logic,
+                        "LEAD_BOX", lab_logic_, false, 0);
     }
 
     //// VERTEX GENERATORS
@@ -265,8 +264,7 @@ namespace nexus {
 		  "Unknown vertex generation region!");
     }
 
-    G4ThreeVector displacement = G4ThreeVector(0., 0., -gate_zpos_in_vessel_);
-    vertex = vertex + displacement;
+    vertex = vertex + displ_from_origin_;
 
     return vertex;
   }

--- a/source/geometries/Next100.h
+++ b/source/geometries/Next100.h
@@ -59,6 +59,7 @@ namespace nexus {
     const G4double gate_tracking_plane_distance_, gate_sapphire_wdw_distance_;
     const G4double ics_ep_lip_width_ ; ///< width of step of the ICS bars in the
     /// energy plane side
+    const G4double fc_displ_x_, fc_displ_y_;
 
     // Pointers to logical volumes
     G4LogicalVolume* lab_logic_;

--- a/source/geometries/Next100.h
+++ b/source/geometries/Next100.h
@@ -81,7 +81,7 @@ namespace nexus {
     G4ThreeVector specific_vertex_;
 
     /// Position of gate in its mother volume
-    G4double gate_zpos_in_vessel_;
+    G4ThreeVector displ_from_origin_;
 
     /// Whether or not to build LSC HallA.
     G4bool lab_walls_;

--- a/source/geometries/Next100.h
+++ b/source/geometries/Next100.h
@@ -81,8 +81,8 @@ namespace nexus {
     /// Specific vertex for AD_HOC region
     G4ThreeVector specific_vertex_;
 
-    /// Position of gate in its mother volume
-    G4ThreeVector displ_from_origin_;
+    /// Origin of coordinates
+    G4ThreeVector coord_origin_;
 
     /// Whether or not to build LSC HallA.
     G4bool lab_walls_;

--- a/source/geometries/Next100.h
+++ b/source/geometries/Next100.h
@@ -86,6 +86,9 @@ namespace nexus {
 
     /// Whether or not to build LSC HallA.
     G4bool lab_walls_;
+
+    /// Whether or not to print SiPM positions
+    G4bool print_;
   };
 
 } // end namespace nexus

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -207,7 +207,7 @@ namespace nexus {
     G4double stand_out_length =
       sapphire_window_thickn_ + tpb_thickn_ + optical_pad_thickn_ + pmt_stand_out_;
 
-    copper_plate_posz_ = GetCoordOrigin()[2]
+    copper_plate_posz_ = GetCoordOrigin().z()
       + gate_sapphire_wdw_dist_ + stand_out_length + copper_plate_thickn_/2.;
 
     new G4PVPlacement(0, G4ThreeVector(0., 0., copper_plate_posz_), copper_plate_logic,

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -51,7 +51,7 @@ namespace nexus {
     hut_hole_length_  (45. * mm),
     hut_length_long_  (120.* mm),
     hut_length_medium_(100.* mm),
-    hut_length_short_ (60. * mm),
+    hut_length_short_ (60. * mm - 1 * mm), // 60 from drawings, subtraction needed to solve small overlap
     last_hut_long_   (17),
     last_hut_medium_ (35),
 

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -207,7 +207,8 @@ namespace nexus {
     G4double stand_out_length =
       sapphire_window_thickn_ + tpb_thickn_ + optical_pad_thickn_ + pmt_stand_out_;
 
-    copper_plate_posz_ = GetELzCoord() + gate_sapphire_wdw_dist_ + stand_out_length + copper_plate_thickn_/2.;
+    copper_plate_posz_ = GetCoordOrigin()[2]
+      + gate_sapphire_wdw_dist_ + stand_out_length + copper_plate_thickn_/2.;
 
     new G4PVPlacement(0, G4ThreeVector(0., 0., copper_plate_posz_), copper_plate_logic,
                       "EP_COPPER_PLATE", mother_logic_, false, 0, false);
@@ -414,7 +415,7 @@ namespace nexus {
       do {
         vertex = copper_gen_->GenerateVertex("VOLUME");
         G4ThreeVector glob_vtx(vertex);
-        glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+        glob_vtx = glob_vtx - GetCoordOrigin();
         VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
       } while (VertexVolume->GetName() != region);
     }
@@ -430,7 +431,7 @@ namespace nexus {
         G4double z_translation = vacuum_posz_;
         vertex.setZ(vertex.z() + z_translation);
         G4ThreeVector glob_vtx(vertex);
-        glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+        glob_vtx = glob_vtx - GetCoordOrigin();
         VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
       } while (VertexVolume->GetName() != region);
     }

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -534,7 +534,7 @@ void Next100FieldCage::BuildELRegion()
   if (elfield_) {
     /// Define EL electric field
     UniformElectricDriftField* el_field = new UniformElectricDriftField();
-    G4double global_el_gap_zpos = el_gap_zpos_ - GetCoordOrigin()[2];
+    G4double global_el_gap_zpos = el_gap_zpos_ - GetCoordOrigin().z();
     el_field->SetCathodePosition(global_el_gap_zpos + el_gap_length_/2. + grid_thickn_);
     el_field->SetAnodePosition  (global_el_gap_zpos - el_gap_length_/2. - grid_thickn_);
     el_field->SetDriftVelocity(2.5 * mm/microsecond);
@@ -793,10 +793,10 @@ void Next100FieldCage::BuildFieldCage()
   }
 
   // Ring vertex generator
-  G4double ring_gen_lenght = first_ring_buff_z_pos + ring_thickn_/2. - (posz - ring_thickn_/2.);
-  G4double ring_gen_zpos = first_ring_buff_z_pos + ring_thickn_/2. - ring_gen_lenght/2.;
+  G4double ring_gen_length = first_ring_buff_z_pos + ring_thickn_/2. - (posz - ring_thickn_/2.);
+  G4double ring_gen_zpos = first_ring_buff_z_pos + ring_thickn_/2. - ring_gen_length/2.;
   ring_gen_ =
-    new CylinderPointSampler2020(ring_int_diam_/2., ring_ext_diam_/2., ring_gen_lenght/2.,
+    new CylinderPointSampler2020(ring_int_diam_/2., ring_ext_diam_/2., ring_gen_length/2.,
                                  0., twopi, nullptr,
                                  G4ThreeVector(GetCoordOrigin().x(),
                                                GetCoordOrigin().y(), ring_gen_zpos));

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -214,7 +214,7 @@ void Next100FieldCage::Construct()
   buffer_length_ = gate_sapphire_wdw_dist_ - gate_cathode_dist_ - grid_thickn_;
 
   /// Calculate relative z positions in mother volume
-  /// All of them are calculated from GetELzCoord(), which is the position
+  /// All of them are calculated from GetCoordOrigin(), which is the position
   /// of the beginning of the ACTIVE volume and the end of the gate grid.
   gate_grid_zpos_  = GetCoordOrigin().z() - grid_thickn_/2.;
   active_zpos_     = GetCoordOrigin().z() + active_length_/2.;
@@ -808,12 +808,12 @@ void Next100FieldCage::BuildFieldCage()
   // Length is approximated to avoid complicated calculations.
   // The correct positioning of vertices is checked at run time anyway.
   G4double stave_gen_length =
-    teflon_buffer_zpos_ - GetELzCoord() + teflon_buffer_length_/2;
+    teflon_buffer_zpos_ - GetCoordOrigin().z() + teflon_buffer_length_/2;
   holder_gen_ =
     new CylinderPointSampler2020(active_diam_/2. + teflon_thickn_ ,
                                  active_diam_/2. + teflon_thickn_ + holder_long_y + holder_short_y,
                                  stave_gen_length/2., 0., twopi, nullptr,
-                                 G4ThreeVector(0., 0., GetELzCoord() + stave_gen_length/2.));
+                                 G4ThreeVector(0., 0., GetCoordOrigin().z() + stave_gen_length/2.));
 
    /// Visibilities
   if (visibility_) {

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -47,7 +47,7 @@ using namespace nexus;
 Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   GeometryBase(),
   // Dimensions
-  active_diam_         (984. * mm), // distance between the centers of two opposite panels
+  active_diam_         (983.3 * mm), // distance between the centers of two opposite panels
   n_panels_            (18),
   active_ext_radius_   (active_diam_/2. / cos(pi/n_panels_)),
 
@@ -72,8 +72,8 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   // cathode_sapphire_wdw_dist_(257.8 * mm),
 
   // external to teflon (hdpe + rings + holders)
-  hdpe_tube_int_diam_ (1093. * mm - 11. * mm), // we keep the thickness, but we make it smaller to be closer to the staves
-  hdpe_tube_ext_diam_ (1105.4 * mm - 11. * mm),
+  hdpe_tube_int_diam_ (1081. * mm),
+  hdpe_tube_ext_diam_ (1094 * mm),
   hdpe_length_        (1115. * mm),
 
   ring_ext_diam_ (1038. * mm),

--- a/source/geometries/Next100FieldCage.h
+++ b/source/geometries/Next100FieldCage.h
@@ -85,6 +85,7 @@ namespace nexus {
     G4double teflon_drift_length_, teflon_drift_zpos_,teflon_buffer_zpos_;
     G4double active_zpos_, cathode_zpos_, gate_zpos_, el_gap_zpos_;
     G4double gate_grid_zpos_, anode_grid_zpos_;
+    G4double active_gen_radius_;
 
 
     // Vertex generators

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -66,7 +66,6 @@ namespace nexus {
 
     // ICS
     G4double ics_z_pos = GetCoordOrigin().z() + length/2. - gate_tp_distance_;
-    G4ThreeVector coord_origin = GetCoordOrigin();
 
     G4Tubs* ics_body = new G4Tubs("ICS", in_rad_, in_rad_ + thickness_,
                                   length/2., 0.*deg, 360.*deg);

--- a/source/geometries/Next100Ics.cc
+++ b/source/geometries/Next100Ics.cc
@@ -65,7 +65,7 @@ namespace nexus {
     G4double offset = 1.* mm;
 
     // ICS
-    G4double ics_z_pos = length/2. - gate_tp_distance_;
+    G4double ics_z_pos = GetCoordOrigin().z() + length/2. - gate_tp_distance_;
     G4ThreeVector coord_origin = GetCoordOrigin();
 
     G4Tubs* ics_body = new G4Tubs("ICS", in_rad_, in_rad_ + thickness_,
@@ -90,25 +90,25 @@ namespace nexus {
                  (thickness_ + offset)/2., 0.*deg, 360.*deg);
 
 
-    G4ThreeVector pos1a =
-      G4ThreeVector(port_x, port_y, port_z_1a_-ics_z_pos) - coord_origin;
-    ics_solid =
-      new G4SubtractionSolid("ICS", ics_body, port_hole_solid, port_a_Rot, pos1a);
+   ics_solid =
+      new G4SubtractionSolid("ICS", ics_body, port_hole_solid,
+                             port_a_Rot, G4ThreeVector(port_x, port_y,
+                                                       port_z_1a_-ics_z_pos));
 
-    G4ThreeVector pos2a =
-      G4ThreeVector(port_x, port_y, port_z_2a_-ics_z_pos) - coord_origin;
     ics_solid =
-      new G4SubtractionSolid("ICS", ics_solid, port_hole_solid, port_a_Rot, pos2a);
+      new G4SubtractionSolid("ICS", ics_solid, port_hole_solid,
+                             port_a_Rot, G4ThreeVector(port_x, port_y,
+                                                       port_z_2a_-ics_z_pos));
 
-    G4ThreeVector pos1b =
-      G4ThreeVector(-port_x, port_y, port_z_1b_-ics_z_pos) - coord_origin;
     ics_solid =
-      new G4SubtractionSolid("ICS", ics_solid, port_hole_solid, port_b_Rot, pos1b);
+      new G4SubtractionSolid("ICS", ics_solid, port_hole_solid,
+                             port_b_Rot, G4ThreeVector(-port_x, port_y,
+                                                       port_z_1b_-ics_z_pos));
 
-    G4ThreeVector pos2b =
-      G4ThreeVector(-port_x, port_y, port_z_2b_-ics_z_pos) - coord_origin;;
     ics_solid =
-      new G4SubtractionSolid("ICS", ics_solid, port_hole_solid, port_b_Rot, pos2b);
+      new G4SubtractionSolid("ICS", ics_solid, port_hole_solid,
+                             port_b_Rot, G4ThreeVector(-port_x, port_y,
+                                                       port_z_2b_-ics_z_pos));
 
     /// Upper holes
     // z distances measured with respect to TP plate, ie the start of ICS
@@ -190,9 +190,7 @@ namespace nexus {
       new G4LogicalVolume(ics_solid,
         G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu"), "ICS");
 
-    G4ThreeVector ics_pos_in_mother =
-      G4ThreeVector(0., 0., ics_z_pos) + GetCoordOrigin();
-    new G4PVPlacement(0, ics_pos_in_mother, ics_logic,
+    new G4PVPlacement(0, G4ThreeVector(0., 0., ics_z_pos), ics_logic,
                       "ICS", mother_logic_, false, 0, false);
 
 
@@ -207,10 +205,10 @@ namespace nexus {
     }
 
     // VERTEX GENERATOR
-    G4ThreeVector gen_pos = G4ThreeVector(0., 0., ics_z_pos) + GetCoordOrigin();
     ics_gen_ =
-      new CylinderPointSampler2020(in_rad_, in_rad_ + thickness_, length/2., 0.*deg, 360.*deg,
-                                   0, gen_pos);
+      new CylinderPointSampler2020(in_rad_, in_rad_ + thickness_, length/2.,
+                                   0.*deg, 360.*deg,
+                                   0, G4ThreeVector(0., 0., ics_z_pos));
   }
 
 

--- a/source/geometries/Next100InnerElements.cc
+++ b/source/geometries/Next100InnerElements.cc
@@ -56,7 +56,8 @@ namespace nexus {
   void Next100InnerElements::Construct()
   {
     // Position in Z of the beginning of the drift region
-    G4double gate_zpos = GetELzCoord();
+    //G4double gate_zpos = GetELzCoord();
+    G4ThreeVector coord_origin = GetCoordOrigin();
     // Reading mother material
     gas_ = mother_logic_->GetMaterial();
     pressure_ =    gas_->GetPressure();
@@ -65,19 +66,19 @@ namespace nexus {
     // Field Cage
     field_cage_->SetMotherLogicalVolume(mother_logic_);
     field_cage_->SetMotherPhysicalVolume(mother_phys_);
-    field_cage_->SetELzCoord(gate_zpos);
+    field_cage_->SetCoordOrigin(coord_origin);
     field_cage_->SetELtoSapphireWDWdistance(gate_sapphire_wdw_distance_);
     field_cage_->Construct();
 
     // Energy Plane
     energy_plane_->SetMotherLogicalVolume(mother_logic_);
-    energy_plane_->SetELzCoord(gate_zpos);
+    energy_plane_->SetCoordOrigin(coord_origin);
     energy_plane_->SetELtoSapphireWDWdistance(gate_sapphire_wdw_distance_);
     energy_plane_->Construct();
 
     // Tracking plane
     tracking_plane_->SetMotherPhysicalVolume(mother_phys_);
-    tracking_plane_->SetELzCoord(gate_zpos);
+    tracking_plane_->SetCoordOrigin(coord_origin);
     tracking_plane_->SetELtoTPdistance(gate_tracking_plane_distance_);
     tracking_plane_->Construct();
   }

--- a/source/geometries/Next100InnerElements.cc
+++ b/source/geometries/Next100InnerElements.cc
@@ -79,6 +79,8 @@ namespace nexus {
     tracking_plane_->SetCoordOrigin(coord_origin);
     tracking_plane_->SetELtoTPdistance(gate_tracking_plane_distance_);
     tracking_plane_->Construct();
+
+    tracking_plane_->GetSiPMPosInGas(sipm_pos_);
   }
 
 

--- a/source/geometries/Next100InnerElements.cc
+++ b/source/geometries/Next100InnerElements.cc
@@ -55,8 +55,6 @@ namespace nexus {
 
   void Next100InnerElements::Construct()
   {
-    // Position in Z of the beginning of the drift region
-    //G4double gate_zpos = GetELzCoord();
     G4ThreeVector coord_origin = GetCoordOrigin();
     // Reading mother material
     gas_ = mother_logic_->GetMaterial();

--- a/source/geometries/Next100InnerElements.h
+++ b/source/geometries/Next100InnerElements.h
@@ -45,6 +45,9 @@ namespace nexus {
     /// Return the relative position respect to the rest of NEXT100 geometry
     G4ThreeVector GetPosition() const;
 
+    /// Return the positions of the SiPMs in their mother volume (gas)
+    std::vector<G4ThreeVector> GetSiPMPosInGas() const;
+
     /// Generate a vertex within a given region of the geometry
     G4ThreeVector GenerateVertex(const G4String& region) const;
 
@@ -73,6 +76,9 @@ namespace nexus {
     // Messenger for the definition of control commands
     G4GenericMessenger* msg_;
 
+    // Positions of the SiPMs in their mother volume (gas)
+    std::vector<G4ThreeVector> sipm_pos_;
+
   };
 
   inline void Next100InnerElements::SetELtoTPdistance(G4double distance){
@@ -81,6 +87,11 @@ namespace nexus {
 
   inline void Next100InnerElements::SetELtoSapphireWDWdistance(G4double distance){
     gate_sapphire_wdw_distance_ = distance;
+  }
+
+  inline std::vector<G4ThreeVector> Next100InnerElements::GetSiPMPosInGas() const
+  {
+    return sipm_pos_;
   }
 
 } // end namespace nexus

--- a/source/geometries/Next100OpticalGeometry.cc
+++ b/source/geometries/Next100OpticalGeometry.cc
@@ -128,7 +128,7 @@ namespace nexus {
                 "Unknown kind of gas, valid options are: naturalXe, enrichedXe, depletedXe.");
   }
 
-  G4double gas_size = lab_size - 1.*cm;
+  G4double gas_size = lab_size - 10.*cm;
   G4Box* gas_solid = new G4Box("GAS", gas_size/2., gas_size/2., gas_size/2.);
   G4LogicalVolume* gas_logic = new G4LogicalVolume(gas_solid, gas_mat, "GAS");
 

--- a/source/geometries/Next100OpticalGeometry.cc
+++ b/source/geometries/Next100OpticalGeometry.cc
@@ -34,11 +34,13 @@ namespace nexus {
     // common variables used in geometry components
     grid_thickness_ (0.1 * mm),
     gate_tracking_plane_distance_(25. * mm + grid_thickness_),
-    gate_sapphire_wdw_distance_  ((1458.8 - 1.3) * mm - grid_thickness_),
+    gate_sapphire_wdw_distance_  (1458.8 * mm - grid_thickness_),
     pressure_(15. * bar),
     temperature_ (300 * kelvin),
     sc_yield_(25510. * 1/MeV),
     e_lifetime_(1000. * ms),
+    fc_displ_x_ (-3.7 * mm), // displacement of the field cage volumes from 0
+    fc_displ_y_ (-6.4 * mm), // displacement of the field cage volumes from 0
     specific_vertex_{},
     gas_("naturalXe")
   {
@@ -130,15 +132,15 @@ namespace nexus {
   G4Box* gas_solid = new G4Box("GAS", gas_size/2., gas_size/2., gas_size/2.);
   G4LogicalVolume* gas_logic = new G4LogicalVolume(gas_solid, gas_mat, "GAS");
 
-  gate_zpos_in_gas_ = 0. * mm;
+  coord_origin_ = G4ThreeVector(fc_displ_x_, fc_displ_y_, 0);
   G4VPhysicalVolume* gas_phys =
-    new G4PVPlacement(0, G4ThreeVector(0, 0, -gate_zpos_in_gas_), gas_logic,
+    new G4PVPlacement(0, -coord_origin_, gas_logic,
 		      "GAS", lab_logic, false, 0, false);
 
   ///INNER ELEMENTS
   inner_elements_->SetLogicalVolume(gas_logic);
   inner_elements_->SetPhysicalVolume(gas_phys);
-  inner_elements_->SetELzCoord(gate_zpos_in_gas_);
+  inner_elements_->SetCoordOrigin(coord_origin_);
   inner_elements_->SetELtoSapphireWDWdistance(gate_sapphire_wdw_distance_);
   inner_elements_->SetELtoTPdistance         (gate_tracking_plane_distance_);
   inner_elements_->Construct();
@@ -167,8 +169,7 @@ namespace nexus {
       vertex = inner_elements_->GenerateVertex(region);
     }
 
-    G4ThreeVector displacement = G4ThreeVector(0., 0., -gate_zpos_in_gas_);
-    vertex = vertex + displacement;
+    vertex = vertex - coord_origin_;
     return vertex;
   }
 

--- a/source/geometries/Next100OpticalGeometry.h
+++ b/source/geometries/Next100OpticalGeometry.h
@@ -48,6 +48,8 @@ namespace nexus {
     G4double temperature_;
     G4double sc_yield_;
     G4double e_lifetime_;
+    G4double fc_displ_x_, fc_displ_y_;
+    G4ThreeVector coord_origin_;
 
     // Vertex decided by user
     G4ThreeVector specific_vertex_;
@@ -55,9 +57,6 @@ namespace nexus {
     G4String gas_;
 
     Next100InnerElements* inner_elements_;
-
-    // Relative position of the gate in its mother volume
-    G4double gate_zpos_in_gas_;
 
   };
 

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -645,7 +645,8 @@ namespace nexus {
           vertex = lead_gen_->GenerateVertex("WHOLE_VOL");
           G4ThreeVector glob_vtx(vertex);
           glob_vtx = glob_vtx - GetCoordOrigin();
-          VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
+          VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx,
+                                                                    0, false);
         } while (VertexVolume->GetName() != "LEAD_BOX");
     }
 
@@ -655,7 +656,8 @@ namespace nexus {
         vertex = steel_gen_->GenerateVertex("WHOLE_VOL");
         G4ThreeVector glob_vtx(vertex);
         glob_vtx = glob_vtx - GetCoordOrigin();
-        VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
+        VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx,
+                                                                  0, false);
       } while (VertexVolume->GetName() != "STEEL_BOX");
     }
 
@@ -665,7 +667,8 @@ namespace nexus {
         vertex = inner_air_gen_->GenerateVertex("INSIDE");
         G4ThreeVector glob_vtx(vertex);
         glob_vtx = glob_vtx - GetCoordOrigin();
-        VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
+        VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx,
+                                                                  0, false);
       } while (VertexVolume->GetName() != "INNER_AIR");
     }
 
@@ -683,7 +686,7 @@ namespace nexus {
               vertex.setZ(vertex.z() +
                           (shield_z_/2.+steel_thickness_+lead_thickness_/2.));
             }
-            else{
+            else {
               vertex.setZ(vertex.z() -
                           (shield_z_/2.+steel_thickness_+lead_thickness_/2.));
             }
@@ -733,14 +736,14 @@ namespace nexus {
           if (G4UniformRand()<lat_prob){ //lateral
             G4double rand_beam = int (4 * G4UniformRand());
             vertex = lat_beam_gen_->GenerateVertex("INSIDE");
-            if (rand_beam ==1){
+            if (rand_beam == 1){
               vertex.setZ(vertex.z() - lateral_z_separation_);
             }
-            else if (rand_beam ==2){
+            else if (rand_beam == 2){
               vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ +
                                         lead_thickness_));
             }
-            else if (rand_beam ==3){
+            else if (rand_beam == 3){
               vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ +
                                         lead_thickness_));
               vertex.setZ(vertex.z() - lateral_z_separation_);

--- a/source/geometries/Next100Shielding.cc
+++ b/source/geometries/Next100Shielding.cc
@@ -644,9 +644,8 @@ namespace nexus {
         do {
           vertex = lead_gen_->GenerateVertex("WHOLE_VOL");
           G4ThreeVector glob_vtx(vertex);
-          glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
-          VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx,
-                                                                    0, false);
+          glob_vtx = glob_vtx - GetCoordOrigin();
+          VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
         } while (VertexVolume->GetName() != "LEAD_BOX");
     }
 
@@ -655,20 +654,18 @@ namespace nexus {
       do {
         vertex = steel_gen_->GenerateVertex("WHOLE_VOL");
         G4ThreeVector glob_vtx(vertex);
-        glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
-        VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx,
-                                                                  0, false);
+        glob_vtx = glob_vtx - GetCoordOrigin();
+        VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
       } while (VertexVolume->GetName() != "STEEL_BOX");
     }
 
     else if (region == "INNER_AIR") {
       G4VPhysicalVolume *VertexVolume;
       do {
-          vertex = inner_air_gen_->GenerateVertex("INSIDE");
-          G4ThreeVector glob_vtx(vertex);
-          glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
-          VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx,
-                                                                    0, false);
+        vertex = inner_air_gen_->GenerateVertex("INSIDE");
+        G4ThreeVector glob_vtx(vertex);
+        glob_vtx = glob_vtx - GetCoordOrigin();
+        VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
       } while (VertexVolume->GetName() != "INNER_AIR");
     }
 
@@ -680,7 +677,7 @@ namespace nexus {
         G4double rand = G4UniformRand();
 
         if (rand < perc_roof_vol_) { //ROOF BEAM STRUCTURE
-        	if (G4UniformRand() <  perc_front_roof_vol_){
+          if (G4UniformRand() <  perc_front_roof_vol_){
             vertex = front_roof_gen_->GenerateVertex("INSIDE");
             if (G4UniformRand() < 0.5) {
               vertex.setZ(vertex.z() +
@@ -690,151 +687,152 @@ namespace nexus {
               vertex.setZ(vertex.z() -
                           (shield_z_/2.+steel_thickness_+lead_thickness_/2.));
             }
-        	}
-        	else{
-              vertex = lat_roof_gen_->GenerateVertex("INSIDE");
-          	  if (G4UniformRand() < 0.5) {
-          	    vertex.setX(vertex.x() +
-                                (shield_x_/2.+ steel_thickness_ +
-                                 lead_thickness_/2.));
-          	  }
-          	  else{
-          	    vertex.setX(vertex.x() -
-                                (shield_x_/2.+ steel_thickness_ +
-                                 lead_thickness_/2.));
-          	  }
-        	}
+          }
+          else {
+            vertex = lat_roof_gen_->GenerateVertex("INSIDE");
+            if (G4UniformRand() < 0.5) {
+              vertex.setX(vertex.x() +
+                          (shield_x_/2.+ steel_thickness_ +
+                           lead_thickness_/2.));
+            }
+            else {
+              vertex.setX(vertex.x() -
+                          (shield_x_/2.+ steel_thickness_ +
+                           lead_thickness_/2.));
+            }
+          }
         }
 
         else if (rand < (perc_top_struct_vol_ + perc_roof_vol_)) { //TOP BEAM STRUCTURE
-            	G4double random = G4UniformRand();
-            	if (random <  perc_struc_x_vol_){
-            	  G4double rand_beam = int (4* G4UniformRand());
-                vertex = struct_x_gen_->GenerateVertex("INSIDE");
-            	  if (rand_beam == 1) {
-            	    vertex.setZ(vertex.z()-roof_z_separation_);
-            	  }
-            	  else if (rand_beam == 2) {
-            	    vertex.setZ(vertex.z()-(roof_z_separation_ +
-                                            lateral_z_separation_));
-            	  }
-            	  else if (rand_beam == 3) {
-            	    vertex.setZ(vertex.z()-(2*roof_z_separation_ +
-                                            lateral_z_separation_));
-            	  }
-            	}
-            	else {
-                vertex = struct_z_gen_->GenerateVertex("INSIDE");
-            	  if (G4UniformRand() < 0.5) {
-            	    vertex.setX(vertex.x()+front_x_separation_);
-            	  }
-              }
-        }
-
-        else{ //LATERAL BEAM STRUCTURE
-              G4double lat_prob = beam_thickness_1/(beam_thickness_1+beam_thickness_2);
-              if (G4UniformRand()<lat_prob){ //lateral
-              	G4double rand_beam = int (4 * G4UniformRand());
-                vertex = lat_beam_gen_->GenerateVertex("INSIDE");
-              	if (rand_beam ==1){
-              	  vertex.setZ(vertex.z() - lateral_z_separation_);
-              	}
-              	else if (rand_beam ==2){
-              	  vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ +
-                                            lead_thickness_));
-              	}
-              	else if (rand_beam ==3){
-              	  vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ +
-                                            lead_thickness_));
-              	  vertex.setZ(vertex.z() - lateral_z_separation_);
-              	}
-              }
-              else{ // front
-                G4double rand_beam = int (4 * G4UniformRand());
-                vertex = front_beam_gen_->GenerateVertex("INSIDE");
-              	if (rand_beam ==1){
-              	  vertex.setX(vertex.x() + front_x_separation_);
-              	}
-              	else if (rand_beam ==2){
-              	  vertex.setZ(vertex.z() - (shield_z_+2*steel_thickness_ +
-                                            lead_thickness_));
-              	}
-              	else if (rand_beam ==3){
-              	  vertex.setX(vertex.x() + front_x_separation_);
-              	  vertex.setZ(vertex.z() - (shield_z_+2*steel_thickness_ +
-                                            lead_thickness_));
-              	}
-              }
+          G4double random = G4UniformRand();
+          if (random <  perc_struc_x_vol_){
+            G4double rand_beam = int (4* G4UniformRand());
+            vertex = struct_x_gen_->GenerateVertex("INSIDE");
+            if (rand_beam == 1) {
+              vertex.setZ(vertex.z()-roof_z_separation_);
             }
+            else if (rand_beam == 2) {
+              vertex.setZ(vertex.z()-(roof_z_separation_ +
+                                      lateral_z_separation_));
+            }
+            else if (rand_beam == 3) {
+              vertex.setZ(vertex.z()-(2*roof_z_separation_ +
+                                      lateral_z_separation_));
+            }
+          }
+          else {
+            vertex = struct_z_gen_->GenerateVertex("INSIDE");
+            if (G4UniformRand() < 0.5) {
+              vertex.setX(vertex.x()+front_x_separation_);
+            }
+          }
         }
 
+        else { //LATERAL BEAM STRUCTURE
+          G4double lat_prob = beam_thickness_1/(beam_thickness_1+beam_thickness_2);
+          if (G4UniformRand()<lat_prob){ //lateral
+            G4double rand_beam = int (4 * G4UniformRand());
+            vertex = lat_beam_gen_->GenerateVertex("INSIDE");
+            if (rand_beam ==1){
+              vertex.setZ(vertex.z() - lateral_z_separation_);
+            }
+            else if (rand_beam ==2){
+              vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ +
+                                        lead_thickness_));
+            }
+            else if (rand_beam ==3){
+              vertex.setX(vertex.x() - (shield_x_ + 2*steel_thickness_ +
+                                        lead_thickness_));
+              vertex.setZ(vertex.z() - lateral_z_separation_);
+            }
+          }
+          else { // front
+            G4double rand_beam = int (4 * G4UniformRand());
+            vertex = front_beam_gen_->GenerateVertex("INSIDE");
+            if (rand_beam ==1){
+              vertex.setX(vertex.x() + front_x_separation_);
+            }
+            else if (rand_beam ==2){
+              vertex.setZ(vertex.z() - (shield_z_+2*steel_thickness_ +
+                                        lead_thickness_));
+            }
+            else if (rand_beam ==3){
+              vertex.setX(vertex.x() + front_x_separation_);
+              vertex.setZ(vertex.z() - (shield_z_+2*steel_thickness_ +
+                                        lead_thickness_));
+            }
+          }
+        }
+        
+    }
+    
     else if(region=="PEDESTAL"){
-        G4double rand = G4UniformRand();
-
-        if (rand < perc_ped_bottom_vol_) { //SUPPORT-BOTTOM
-          vertex = ped_support_bottom_gen_->GenerateVertex("INSIDE");
-      	  if (G4UniformRand() < 0.5) {
-      	    vertex.setZ(vertex.z() - support_beam_dist_);
-      	  }
+      G4double rand = G4UniformRand();
+      
+      if (rand < perc_ped_bottom_vol_) { //SUPPORT-BOTTOM
+        vertex = ped_support_bottom_gen_->GenerateVertex("INSIDE");
+        if (G4UniformRand() < 0.5) {
+          vertex.setZ(vertex.z() - support_beam_dist_);
         }
-        else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_)) { //SUPPORT-TOP
-          vertex = ped_support_top_gen_->GenerateVertex("INSIDE");
-          if (G4UniformRand() < 0.5) {
-      	    vertex.setZ(vertex.z() - support_beam_dist_);
-      	  }
-        }
-        else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_ +
-                         perc_ped_front_vol_)){ //FRONT BEAM
-          vertex = ped_front_gen_->GenerateVertex("INSIDE");
-          if (G4UniformRand() < 0.5) {
-      	    vertex.setZ(vertex.z() - (2.*support_front_dist_ +
-                                      support_beam_dist_));
-      	  }
-        }
-        else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_ +
-                         perc_ped_front_vol_ + perc_ped_lateral_vol_)){ // LATERAL BEAM
-          vertex = ped_lateral_gen_->GenerateVertex("INSIDE");
-          if (G4UniformRand() < 0.5) {
-            vertex.setX(vertex.x() - (pedestal_x_ +
-                                      pedestal_lateral_beam_thickness_));
-          }
-         }
-        else { // ROOF
-          if (G4UniformRand() < 0.5) {
-            vertex = ped_roof_lat_gen_->GenerateVertex("INSIDE");
-            if (G4UniformRand() < 0.5){
-              vertex.setX(vertex.x() - pedestal_top_x_ -
-                          pedestal_roof_thickness_);
-            }
-          }
-          else{
-            vertex = ped_roof_front_gen_->GenerateVertex("INSIDE");
-            if (G4UniformRand() < 0.5){
-              vertex.setZ(vertex.z() - pedestal_lateral_length_ +
-                          pedestal_roof_thickness_);
-            }
-          }
-         }
       }
+      else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_)) { //SUPPORT-TOP
+        vertex = ped_support_top_gen_->GenerateVertex("INSIDE");
+        if (G4UniformRand() < 0.5) {
+          vertex.setZ(vertex.z() - support_beam_dist_);
+        }
+      }
+      else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_ +
+                       perc_ped_front_vol_)){ //FRONT BEAM
+        vertex = ped_front_gen_->GenerateVertex("INSIDE");
+        if (G4UniformRand() < 0.5) {
+          vertex.setZ(vertex.z() - (2.*support_front_dist_ +
+                                    support_beam_dist_));
+        }
+      }
+      else if (rand < (perc_ped_bottom_vol_ + perc_ped_top_vol_ +
+                       perc_ped_front_vol_ + perc_ped_lateral_vol_)){ // LATERAL BEAM
+        vertex = ped_lateral_gen_->GenerateVertex("INSIDE");
+        if (G4UniformRand() < 0.5) {
+          vertex.setX(vertex.x() - (pedestal_x_ +
+                                    pedestal_lateral_beam_thickness_));
+        }
+      }
+      else { // ROOF
+        if (G4UniformRand() < 0.5) {
+          vertex = ped_roof_lat_gen_->GenerateVertex("INSIDE");
+          if (G4UniformRand() < 0.5){
+            vertex.setX(vertex.x() - pedestal_top_x_ -
+                        pedestal_roof_thickness_);
+          }
+        }
+        else{
+          vertex = ped_roof_front_gen_->GenerateVertex("INSIDE");
+          if (G4UniformRand() < 0.5){
+            vertex.setZ(vertex.z() - pedestal_lateral_length_ +
+                        pedestal_roof_thickness_);
+          }
+        }
+      }
+    }
 
     // Note: BUBBLE_SEAL and EDPM_SEAL are not implemented as logical volumes, only their
     // generators. They are placed in INNER_AIR volume.
-    else if(region=="BUBBLE_SEAL"){
+    else if (region=="BUBBLE_SEAL"){
       G4double rand = G4UniformRand();
       if (rand<perc_bubble_front_vol_){ // front
         vertex = bubble_seal_front_gen_->GenerateVertex("INSIDE");
         if (G4UniformRand() < 0.5){
-          vertex.setZ(vertex.z() + (support_beam_dist_/2. + support_front_dist_
-                                 + pedestal_front_beam_thickness_/2. +
+          vertex.setZ(vertex.z() + (support_beam_dist_/2. + support_front_dist_ +
+                                    pedestal_front_beam_thickness_/2. +
                                     bubble_seal_thickness_/2.));
         }
-        else{
-          vertex.setZ(vertex.z() - (support_beam_dist_/2. + support_front_dist_
-                                 + pedestal_front_beam_thickness_/2. +
+        else {
+          vertex.setZ(vertex.z() - (support_beam_dist_/2. + support_front_dist_ +
+                                    pedestal_front_beam_thickness_/2. +
                                     bubble_seal_thickness_/2.));
         }
       }
-      else{ // lateral
+      else { // lateral
         vertex = bubble_seal_lateral_gen_->GenerateVertex("INSIDE");
         if (G4UniformRand() < 0.5){
           vertex.setX(vertex.x() + (pedestal_x_/2. +
@@ -847,8 +845,8 @@ namespace nexus {
                                     bubble_seal_thickness_/2.));
         }
       }
-      }
-
+    }
+    
     else if(region=="EDPM_SEAL"){
       G4double rand = G4UniformRand();
       if (rand<perc_edpm_front_vol_){ // front

--- a/source/geometries/Next100Stave.cc
+++ b/source/geometries/Next100Stave.cc
@@ -64,7 +64,7 @@ void Next100Stave::Construct()
 {
   G4Material* pe500 = materials::PE500();
 
-  // BUFFER staves.
+  // BUFFER part.
   // The unions of volumes go from lower to higher z.
   G4Box* buffer_short_solid =
     new G4Box("BUFF_SHORT", holder_x_/2., holder_short_y_/2. + overlap_/2.,
@@ -102,7 +102,7 @@ void Next100Stave::Construct()
                                    overlap_/2.,
                                    buffer_long_length_/2. - buffer_last_z_/2.));
 
-  // DRIFT staves.
+  // DRIFT part.
   G4Box* drift_short_first_solid =
     new G4Box("DRIFT_SHORT", holder_x_/2., holder_short_y_/2. + overlap_/2.,
               drift_short_first_length_/2.);
@@ -134,7 +134,7 @@ void Next100Stave::Construct()
                                      overlap_/2., posz));
     }
 
-  // CATHODE staves.
+  // CATHODE part.
   // They are placed at the same z position as the cathode ring.
   G4Box* cathode_large_solid =
     new G4Box("CATHODE_LARGE", holder_x_/2., cathode_long_y_/2.,

--- a/source/geometries/Next100TrackingPlane.cc
+++ b/source/geometries/Next100TrackingPlane.cc
@@ -186,7 +186,7 @@ void Next100TrackingPlane::PlaceSiPMBoardColumns(G4int num_boards,
 }
 
 
-void Next100TrackingPlane::PrintSiPMPositions() const
+void Next100TrackingPlane::PrintSiPMPosInGas() const
 {
   auto sipm_positions = sipm_board_geom_->GetSiPMPositions();
 
@@ -198,6 +198,18 @@ void Next100TrackingPlane::PrintSiPMPositions() const
     }
   }
 }
+
+void Next100TrackingPlane::GetSiPMPosInGas(std::vector<G4ThreeVector>& sipm_pos) const
+{
+  auto sipm_positions = sipm_board_geom_->GetSiPMPositions();
+  for (unsigned int i=0; i<board_pos_.size(); ++i) {
+    for (unsigned int j=0; j<sipm_positions.size(); ++j) {
+      G4ThreeVector pos = sipm_positions[j] + board_pos_[i];
+      sipm_pos.push_back(pos);
+    }
+  }
+}
+
 
 
 G4ThreeVector Next100TrackingPlane::GenerateVertex(const G4String& region) const

--- a/source/geometries/Next100TrackingPlane.cc
+++ b/source/geometries/Next100TrackingPlane.cc
@@ -100,7 +100,7 @@ void Next100TrackingPlane::Construct()
   sipm_board_geom_->Construct();
   G4LogicalVolume* sipm_board_logic = sipm_board_geom_->GetLogicalVolume();
 
-  G4double zpos = GetELzCoord() - gate_tp_dist_ + sipm_board_geom_->GetThickness()/2.;
+  G4double zpos = GetCoordOrigin()[2] - gate_tp_dist_ + sipm_board_geom_->GetThickness()/2.;
 
   // SiPM boards are positioned bottom (negative Y) to top (positive Y)
   // and left (negative X) to right (positive X).
@@ -211,7 +211,7 @@ G4ThreeVector Next100TrackingPlane::GenerateVertex(const G4String& region) const
         G4int board_num = G4RandFlat::shootInt((long) 0, board_pos_.size());
         vertex += board_pos_[board_num];
         G4ThreeVector glob_vtx(vertex);
-        glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+        glob_vtx = glob_vtx - GetCoordOrigin();
         VertexVolume =
           geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
 

--- a/source/geometries/Next100TrackingPlane.cc
+++ b/source/geometries/Next100TrackingPlane.cc
@@ -84,7 +84,7 @@ void Next100TrackingPlane::Construct()
   G4LogicalVolume* copper_plate_logic =
     new G4LogicalVolume(copper_plate_solid, copper, copper_plate_name);
 
-  G4double copper_plate_zpos = GetCoordOrigin()[2] - gate_tp_dist_ - copper_plate_thickness_/2.;
+  G4double copper_plate_zpos = GetCoordOrigin().z() - gate_tp_dist_ - copper_plate_thickness_/2.;
 
   G4VPhysicalVolume* copper_plate_phys =
     new G4PVPlacement(nullptr, G4ThreeVector(0.,0.,copper_plate_zpos),
@@ -100,7 +100,7 @@ void Next100TrackingPlane::Construct()
   sipm_board_geom_->Construct();
   G4LogicalVolume* sipm_board_logic = sipm_board_geom_->GetLogicalVolume();
 
-  G4double zpos = GetCoordOrigin()[2] - gate_tp_dist_ + sipm_board_geom_->GetThickness()/2.;
+  G4double zpos = GetCoordOrigin().z() - gate_tp_dist_ + sipm_board_geom_->GetThickness()/2.;
 
   // SiPM boards are positioned bottom (negative Y) to top (positive Y)
   // and left (negative X) to right (positive X).

--- a/source/geometries/Next100TrackingPlane.cc
+++ b/source/geometries/Next100TrackingPlane.cc
@@ -84,7 +84,7 @@ void Next100TrackingPlane::Construct()
   G4LogicalVolume* copper_plate_logic =
     new G4LogicalVolume(copper_plate_solid, copper, copper_plate_name);
 
-  G4double copper_plate_zpos = GetELzCoord() - gate_tp_dist_ - copper_plate_thickness_/2.;
+  G4double copper_plate_zpos = GetCoordOrigin()[2] - gate_tp_dist_ - copper_plate_thickness_/2.;
 
   G4VPhysicalVolume* copper_plate_phys =
     new G4PVPlacement(nullptr, G4ThreeVector(0.,0.,copper_plate_zpos),

--- a/source/geometries/Next100TrackingPlane.h
+++ b/source/geometries/Next100TrackingPlane.h
@@ -40,7 +40,8 @@ namespace nexus {
     //
     G4ThreeVector GenerateVertex(const G4String&) const override;
 
-    void PrintSiPMPositions() const;
+    void PrintSiPMPosInGas() const;
+    void GetSiPMPosInGas(std::vector<G4ThreeVector>& sipm_pos) const;
 
   private:
     void PlaceSiPMBoardColumns(G4int, G4double, G4double, G4int&, G4LogicalVolume*);

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -467,7 +467,16 @@ namespace nexus {
         vertex = tracking_flange_gen_->GenerateVertex("VOLUME");
       }
       else {// Body
-        vertex = body_gen_->GenerateVertex("VOLUME");
+        G4VPhysicalVolume* VertexVolume;
+        do {
+          vertex = body_gen_->GenerateVertex("VOLUME");
+
+          G4ThreeVector glob_vtx(vertex);
+          // this->GetCoordOrigin() only has x and y set
+          glob_vtx = glob_vtx - GetCoordOrigin() - G4ThreeVector(0, 0, gate_z_pos_);
+          VertexVolume =
+            geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
+        } while (VertexVolume->GetName() != "VESSEL");
       }
     }
 

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -457,7 +457,7 @@ namespace nexus {
           vertex = energy_flange_gen_->GenerateVertex("VOLUME");
 
           G4ThreeVector glob_vtx(vertex);
-          glob_vtx = glob_vtx + G4ThreeVector(0, 0, -GetELzCoord());
+          glob_vtx = glob_vtx - GetCoordOrigin();
           VertexVolume =
             geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
         } while (VertexVolume->GetName() != "VESSEL");

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -328,8 +328,7 @@ namespace nexus {
     G4LogicalVolume* vessel_gas_logic = new G4LogicalVolume(vessel_gas_final_solid, vessel_gas_mat, "VESSEL_GAS");
 
     internal_logic_vol_ = vessel_gas_logic;
-    G4double el_z_coord = flange_tp_z_pos + flange_tp_length /2. + 67.5*mm + gate_tp_distance_;
-    SetELzCoord(el_z_coord);
+    SetGateZpos(flange_tp_z_pos + flange_tp_length /2. + 67.5*mm + gate_tp_distance_);
     internal_phys_vol_ =
       new G4PVPlacement(0, G4ThreeVector(0.,0.,0.), vessel_gas_logic,
                         "VESSEL_GAS", vessel_logic, false, 0, false);

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -457,7 +457,8 @@ namespace nexus {
           vertex = energy_flange_gen_->GenerateVertex("VOLUME");
 
           G4ThreeVector glob_vtx(vertex);
-          glob_vtx = glob_vtx - GetCoordOrigin();
+          // this->GetCoordOrigin() only has x and y set
+          glob_vtx = glob_vtx - GetCoordOrigin() - G4ThreeVector(0, 0, gate_z_pos_);
           VertexVolume =
             geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
         } while (VertexVolume->GetName() != "VESSEL");

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -63,6 +63,7 @@ namespace nexus {
     G4double sc_yield_, e_lifetime_;
     G4double pressure_, temperature_;
     G4double gate_tp_distance_;
+    G4double gate_z_pos_;
 
     // Visibility of the shielding
     G4bool visibility_;

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -39,6 +39,10 @@ namespace nexus {
     G4VPhysicalVolume* GetInternalPhysicalVolume();
 
     void SetELtoTPdistance(G4double);
+    void SetGateZpos(G4double);
+
+    G4double GetGateZpos();
+
     // get Z position of calibration ports
     G4double* GetPortZpositions();
 
@@ -94,6 +98,14 @@ namespace nexus {
 
   inline void Next100Vessel::SetELtoTPdistance(G4double distance){
     gate_tp_distance_ = distance;
+  }
+
+  inline void Next100Vessel::SetGateZpos(G4double pos){
+    gate_z_pos_ = pos;
+  }
+
+  inline G4double Next100Vessel::GetGateZpos(){
+    return gate_z_pos_;
   }
 
 } // end namespace nexus

--- a/source/geometries/Next1EL.cc
+++ b/source/geometries/Next1EL.cc
@@ -293,7 +293,6 @@ void Next1EL::BuildLab()
 
   lab_logic_ = new G4LogicalVolume(lab_solid, air_, "LAB");
   lab_logic_->SetVisAttributes(G4VisAttributes::GetInvisible());
-  this->SetDrift(true);
 
   // Set this volume as the wrapper for the whole geometry
   // (i.e., this is the volume that will be placed in the world)

--- a/source/geometries/NextFlex.cc
+++ b/source/geometries/NextFlex.cc
@@ -58,7 +58,8 @@ NextFlex::NextFlex():
                                 "Control commands of the NextFlex geometry.");
 
   // Hard-wired dimensions
-  lightTube_ICS_gap_ = 55. * mm;  // (Set as in NEXT100. To be checked)
+  // Set as in NEXT100: ICS inner rad - active diam/2. - teflon thickness
+  lightTube_ICS_gap_ = 57.65 * mm;
 
   // Parametrized dimensions
   DefineConfigurationParameters();


### PR DESCRIPTION
This PR displaces the field cage volumes in `xy`, trying to reproduce the real displacement at LSC as much as possible. This displacement is caused by having two HDPE layers only in one sector of the cylinder, and not all over the place.
Modifications have been made in order to have the `ACTIVE` volume centred in the TPC axis.