### PR TITLE
Add memory header

### DIFF
--- a/source/base/DetectorConstruction.h
+++ b/source/base/DetectorConstruction.h
@@ -11,6 +11,8 @@
 
 #include <G4VUserDetectorConstruction.hh>
 
+#include <memory>
+
 class G4GenericMessenger;
 
 namespace nexus {

--- a/source/base/PrimaryGeneration.h
+++ b/source/base/PrimaryGeneration.h
@@ -13,6 +13,8 @@
 #include <G4VUserPrimaryGeneratorAction.hh>
 #include <globals.hh>
 
+#include <memory>
+
 class G4VPrimaryGenerator;
 
 namespace nexus {


### PR DESCRIPTION
This header is necessary in some compilers to include reference to smart pointers. Some compilers issue an error if it is missing.