### PR TITLE
Add Th calibration source

### DIFF
--- a/macros/NEXT100.config.mac
+++ b/macros/NEXT100.config.mac
@@ -1,7 +1,7 @@
 ## ----------------------------------------------------------------------------
 ## nexus | NEXT100.config.mac
 ##
-## Configuration macro to simulate Bi-214 radioactive decays from thethe
+## Configuration macro to simulate Bi-214 radioactive decays from the
 ## copper plate of the tracking plane in the NEXT-100 detector.
 ##
 ## The NEXT Collaboration

--- a/macros/calibration/NEW_external_source.init.mac
+++ b/macros/calibration/NEW_external_source.init.mac
@@ -1,0 +1,28 @@
+## ----------------------------------------------------------------------------
+## nexus | NEW_disk_source.init.mac
+##
+## Initialization macro to simulate the activity of a specific calibration
+## source in the NEXT-WHITE detector. The source is placed outside the
+## axial or the lateral port, with lead collimator and external scintillator.
+##
+## The NEXT Collaboration
+## ----------------------------------------------------------------------------
+
+### PHYSICS
+/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
+/PhysicsList/RegisterPhysics G4DecayPhysics
+/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
+/PhysicsList/RegisterPhysics NexusPhysics
+/PhysicsList/RegisterPhysics G4StepLimiterPhysics
+
+/nexus/RegisterGeometry NextNew
+
+/nexus/RegisterGenerator IonGenerator
+
+/nexus/RegisterPersistencyManager PersistencyManager
+
+/nexus/RegisterTrackingAction DefaultTrackingAction
+/nexus/RegisterEventAction DefaultEventAction
+/nexus/RegisterRunAction DefaultRunAction
+
+/nexus/RegisterMacro macros/calibration/NEW_external_source.config.mac

--- a/macros/calibration/NEW_internal_source.init.mac
+++ b/macros/calibration/NEW_internal_source.init.mac
@@ -1,0 +1,29 @@
+## ----------------------------------------------------------------------------
+## nexus | NEW_disk_source.init.mac
+##
+## Initialization macro to simulate the activity of a specific calibration
+## source in the NEXT-WHITE detector. The source is placed inside one of the
+## ports inside the feedthrough, at configurable distance
+## from the most internal part of the feedthrough.
+##
+## The NEXT Collaboration
+## ----------------------------------------------------------------------------
+
+### PHYSICS
+/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
+/PhysicsList/RegisterPhysics G4DecayPhysics
+/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
+/PhysicsList/RegisterPhysics NexusPhysics
+/PhysicsList/RegisterPhysics G4StepLimiterPhysics
+
+/nexus/RegisterGeometry NextNew
+
+/nexus/RegisterGenerator IonGenerator
+
+/nexus/RegisterPersistencyManager PersistencyManager
+
+/nexus/RegisterTrackingAction DefaultTrackingAction
+/nexus/RegisterEventAction DefaultEventAction
+/nexus/RegisterRunAction DefaultRunAction
+
+/nexus/RegisterMacro macros/calibration/NEW_internal_source.config.mac

--- a/macros/calibration/NEXT100_cal.config.mac
+++ b/macros/calibration/NEXT100_cal.config.mac
@@ -15,6 +15,7 @@
 /process/em/verbose 0
 
 ##### GEOMETRY #####
+/Geometry/Next100/pressure 10 bar
 /Geometry/Next100/elfield false
 /Geometry/Next100/max_step_size 1. mm
 /Geometry/Next100/th_source next100 #next_white
@@ -22,7 +23,7 @@
 ##### GENERATOR #####
 /Generator/IonGenerator/atomic_number 81
 /Generator/IonGenerator/mass_number 208
-/Generator/IonGenerator/region PORT_2b
+/Generator/IonGenerator/region PORT_2b # PORT_2a, PORT_1a, PORT_1b
 
 ##### PHYSICS #####
 ## No full simulation

--- a/macros/calibration/NEXT100_cal.config.mac
+++ b/macros/calibration/NEXT100_cal.config.mac
@@ -1,0 +1,34 @@
+## ----------------------------------------------------------------------------
+## nexus | NEXT100_cal.config.mac
+##
+## Configuration macro to simulate decays of the Th calibration source
+## from one of the vessel ports in the NEXT-100 detector.
+##
+## The NEXT Collaboration
+## ----------------------------------------------------------------------------
+
+##### VERBOSITY #####
+/run/verbose 0
+/event/verbose 0
+/tracking/verbose 0
+
+/process/em/verbose 0
+
+##### GEOMETRY #####
+/Geometry/Next100/elfield false
+/Geometry/Next100/max_step_size 1. mm
+/Geometry/Next100/th_source true
+
+##### GENERATOR #####
+/Generator/IonGenerator/atomic_number 81
+/Generator/IonGenerator/mass_number 208
+/Generator/IonGenerator/region PORT_2b
+
+##### PHYSICS #####
+## No full simulation
+/PhysicsList/Nexus/clustering          false
+/PhysicsList/Nexus/drift               false
+/PhysicsList/Nexus/electroluminescence false
+
+##### PERSISTENCY #####
+/nexus/persistency/output_file Next100_th_cal

--- a/macros/calibration/NEXT100_cal.config.mac
+++ b/macros/calibration/NEXT100_cal.config.mac
@@ -18,7 +18,7 @@
 /Geometry/Next100/pressure 10 bar
 /Geometry/Next100/elfield false
 /Geometry/Next100/max_step_size 1. mm
-/Geometry/Next100/th_source next100 #next_white
+/Geometry/Next100/th_source new_source #old_source
 
 ##### GENERATOR #####
 /Generator/IonGenerator/atomic_number 81

--- a/macros/calibration/NEXT100_cal.config.mac
+++ b/macros/calibration/NEXT100_cal.config.mac
@@ -17,7 +17,7 @@
 ##### GEOMETRY #####
 /Geometry/Next100/elfield false
 /Geometry/Next100/max_step_size 1. mm
-/Geometry/Next100/th_source true
+/Geometry/Next100/th_source next100 #next_white
 
 ##### GENERATOR #####
 /Generator/IonGenerator/atomic_number 81

--- a/macros/calibration/NEXT100_cal.init.mac
+++ b/macros/calibration/NEXT100_cal.init.mac
@@ -1,0 +1,26 @@
+## ----------------------------------------------------------------------------
+## nexus | NEXT100_cal.init.mac
+##
+## Configuration macro to simulate decays of the Th calibration source
+## from one of the vessel ports in the NEXT-100 detector.
+##
+## The NEXT Collaboration
+## ----------------------------------------------------------------------------
+
+/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
+/PhysicsList/RegisterPhysics G4DecayPhysics
+/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
+/PhysicsList/RegisterPhysics NexusPhysics
+/PhysicsList/RegisterPhysics G4StepLimiterPhysics
+
+/nexus/RegisterGeometry Next100
+
+/nexus/RegisterGenerator IonGenerator
+
+/nexus/RegisterPersistencyManager PersistencyManager
+
+/nexus/RegisterRunAction DefaultRunAction
+/nexus/RegisterEventAction DefaultEventAction
+/nexus/RegisterTrackingAction DefaultTrackingAction
+
+/nexus/RegisterMacro macros/calibration/NEXT100_cal.config.mac

--- a/source/geometries/CalibrationSource.cc
+++ b/source/geometries/CalibrationSource.cc
@@ -36,9 +36,10 @@ namespace nexus {
     source_("Na")
   {
     /// Messenger
-    msg_ = new G4GenericMessenger(this, "/Geometry/CalibrationSource/",
-                                  "Control commands of geometry CalibrationSource.");
-     msg_->DeclareProperty("source", source_, "Radioactive source being used");
+    msg_ =
+      new G4GenericMessenger(this, "/Geometry/CalibrationSource/",
+                             "Control commands of geometry CalibrationSource.");
+    msg_->DeclareProperty("source", source_, "Radioactive source being used");
   }
 
   CalibrationSource::~CalibrationSource()
@@ -51,7 +52,8 @@ namespace nexus {
     // G4double piece_diam = 7. *mm;
     // G4double piece_length = 16. *mm;
     G4Tubs* screw_tube_solid =
-      new G4Tubs("SCREW_SUPPORT", 0., capsule_diam_/2., capsule_thick_/2., 0, twopi);
+      new G4Tubs("SCREW_SUPPORT", 0., capsule_diam_/2., capsule_thick_/2.,
+                 0, twopi);
     G4LogicalVolume* screw_tube_logic =
       new G4LogicalVolume(screw_tube_solid,
                           G4NistManager::Instance()->FindOrBuildMaterial("G4_Al"),
@@ -63,7 +65,8 @@ namespace nexus {
     // G4double source_thickness = 2. * mm;
 
     G4Tubs* source_solid =
-      new G4Tubs("SCREW_SOURCE", 0., source_diam_/2., source_thick_/2., 0., twopi);
+      new G4Tubs("SCREW_SOURCE", 0., source_diam_/2., source_thick_/2.,
+                 0., twopi);
 
     G4String material = "G4_" + source_;
 

--- a/source/geometries/CalibrationSource.h
+++ b/source/geometries/CalibrationSource.h
@@ -35,6 +35,8 @@ namespace nexus {
 
     G4double GetSourceZpos();
 
+    void SetActiveMaterial(G4String source);
+
   private:
 
     // Messenger for the definition of control commands
@@ -53,8 +55,8 @@ namespace nexus {
 
     // Radioactive source being used
     G4String source_;
-
-
   };
+
+  inline void CalibrationSource::SetActiveMaterial(G4String source) {source_ = source;}
 }
 #endif

--- a/source/geometries/Next100Th228Source.cc
+++ b/source/geometries/Next100Th228Source.cc
@@ -1,0 +1,92 @@
+// ----------------------------------------------------------------------------
+// nexus | Next100Th228Source.cc
+//
+// Th-228 calibration specific source used at LSC with NEXT-100.
+//
+// The NEXT Collaboration
+// ----------------------------------------------------------------------------
+
+
+#include "Next100Th228Source.h"
+#include "MaterialsList.h"
+#include "Visibilities.h"
+
+#include <G4Tubs.hh>
+#include <G4Orb.hh>
+#include <G4NistManager.hh>
+#include <G4Material.hh>
+#include <G4LogicalVolume.hh>
+#include <G4PVPlacement.hh>
+#include <G4VisAttributes.hh>
+#include <G4SubtractionSolid.hh>
+
+
+namespace nexus {
+
+  using namespace CLHEP;
+
+  Next100Th228Source::Next100Th228Source(): GeometryBase(),
+                                            source_diam_ (1. * mm),
+                                            support_ext_diam_ (7. * mm),
+                                            support_int_diam_ (5. *mm),
+                                            support_length_ (16. * mm),
+                                            support_screw_length_ (7. * mm)
+  {
+  }
+
+  Next100Th228Source::~Next100Th228Source()
+  {
+  }
+
+  void Next100Th228Source::Construct()
+  {
+
+    /// Support
+    G4Tubs* support_full_solid =
+      new G4Tubs("TH228_SOURCE_SUPPORT", 0., support_ext_diam_/2.,
+                 support_length_/2., 0., twopi);
+
+    G4double offset = 1. * mm;
+    G4Tubs* screw_hole_solid =
+      new G4Tubs("SCREW_HOLE", 0, support_int_diam_/2.,
+                 (support_screw_length_ + offset)/2., 0., twopi);
+
+    G4SubtractionSolid*  support_solid =
+      new G4SubtractionSolid("TH228_SOURCE_SUPPORT", support_full_solid,
+                             screw_hole_solid, 0,
+                             G4ThreeVector(0., 0., -support_length_/2. +
+                                           (support_screw_length_-offset)/2.));
+
+    G4Material* steel =
+      G4NistManager::Instance()->FindOrBuildMaterial("G4_STAINLESS-STEEL");
+    G4LogicalVolume* support_logic =
+      new G4LogicalVolume(support_solid, steel, "TH228_SOURCE_SUPPORT");
+
+    this->SetLogicalVolume(support_logic);
+
+
+    /// Active source
+    G4Orb* source_solid = new G4Orb("TH228", source_diam_/2.);
+    G4Material* thorium_mat =
+      G4NistManager::Instance()->FindOrBuildMaterial("G4_Th");
+    G4LogicalVolume* source_logic =
+      new G4LogicalVolume(source_solid, thorium_mat, "TH228");
+
+    G4ThreeVector source_pos =
+      G4ThreeVector(0., 0., support_length_/2. - source_diam_/2.-0.2*mm);
+    new G4PVPlacement(0, source_pos, source_logic, "TH228", support_logic,
+                      false, 0, false);
+
+    G4VisAttributes source_col = nexus::DarkGreen();
+    source_col.SetForceSolid(true);
+    source_logic->SetVisAttributes(source_col);
+
+    return;
+  }
+
+  G4double Next100Th228Source::GetSupportLength() const
+  {
+    return support_length_;
+  }
+
+}

--- a/source/geometries/Next100Th228Source.cc
+++ b/source/geometries/Next100Th228Source.cc
@@ -27,6 +27,7 @@ namespace nexus {
 
   Next100Th228Source::Next100Th228Source(): GeometryBase(),
                                             source_diam_ (1. * mm),
+                                            source_offset_ (0.2 * mm),
                                             support_ext_diam_ (7. * mm),
                                             support_int_diam_ (5. *mm),
                                             support_length_ (16. * mm),
@@ -73,7 +74,7 @@ namespace nexus {
       new G4LogicalVolume(source_solid, thorium_mat, "TH228");
 
     G4ThreeVector source_pos =
-      G4ThreeVector(0., 0., support_length_/2. - source_diam_/2.-0.2*mm);
+      G4ThreeVector(0., 0., support_length_/2. - source_diam_/2. -source_offset_);
     new G4PVPlacement(0, source_pos, source_logic, "TH228", support_logic,
                       false, 0, false);
 
@@ -90,6 +91,16 @@ namespace nexus {
   G4double Next100Th228Source::GetSupportLength() const
   {
     return support_length_;
+  }
+
+  G4double Next100Th228Source::GetDiffThZPosEnd() const
+  {
+    return  source_diam_/2. + source_offset_;
+  }
+
+  G4double Next100Th228Source::GetThRadius() const
+  {
+    return source_diam_/2.;
   }
 
 }

--- a/source/geometries/Next100Th228Source.cc
+++ b/source/geometries/Next100Th228Source.cc
@@ -77,9 +77,12 @@ namespace nexus {
     new G4PVPlacement(0, source_pos, source_logic, "TH228", support_logic,
                       false, 0, false);
 
-    G4VisAttributes source_col = nexus::DarkGreen();
+    G4VisAttributes source_col = nexus::Red();
     source_col.SetForceSolid(true);
     source_logic->SetVisAttributes(source_col);
+
+    G4VisAttributes support_col = nexus::DarkGreen();
+    support_logic->SetVisAttributes(support_col);
 
     return;
   }

--- a/source/geometries/Next100Th228Source.h
+++ b/source/geometries/Next100Th228Source.h
@@ -1,0 +1,39 @@
+// ----------------------------------------------------------------------------
+// nexus | Next100Th228Source.h
+//
+// Th-228 calibration specific source used at LSC with NEXT-100.
+//
+// The NEXT Collaboration
+// ----------------------------------------------------------------------------
+
+#ifndef NEXT100_TH228_SOURCE_H
+#define NEXT100_TH228_SOURCE_H
+
+#include "GeometryBase.h"
+
+#include <globals.hh>
+
+namespace nexus {
+
+  class Next100Th228Source: public GeometryBase {
+  public:
+    /// Constructor
+    Next100Th228Source();
+
+    /// Destructor
+    ~Next100Th228Source();
+
+    void Construct();
+
+    G4double GetSupportLength() const;
+
+  private:
+    const G4double source_diam_;
+    const G4double support_ext_diam_, support_int_diam_, support_length_;
+    const G4double support_screw_length_;
+
+
+  };
+}
+#endif
+

--- a/source/geometries/Next100Th228Source.h
+++ b/source/geometries/Next100Th228Source.h
@@ -26,9 +26,12 @@ namespace nexus {
     void Construct();
 
     G4double GetSupportLength() const;
+    // Distance between center of Th and the end of the support 
+    G4double GetDiffThZPosEnd() const;
+    G4double GetThRadius() const;
 
   private:
-    const G4double source_diam_;
+    const G4double source_diam_, source_offset_;
     const G4double support_ext_diam_, support_int_diam_, support_length_;
     const G4double support_screw_length_;
 

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -74,7 +74,8 @@ namespace nexus {
     gas_("enrichedXe"),
     helium_mass_num_(4),
     xe_perc_(100.),
-    th_source_(false)
+    th_source_(false),
+    dist_th_zpos_end_(0.*mm)
   {
     /// HOW THIS GEOMETRY IS BUILT ///
     /// The vessel is a union of several volumes, as explained in
@@ -362,7 +363,7 @@ namespace nexus {
                         "TH228_SOURCE_SUPPORT", port_tube_gas_logic, false, 0);
 
       // Vertex generation
-      port_gen_ = new SpherePointSampler(0., source.GetThRadius());
+      th_port_gen_ = new SpherePointSampler(0., source.GetThRadius());
     }
 
     new G4PVPlacement(0, G4ThreeVector(0., 0., port_tube_tip_/2.), port_tube_gas_logic,
@@ -502,8 +503,9 @@ namespace nexus {
     }
 
     else if (region == "PORT_1a"){
-      vertex = port_gen_->GenerateVertex(VOLUME);
-
+      if (th_source_) {
+        vertex = th_port_gen_->GenerateVertex(VOLUME);
+      }
       vertex = vertex.rotateX( 90. * deg);
       vertex = vertex.rotateZ(-45. * deg);
 
@@ -512,8 +514,9 @@ namespace nexus {
     }
 
     else if (region == "PORT_2a"){
-      vertex = port_gen_->GenerateVertex(VOLUME);
-
+      if (th_source_) {
+        vertex = th_port_gen_->GenerateVertex(VOLUME);
+      }
       vertex = vertex.rotateX( 90. * deg);
       vertex = vertex.rotateZ(-45. * deg);
 
@@ -522,8 +525,9 @@ namespace nexus {
     }
 
     else if (region == "PORT_1b"){
-      vertex = port_gen_->GenerateVertex(VOLUME);
-
+      if (th_source_) {
+        vertex = th_port_gen_->GenerateVertex(VOLUME);
+      }
       vertex = vertex.rotateX( 90. * deg);
       vertex = vertex.rotateZ( 45. * deg);
 
@@ -532,8 +536,9 @@ namespace nexus {
     }
 
     else if (region == "PORT_2b"){
-      vertex = port_gen_->GenerateVertex(VOLUME);
-
+      if (th_source_) {
+        vertex = th_port_gen_->GenerateVertex(VOLUME);
+      }
       vertex = vertex.rotateX( 90. * deg);
       vertex = vertex.rotateZ( 45. * deg);
 

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -401,6 +401,10 @@ namespace nexus {
                                    source.GetSourceThickness()/2.,
                                    0., 360.*deg, source_rot);
         source_logic = source.GetLogicalVolume();
+      } else {
+        G4Exception("[Next100Vessel]", "Construct()", FatalException,
+                    "Unknow kind of calibration source; it must be "
+                    "next100 or next_white.");
       }
 
       G4ThreeVector source_pos =

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -376,7 +376,7 @@ namespace nexus {
     // SETTING VISIBILITIES   //////////
     if (visibility_) {
       G4VisAttributes grey = nexus::TitaniumGreyAlpha();
-      G4VisAttributes yellow = nexus::Yellow();
+      G4VisAttributes yellow = nexus::YellowAlpha();
       grey  .SetForceSolid(true);
       yellow.SetForceSolid(true);
       vessel_logic       ->SetVisAttributes(grey);

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -125,7 +125,7 @@ namespace nexus {
     e_lifetime_cmd.SetUnitCategory("Time");
     e_lifetime_cmd.SetRange("e_lifetime>0.");
 
-    msg_->DeclareProperty("th_source", th_source_,  "Th-228 source used: next_white or next100");
+    msg_->DeclareProperty("th_source", th_source_,  "Th-228 source used: old_source or new_source");
   }
 
 
@@ -380,7 +380,7 @@ namespace nexus {
       G4double source_length = 0.;
       G4RotationMatrix* source_rot = new G4RotationMatrix;
       source_rot->rotateY(180. * deg);
-      if (th_source_ == "next100") {
+      if (th_source_ == "new_source") {
         Next100Th228Source source = Next100Th228Source();
         source.Construct();
         dist_th_zpos_end_ = source.GetDiffThZPosEnd();
@@ -389,7 +389,7 @@ namespace nexus {
         th_port_gen_ = new SpherePointSampler(0., source.GetThRadius());
 
         source_logic = source.GetLogicalVolume();
-      } else if (th_source_ == "next_white") {
+      } else if (th_source_ == "old_source") {
         CalibrationSource source = CalibrationSource();
         source.SetActiveMaterial("Th");
         source.Construct();
@@ -404,7 +404,7 @@ namespace nexus {
       } else {
         G4Exception("[Next100Vessel]", "Construct()", FatalException,
                     "Unknow kind of calibration source; it must be "
-                    "next100 or next_white.");
+                    "old_source or new_source.");
       }
 
       G4ThreeVector source_pos =
@@ -553,9 +553,9 @@ namespace nexus {
     }
 
     else if (region == "PORT_1a"){
-      if (th_source_ == "next100") {
+      if (th_source_ == "new_source") {
         vertex = th_port_gen_->GenerateVertex(VOLUME);
-      } else if (th_source_ == "next_white") {
+      } else if (th_source_ == "old_source") {
         vertex = th_white_port_gen_->GenerateVertex(VOLUME);
       }
       vertex = vertex.rotateX( 90. * deg);
@@ -566,9 +566,9 @@ namespace nexus {
     }
 
     else if (region == "PORT_2a"){
-      if (th_source_ == "next100") {
+      if (th_source_ == "new_source") {
         vertex = th_port_gen_->GenerateVertex(VOLUME);
-      } else if (th_source_ == "next_white") {
+      } else if (th_source_ == "old_source") {
         vertex = th_white_port_gen_->GenerateVertex(VOLUME);
       }
       vertex = vertex.rotateX( 90. * deg);
@@ -579,9 +579,9 @@ namespace nexus {
     }
 
     else if (region == "PORT_1b"){
-      if (th_source_ == "next100") {
+      if (th_source_ == "new_source") {
         vertex = th_port_gen_->GenerateVertex(VOLUME);
-      } else if (th_source_ == "next_white") {
+      } else if (th_source_ == "old_source") {
         vertex = th_white_port_gen_->GenerateVertex(VOLUME);
       }
       vertex = vertex.rotateX( 90. * deg);
@@ -592,9 +592,9 @@ namespace nexus {
     }
 
     else if (region == "PORT_2b"){
-      if (th_source_ == "next100") {
+      if (th_source_ == "new_source") {
         vertex = th_port_gen_->GenerateVertex(VOLUME);
-      } else if (th_source_ == "next_white") {
+      } else if (th_source_ == "old_source") {
         vertex = th_white_port_gen_->GenerateVertex(VOLUME);
       }
       vertex = vertex.rotateX( 90. * deg);

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -98,14 +98,12 @@ namespace nexus {
 
     /// Messenger
     msg_ =
-      new G4GenericMessenger(this, "/Geometry/Next100/", "Control commands of geometry Next100.");
+      new G4GenericMessenger(this, "/Geometry/Next100/", "Control commands of Next100 geometry.");
 
     msg_->DeclareProperty("vessel_vis", visibility_, "Vessel Visibility");
     msg_->DeclareProperty("gas", gas_, "Gas being used");
-    msg_->DeclareProperty("XePercentage", xe_perc_,
-			  "Percentage of xenon used in mixtures");
-    msg_->DeclareProperty("helium_A", helium_mass_num_,
-			  "Mass number for helium used, 3 or 4");
+    msg_->DeclareProperty("XePercentage", xe_perc_, "Percentage of xenon used in mixtures");
+    msg_->DeclareProperty("helium_A", helium_mass_num_, "Mass number for helium used, 3 or 4");
 
     G4GenericMessenger::Command& pressure_cmd =
       msg_->DeclareProperty("pressure", pressure_, "Xenon pressure");
@@ -117,19 +115,17 @@ namespace nexus {
 
     G4GenericMessenger::Command& sc_yield_cmd =
       msg_->DeclareProperty("sc_yield", sc_yield_,
-			    "Set scintillation yield for GXe. It is in photons/MeV");
+			    "Scintillation yield for GXe. It is in photons/MeV");
     sc_yield_cmd.SetParameterName("sc_yield", true);
     sc_yield_cmd.SetUnitCategory("1/Energy");
 
     G4GenericMessenger::Command& e_lifetime_cmd =
-      msg_->DeclareProperty("e_lifetime", e_lifetime_,
-			    "Electron lifetime in gas.");
+      msg_->DeclareProperty("e_lifetime", e_lifetime_, "Electron lifetime in gas.");
     e_lifetime_cmd.SetParameterName("e_lifetime", false);
     e_lifetime_cmd.SetUnitCategory("Time");
     e_lifetime_cmd.SetRange("e_lifetime>0.");
 
-    msg_->DeclareProperty("th_source", th_source_,
-                          "Th-228 source used: next_white or next100");
+    msg_->DeclareProperty("th_source", th_source_,  "Th-228 source used: next_white or next100");
   }
 
 
@@ -138,24 +134,22 @@ namespace nexus {
     // Body solid
     G4double vessel_out_rad = vessel_in_rad_ + vessel_thickness_;
 
-    G4Tubs* vessel_body_solid = new G4Tubs("VESSEL_BODY", 0., vessel_out_rad, body_length_/2.,
-					   0.*deg, 360.*deg);
+    G4Tubs* vessel_body_solid =
+      new G4Tubs("VESSEL_BODY", 0., vessel_out_rad, body_length_/2., 0.*deg, 360.*deg);
 
-    G4Tubs* vessel_gas_body_solid = new G4Tubs("VESSEL_GAS_BODY", 0., vessel_in_rad_, body_length_/2.,
-					       0.*deg, 360.*deg);
+    G4Tubs* vessel_gas_body_solid =
+      new G4Tubs("VESSEL_GAS_BODY", 0., vessel_in_rad_, body_length_/2., 0.*deg, 360.*deg);
 
     // Endcaps solids
     G4double endcap_out_rad = endcap_in_rad_ + vessel_thickness_;
 
-    G4Sphere* vessel_endcap_solid = new G4Sphere("VESSEL_ENDCAP",
-							  0. * cm,  endcap_out_rad,
-							  0. * deg, 360. * deg,
-							  0. * deg, endcap_theta_);
+    G4Sphere* vessel_endcap_solid =
+      new G4Sphere("VESSEL_ENDCAP", 0.*cm,  endcap_out_rad, 0.*deg,
+                   360.*deg, 0.*deg, endcap_theta_);
 
-    G4Sphere* vessel_gas_endcap_solid = new G4Sphere("VESSEL_GAS_ENDCAP",
-							      0. * cm,  endcap_in_rad_,
-							      0. * deg, 360. * deg,
-							      0. * deg, endcap_theta_);
+    G4Sphere* vessel_gas_endcap_solid =
+      new G4Sphere("VESSEL_GAS_ENDCAP", 0. * cm,  endcap_in_rad_, 0.*deg,
+                   360.*deg, 0.*deg, endcap_theta_);
 
     // Flange solid
     G4double flange_out_rad   = 74.0 * cm;
@@ -166,13 +160,15 @@ namespace nexus {
     G4double flange_ep_body_length = 77.5 * mm;
     G4double flange_ep_endcap_length = 41.5 * mm;
     G4double flange_ep_length = flange_ep_body_length + flange_ep_endcap_length;
-    G4double flange_ep_z_pos  =   body_length_/2. - flange_ep_length/2. - endcap_in_body_;
+    G4double flange_ep_z_pos  = body_length_/2. - flange_ep_length/2. - endcap_in_body_;
     G4double flange_tp_z_pos  = -(body_length_/2. - flange_tp_length/2. - endcap_in_body_);
 
-    G4Tubs* vessel_tp_flange_solid = new G4Tubs("VESSEL_TRACKING_FLANGE", vessel_in_rad_, flange_out_rad,
-                                                flange_tp_length/2., 0.*deg, 360.*deg);
-    G4Tubs* vessel_ep_flange_solid = new G4Tubs("VESSEL_ENERGY_FLANGE"  , vessel_in_rad_, flange_out_rad,
-                                                flange_ep_length/2., 0.*deg, 360.*deg);
+    G4Tubs* vessel_tp_flange_solid =
+      new G4Tubs("VESSEL_TRACKING_FLANGE", vessel_in_rad_, flange_out_rad,
+                 flange_tp_length/2., 0.*deg, 360.*deg);
+    G4Tubs* vessel_ep_flange_solid =
+      new G4Tubs("VESSEL_ENERGY_FLANGE", vessel_in_rad_, flange_out_rad,
+                 flange_ep_length/2., 0.*deg, 360.*deg);
 
     // Calibration ports: nozzel and inner tube
     G4double port_in_rad      = 15.5 * mm;
@@ -181,25 +177,29 @@ namespace nexus {
     G4double port_base_rad    = 21.1 * mm;
     G4double offset = 1. * mm; // add offset to overlap G4UnionSolid
 
-    G4Tubs* port_solid_cap  = new G4Tubs("PORT_cap" , 0., port_cap_rad, port_cap_height/2.,
-                                         0.*deg, 360.*deg);
-    G4Tubs* port_solid_base = new G4Tubs("PORT_base", 0., port_base_rad, (port_base_height_+offset)/2.,
-                                         0.*deg, 360.*deg);
-    G4UnionSolid* port_solid = new G4UnionSolid("PORT", port_solid_base, port_solid_cap,
-               0, G4ThreeVector(0., 0., (port_base_height_ + offset + port_cap_height)/2. - offset));
-    G4Tubs* port_gas_solid = new G4Tubs("PORT_GAS", 0., port_in_rad, (port_base_height_ + offset)/2.,
-                                        0.*deg, 360.*deg);
+    G4Tubs* port_solid_cap  =
+      new G4Tubs("PORT_cap" , 0., port_cap_rad, port_cap_height/2., 0.*deg, 360.*deg);
+    G4Tubs* port_solid_base =
+      new G4Tubs("PORT_base", 0., port_base_rad, (port_base_height_+offset)/2., 0.*deg, 360.*deg);
+    G4UnionSolid* port_solid =
+      new G4UnionSolid("PORT", port_solid_base, port_solid_cap,
+                       0, G4ThreeVector(0., 0., (port_base_height_ + offset +
+                                                 port_cap_height)/2. - offset));
+    G4Tubs* port_gas_solid =
+      new G4Tubs("PORT_GAS", 0., port_in_rad, (port_base_height_ + offset)/2., 0.*deg, 360.*deg);
 
     // Port inner tube
     G4double port_tube_rad   = 4.  * mm;
     G4double port_tube_thick = 1.2 * mm;
-    G4Tubs* port_tube_solid = new G4Tubs("PORT_TUBE", 0., (port_tube_rad + port_tube_thick),
-                                         (port_tube_height_ + port_tube_tip_)/2., 0.*deg, 360.*deg);
-    G4Tubs* port_tube_gas_solid = new G4Tubs("PORT_TUBE_GAS", 0., port_tube_rad,
-                                             port_tube_height_/2., 0.*deg, 360.*deg);
+    G4Tubs* port_tube_solid =
+      new G4Tubs("PORT_TUBE", 0., (port_tube_rad + port_tube_thick),
+                 (port_tube_height_ + port_tube_tip_)/2., 0.*deg, 360.*deg);
+    G4Tubs* port_tube_gas_solid =
+      new G4Tubs("PORT_TUBE_GAS", 0., port_tube_rad, port_tube_height_/2., 0.*deg, 360.*deg);
 
     //// Unions
-    G4double endcap_z_pos = (body_length_ / 2.) + endcap_in_z_width_ - endcap_in_rad_;
+    G4double endcap_z_pos =
+      (body_length_ / 2.) + endcap_in_z_width_ - endcap_in_rad_;
     G4ThreeVector energy_endcap_pos  (0, 0,  endcap_z_pos);
     G4ThreeVector tracking_endcap_pos(0, 0, -endcap_z_pos);
     G4ThreeVector energy_flange_pos  (0, 0, flange_ep_z_pos);
@@ -210,21 +210,21 @@ namespace nexus {
     xRot->rotateX(180. * deg);
 
     // Body + Energy endcap
-    G4UnionSolid* vessel_solid = new G4UnionSolid("VESSEL", vessel_body_solid, vessel_endcap_solid,
-    						  0, energy_endcap_pos);
+    G4UnionSolid* vessel_solid =
+      new G4UnionSolid("VESSEL", vessel_body_solid, vessel_endcap_solid, 0, energy_endcap_pos);
 
     // Body + Energy endcap + Tracking endcap
     // G4UnionSolid* vessel_solid = new G4UnionSolid("VESSEL", vessel_body_solid, vessel_endcap_solid,
-    vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, vessel_endcap_solid,
-				    xRot, tracking_endcap_pos);
+    vessel_solid =
+      new G4UnionSolid("VESSEL", vessel_solid, vessel_endcap_solid, xRot, tracking_endcap_pos);
 
     // Body + Energy endcap + Tracking endcap + Energy flange
-    vessel_solid = new G4UnionSolid("VESSEL", vessel_solid,
-				    vessel_ep_flange_solid, 0, energy_flange_pos);
+    vessel_solid =
+      new G4UnionSolid("VESSEL", vessel_solid, vessel_ep_flange_solid, 0, energy_flange_pos);
 
     // Body + Energy endcap + Tracking endcap + Energy flange + Tracking flange
-    vessel_solid = new G4UnionSolid("VESSEL", vessel_solid,
-				    vessel_tp_flange_solid, 0, tracking_flange_pos);
+    vessel_solid =
+      new G4UnionSolid("VESSEL", vessel_solid, vessel_tp_flange_solid, 0, tracking_flange_pos);
 
     // Add port nozzles (x,y at 45*deg)
     G4double port_nozzle_x = (vessel_in_rad_ + port_base_height_/2.) * cos(port_angle_);
@@ -240,40 +240,58 @@ namespace nexus {
     port_a_Rot->rotateX( 90. * deg);
     port_a_Rot->rotateY(-45. * deg);
 
-    vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, port_solid,
-                                    port_a_Rot, G4ThreeVector(port_nozzle_x, port_nozzle_y, port_z_1a_));
-    vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, port_solid,
-                                    port_a_Rot, G4ThreeVector(port_nozzle_x, port_nozzle_y, port_z_2a_));
+    vessel_solid =
+      new G4UnionSolid("VESSEL", vessel_solid, port_solid,
+                       port_a_Rot, G4ThreeVector(port_nozzle_x, port_nozzle_y,
+                                                 port_z_1a_));
+    vessel_solid =
+      new G4UnionSolid("VESSEL", vessel_solid, port_solid,
+                       port_a_Rot, G4ThreeVector(port_nozzle_x, port_nozzle_y,
+                                                 port_z_2a_));
 
     G4RotationMatrix* port_b_Rot = new G4RotationMatrix;
     port_b_Rot->rotateX( 90. * deg);
     port_b_Rot->rotateY( 45. * deg);
 
-    vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, port_solid,
-                                    port_b_Rot, G4ThreeVector(-port_nozzle_x, port_nozzle_y, port_z_1b_));
-    vessel_solid = new G4UnionSolid("VESSEL", vessel_solid, port_solid,
-                                    port_b_Rot, G4ThreeVector(-port_nozzle_x, port_nozzle_y, port_z_2b_));
+    vessel_solid =
+      new G4UnionSolid("VESSEL", vessel_solid, port_solid,
+                       port_b_Rot, G4ThreeVector(-port_nozzle_x, port_nozzle_y,
+                                                 port_z_1b_));
+    vessel_solid =
+      new G4UnionSolid("VESSEL", vessel_solid, port_solid,
+                       port_b_Rot, G4ThreeVector(-port_nozzle_x, port_nozzle_y,
+                                                 port_z_2b_));
 
     // Body gas + Energy endcap gas
-    G4UnionSolid* vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_body_solid,
-    						      vessel_gas_endcap_solid, 0, energy_endcap_pos);
+    G4UnionSolid* vessel_gas_solid =
+      new G4UnionSolid("VESSEL_GAS", vessel_gas_body_solid,
+                       vessel_gas_endcap_solid, 0, energy_endcap_pos);
 
     //  Body gas + Energy endcap gas + Tracking endcap gas
-    vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid,
-					vessel_gas_endcap_solid, xRot, tracking_endcap_pos);
+    vessel_gas_solid =
+      new G4UnionSolid("VESSEL_GAS", vessel_gas_solid,
+                       vessel_gas_endcap_solid, xRot, tracking_endcap_pos);
 
     // Add gas inside ports
     G4double port_gas_x = port_nozzle_x - (offset/2.) * cos(port_angle_);
     G4double port_gas_y = port_gas_x;
 
-    vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, port_gas_solid,
-                                        port_a_Rot, G4ThreeVector(port_gas_x, port_gas_y, port_z_1a_));
-    vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, port_gas_solid,
-                                        port_a_Rot, G4ThreeVector(port_gas_x, port_gas_y, port_z_2a_));
-    vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, port_gas_solid,
-                                        port_b_Rot, G4ThreeVector(-port_gas_x, port_gas_y, port_z_1b_));
-    vessel_gas_solid = new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, port_gas_solid,
-                                        port_b_Rot, G4ThreeVector(-port_gas_x, port_gas_y, port_z_2b_));
+    vessel_gas_solid =
+      new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, port_gas_solid,
+                       port_a_Rot, G4ThreeVector(port_gas_x, port_gas_y,
+                                                 port_z_1a_));
+    vessel_gas_solid =
+      new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, port_gas_solid,
+                       port_a_Rot, G4ThreeVector(port_gas_x, port_gas_y,
+                                                 port_z_2a_));
+    vessel_gas_solid =
+      new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, port_gas_solid,
+                       port_b_Rot, G4ThreeVector(-port_gas_x, port_gas_y,
+                                                 port_z_1b_));
+    vessel_gas_solid =
+      new G4UnionSolid("VESSEL_GAS", vessel_gas_solid, port_gas_solid,
+                       port_b_Rot, G4ThreeVector(-port_gas_x, port_gas_y,
+                                                 port_z_2b_));
 
     // Remove part of gas to let the internal part of the
     // energy plane flange emerge from the subtraction.
@@ -326,12 +344,17 @@ namespace nexus {
 					    xe_perc_, helium_mass_num_);
     } else {
       G4Exception("[Next100Vessel]", "Construct()", FatalException,
-		  "Unknown kind of xenon, valid options are: natural, enriched, depleted, or XeHe.");
+		  "Unknown kind of xenon, valid options are: "
+                  "natural, enriched, depleted, or XeHe.");
     }
 
-    vessel_gas_mat->SetMaterialPropertiesTable(opticalprops::GXe(pressure_, temperature_, sc_yield_, e_lifetime_));
+    vessel_gas_mat->SetMaterialPropertiesTable(opticalprops::GXe(pressure_,
+                                                                 temperature_,
+                                                                 sc_yield_,
+                                                                 e_lifetime_));
 
-    G4LogicalVolume* vessel_gas_logic = new G4LogicalVolume(vessel_gas_final_solid, vessel_gas_mat, "VESSEL_GAS");
+    G4LogicalVolume* vessel_gas_logic =
+      new G4LogicalVolume(vessel_gas_final_solid, vessel_gas_mat, "VESSEL_GAS");
 
     internal_logic_vol_ = vessel_gas_logic;
     SetGateZpos(flange_tp_z_pos + flange_tp_length /2. + 67.5*mm + gate_tp_distance_);
@@ -344,7 +367,8 @@ namespace nexus {
       new G4LogicalVolume(port_tube_solid, materials::Steel316Ti(), "PORT_TUBE");
 
     G4LogicalVolume* port_tube_gas_logic =
-      new G4LogicalVolume(port_tube_gas_solid, G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"),
+      new G4LogicalVolume(port_tube_gas_solid,
+                          G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR"),
                           "PORT_TUBE_AIR");
 
     // If a Th source is used, it is placed in all ports for simplicity.
@@ -369,8 +393,7 @@ namespace nexus {
         CalibrationSource source = CalibrationSource();
         source.SetActiveMaterial("Th");
         source.Construct();
-        dist_th_zpos_end_ =
-          source.GetCapsuleThickness()/2. - source.GetSourceZpos();
+        dist_th_zpos_end_ = source.GetCapsuleThickness()/2. - source.GetSourceZpos();
         source_length = source.GetCapsuleThickness();
         // Vertex generation
         th_white_port_gen_ =
@@ -389,14 +412,14 @@ namespace nexus {
     new G4PVPlacement(0, G4ThreeVector(0., 0., port_tube_tip_/2.), port_tube_gas_logic,
                       "PORT_TUBE_AIR", port_tube_logic, false, 0);
 
-    new G4PVPlacement(port_a_Rot, G4ThreeVector(port_x_, port_y_, port_z_1a_), port_tube_logic,
-                      "PORT_TUBE_1a", vessel_gas_logic, false, 0);
-    new G4PVPlacement(port_a_Rot, G4ThreeVector(port_x_, port_y_, port_z_2a_), port_tube_logic,
-                      "PORT_TUBE_2a", vessel_gas_logic, false, 0);
-    new G4PVPlacement(port_b_Rot, G4ThreeVector(-port_x_, port_y_, port_z_1b_), port_tube_logic,
-                      "PORT_TUBE_1b", vessel_gas_logic, false, 0);
-    new G4PVPlacement(port_b_Rot, G4ThreeVector(-port_x_, port_y_, port_z_2b_), port_tube_logic,
-                      "PORT_TUBE_2b", vessel_gas_logic, false, 0);
+    new G4PVPlacement(port_a_Rot, G4ThreeVector(port_x_, port_y_, port_z_1a_),
+                      port_tube_logic, "PORT_TUBE_1a", vessel_gas_logic, false, 0);
+    new G4PVPlacement(port_a_Rot, G4ThreeVector(port_x_, port_y_, port_z_2a_),
+                      port_tube_logic, "PORT_TUBE_2a", vessel_gas_logic, false, 0);
+    new G4PVPlacement(port_b_Rot, G4ThreeVector(-port_x_, port_y_, port_z_1b_),
+                      port_tube_logic, "PORT_TUBE_1b", vessel_gas_logic, false, 0);
+    new G4PVPlacement(port_b_Rot, G4ThreeVector(-port_x_, port_y_, port_z_2b_),
+                      port_tube_logic, "PORT_TUBE_2b", vessel_gas_logic, false, 0);
 
 
     // SETTING VISIBILITIES   //////////
@@ -419,18 +442,22 @@ namespace nexus {
 
     // VERTEX GENERATORS   //////////
     body_gen_  = new CylinderPointSampler(vessel_in_rad_, vessel_out_rad, body_length_/2.,
-                                              0., 360.*deg, 0, G4ThreeVector(0., 0., 0.));
+                                          0., 360.*deg, 0, G4ThreeVector(0., 0., 0.));
 
-    energy_endcap_gen_ = new SpherePointSampler(endcap_in_rad_, endcap_in_rad_+vessel_thickness_, 0., twopi, 0., endcap_theta_, energy_endcap_pos, 0);
+    energy_endcap_gen_ =
+      new SpherePointSampler(endcap_in_rad_, endcap_in_rad_+vessel_thickness_,
+                             0., twopi, 0., endcap_theta_, energy_endcap_pos, 0);
 
-    tracking_endcap_gen_ = new SpherePointSampler(endcap_in_rad_, endcap_in_rad_+vessel_thickness_, 0., twopi, 0., endcap_theta_, tracking_endcap_pos, xRot);
+    tracking_endcap_gen_ =
+      new SpherePointSampler(endcap_in_rad_, endcap_in_rad_+vessel_thickness_,
+                             0., twopi, 0., endcap_theta_, tracking_endcap_pos, xRot);
 
-    tracking_flange_gen_ = new CylinderPointSampler(vessel_in_rad_, flange_out_rad, flange_tp_length/2.,
-                                                        0., 360.*deg, 0, tracking_flange_pos);
+    tracking_flange_gen_ =
+      new CylinderPointSampler(vessel_in_rad_, flange_out_rad, flange_tp_length/2.,
+                               0., 360.*deg, 0, tracking_flange_pos);
 
     energy_flange_gen_ =
-      new CylinderPointSampler(ep_int_flange_in_rad, flange_out_rad,
-                               flange_ep_length/2.,
+      new CylinderPointSampler(ep_int_flange_in_rad, flange_out_rad, flange_ep_length/2.,
                                0., 360.*deg, 0, energy_flange_pos);
 
     // Calculating some prob
@@ -439,8 +466,10 @@ namespace nexus {
                        ep_int_flange_long_solid, 0,
                        G4ThreeVector(0., 0., -ep_int_flange_short_length/2.
                                      - ics_ep_lip_width_/2. ));
-    G4double body_vol   = vessel_body_solid  ->GetCubicVolume() - vessel_gas_body_solid  ->GetCubicVolume();
-    G4double endcap_vol = vessel_endcap_solid->GetCubicVolume() - vessel_gas_endcap_solid->GetCubicVolume();
+    G4double body_vol = vessel_body_solid  ->GetCubicVolume() -
+      vessel_gas_body_solid  ->GetCubicVolume();
+    G4double endcap_vol = vessel_endcap_solid->GetCubicVolume() -
+      vessel_gas_endcap_solid->GetCubicVolume();
     G4double flange_ep_vol = vessel_ep_flange_solid->GetCubicVolume() +
       ep_int_flange_solid->GetCubicVolume();
     G4double flange_tp_vol = vessel_tp_flange_solid->GetCubicVolume();
@@ -477,9 +506,8 @@ namespace nexus {
   G4ThreeVector Next100Vessel::GenerateVertex(const G4String& region) const
   {
     G4ThreeVector vertex(0., 0., 0.);
-    G4double source_x =
-      port_x_ + (-(port_tube_height_ + port_tube_tip_)/2 +
-                 port_tube_tip_ + dist_th_zpos_end_) * cos(port_angle_);
+    G4double source_x = port_x_ + (-(port_tube_height_ + port_tube_tip_)/2 +
+                                   port_tube_tip_ + dist_th_zpos_end_) * cos(port_angle_);
     G4double source_y = source_x;
 
     // Vertex in the whole VESSEL volume
@@ -501,8 +529,7 @@ namespace nexus {
           G4ThreeVector glob_vtx(vertex);
           // this->GetCoordOrigin() only has x and y set
           glob_vtx = glob_vtx - GetCoordOrigin() - G4ThreeVector(0, 0, gate_z_pos_);
-          VertexVolume =
-            geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
+          VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
         } while (VertexVolume->GetName() != "VESSEL");
       }
       else if (rand < (perc_endcap_vol_ + perc_ep_flange_vol_ + perc_tp_flange_vol_)){// Tracking flange
@@ -516,8 +543,7 @@ namespace nexus {
           G4ThreeVector glob_vtx(vertex);
           // this->GetCoordOrigin() only has x and y set
           glob_vtx = glob_vtx - GetCoordOrigin() - G4ThreeVector(0, 0, gate_z_pos_);
-          VertexVolume =
-            geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
+          VertexVolume = geom_navigator_->LocateGlobalPointAndSetup(glob_vtx, 0, false);
         } while (VertexVolume->GetName() != "VESSEL");
       }
     }

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -58,8 +58,8 @@ namespace nexus {
     const G4double endcap_in_z_width_;
     const G4double port_base_height_, port_tube_height_, port_tube_tip_;
 
-    G4double port_x_, port_y_, source_height_, port_z_1a_, port_z_1b_;
-    G4double port_z_2a_, port_z_2b_;
+    G4double port_angle_, port_x_, port_y_;
+    G4double port_z_1a_, port_z_1b_, port_z_2a_, port_z_2b_;
     G4double sc_yield_, e_lifetime_;
     G4double pressure_, temperature_;
     G4double gate_tp_distance_;
@@ -78,7 +78,7 @@ namespace nexus {
     SpherePointSampler*   energy_endcap_gen_;
     CylinderPointSampler* tracking_flange_gen_;
     CylinderPointSampler* energy_flange_gen_;
-    CylinderPointSampler* port_gen_;
+    SpherePointSampler* port_gen_;
 
     G4double perc_endcap_vol_;
     G4double perc_ep_flange_vol_;
@@ -97,6 +97,7 @@ namespace nexus {
 
     // Th calibration source
     G4bool th_source_;
+    G4double dist_th_zpos_end_;
   };
 
   inline void Next100Vessel::SetELtoTPdistance(G4double distance){

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -78,7 +78,7 @@ namespace nexus {
     SpherePointSampler*   energy_endcap_gen_;
     CylinderPointSampler* tracking_flange_gen_;
     CylinderPointSampler* energy_flange_gen_;
-    SpherePointSampler* port_gen_;
+    SpherePointSampler* th_port_gen_;
 
     G4double perc_endcap_vol_;
     G4double perc_ep_flange_vol_;

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -95,6 +95,8 @@ namespace nexus {
     G4int helium_mass_num_;
     G4double xe_perc_;
 
+    // Th calibration source
+    G4bool th_source_;
   };
 
   inline void Next100Vessel::SetELtoTPdistance(G4double distance){

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -57,16 +57,25 @@ namespace nexus {
     const G4double endcap_in_rad_, endcap_in_body_, endcap_theta_;
     const G4double endcap_in_z_width_;
     const G4double port_base_height_, port_tube_height_, port_tube_tip_;
+    const G4double port_angle_, port_x_, port_y_;
 
-    G4double port_angle_, port_x_, port_y_;
-    G4double port_z_1a_, port_z_1b_, port_z_2a_, port_z_2b_;
     G4double sc_yield_, e_lifetime_;
     G4double pressure_, temperature_;
-    G4double gate_tp_distance_;
-    G4double gate_z_pos_;
 
     // Visibility of the shielding
     G4bool visibility_;
+
+    // Type of gas being used
+    G4String gas_;
+    G4int helium_mass_num_;
+    G4double xe_perc_;
+
+    // Th calibration source
+    G4String th_source_;
+    G4double dist_th_zpos_end_;
+
+    G4double port_z_1a_, port_z_1b_, port_z_2a_, port_z_2b_;
+    G4double gate_tp_distance_, gate_z_pos_;
 
     // Internal logical and physical volumes
     G4LogicalVolume* internal_logic_vol_;
@@ -90,15 +99,6 @@ namespace nexus {
 
     // Messenger for the definition of control commands
     G4GenericMessenger* msg_;
-
-    // Type of gas being used
-    G4String gas_;
-    G4int helium_mass_num_;
-    G4double xe_perc_;
-
-    // Th calibration source
-    G4String th_source_;
-    G4double dist_th_zpos_end_;
 
   };
 

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -79,6 +79,7 @@ namespace nexus {
     CylinderPointSampler* tracking_flange_gen_;
     CylinderPointSampler* energy_flange_gen_;
     SpherePointSampler* th_port_gen_;
+    CylinderPointSampler* th_white_port_gen_;
 
     G4double perc_endcap_vol_;
     G4double perc_ep_flange_vol_;
@@ -96,8 +97,9 @@ namespace nexus {
     G4double xe_perc_;
 
     // Th calibration source
-    G4bool th_source_;
+    G4String th_source_;
     G4double dist_th_zpos_end_;
+
   };
 
   inline void Next100Vessel::SetELtoTPdistance(G4double distance){


### PR DESCRIPTION
This PR adds the Th-228 calibration source purchased for NEXT-100. It implements the geometry of the encapsulation, following the [technical drawing](https://github.com/next-exp/nexus/files/13391518/Th228_source.pdf).
The source is screwed to a plastic stick, which is not simulated; however, the hole in the capsule, which hosts the stick, is simulated.
The diameter of the active spot, as well as its distance from the top of the capsule are not measured, therefore they have been estimated by eye.

The possibility of using the old source employed in NEXT-White has also been added. The two sources cannot be simulated at the same time.

In order not to further complicate an already complex class, when either source is placed in the geometry (via a configuration parameter), it is placed in all four ports. The vertex generation is independent of the placement of the actual volume, therefore it is not affected by this approximation.
