### PR TITLE
Add epoxy optical properties

### DIFF
--- a/source/geometries/Next100SiPM.cc
+++ b/source/geometries/Next100SiPM.cc
@@ -110,7 +110,7 @@ void Next100SiPM::Construct()
   G4double window_zpos   = sipm_thickn/2. - coating_thickn_ - window_thickn/2.;
 
   G4Material* optical_silicone = materials::OpticalSilicone();
-  optical_silicone->SetMaterialPropertiesTable(opticalprops::GlassEpoxy());
+  optical_silicone->SetMaterialPropertiesTable(opticalprops::Epoxy());
 
   G4Box* window_solid_vol =
     new G4Box(window_name, window_width/2., window_length/2., window_thickn/2.);

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -598,7 +598,7 @@ namespace opticalprops {
 
   /// Gaseous xenon ///
   G4MaterialPropertiesTable* GXe(G4double pressure,
-                                G4double temperature,
+                                 G4double /*temperature*/,
                                 G4int    sc_yield,
                                 G4double e_lifetime)
   {

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -225,9 +225,10 @@ namespace opticalprops {
       hc_ / (554.84 * nm),  hc_ / (541.0 * nm),   hc_ / (519.1 * nm),
       hc_ / (509.87 * nm),  hc_ / (499.49 * nm),  hc_ / (490.27 * nm),
       hc_ / (481.04 * nm),  hc_ / (470.67 * nm),  hc_ / (456.83 * nm),
-      hc_ / (451.06 * nm),  hc_ / (442.99 * nm),   hc_ / (434.92 * nm),
-      hc_ / (426.85 * nm),  hc_ / (417.63 * nm), hc_ / (401.48 * nm),
-      hc_ / (395.95 * nm), optPhotMaxE_
+      hc_ / (451.06 * nm),  hc_ / (442.99 * nm),  hc_ / (434.92 * nm),
+      hc_ / (426.85 * nm),  hc_ / (417.63 * nm),  hc_ / (401.48 * nm),
+      hc_ / (395.95 * nm),
+      optPhotMaxE_
      };
 
      std::vector<G4double> rIndex = {
@@ -262,7 +263,8 @@ namespace opticalprops {
        1.563, 1.565, 1.567,
        1.568, 1.569, 1.57,
        1.572, 1.573, 1.576,
-       1.577, 1.577
+       1.577,
+       1.577
      };
 
     mpt->AddProperty("RINDEX", ri_energy, rIndex);
@@ -273,15 +275,17 @@ namespace opticalprops {
       2.132 * eV,   2.735 * eV,  2.908 * eV,  3.119 * eV,
       3.320 * eV,   3.476 * eV,  3.588 * eV,  3.749 * eV,
       3.869 * eV,   3.973 * eV,  4.120 * eV,  4.224 * eV,
-      4.320 * eV,   4.420 * eV,  5.018 * eV
+      4.320 * eV,   4.420 * eV,  5.018 * eV,
+      optPhotMaxE_
     };
 
     std::vector<G4double> absLength = {
       noAbsLength_, noAbsLength_,
       326.00 * mm,  117.68 * mm,  85.89 * mm,  50.93 * mm,
       31.25 * mm,   17.19 * mm,  10.46 * mm,   5.26 * mm,
-        3.77 * mm,    2.69 * mm,   1.94 * mm,   1.33 * mm,
-        0.73 * mm,    0.32 * mm,   0.10 * mm
+       3.77 * mm,    2.69 * mm,   1.94 * mm,   1.33 * mm,
+       0.73 * mm,    0.32 * mm,   0.10 * mm,
+       0.10 * mm
     };
     mpt->AddProperty("ABSLENGTH", abs_energy, absLength);
 

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -179,6 +179,146 @@ namespace opticalprops {
   }
 
 
+  G4MaterialPropertiesTable* Epoxy()
+  {
+    // This is the material used as a window for NEXT-100 SiPMs.
+    // The only information we have is that n = 1.55 at a
+    // not specified wavelength. It seems that it's common to measure
+    // the refractive index at the D line of sodium (590 nm),
+    // therefore we assume that.
+    // The dependence of n on the wavelength is taken from
+    // https://www.epotek.com/docs/en/Related/Tech%20Tip%2018%20Understanding%20Optical%20Properties%20of%20Epoxy%20Applications.pdf,
+    // shifting the whole graphs in y down to match 1.55 at 590 nm.
+    // We fill the values outside the range of the plot withg the
+    // minimum and maximum values.
+
+    G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
+
+    // REFRACTIVE INDEX
+     std::vector<G4double> ri_energy = {
+      optPhotMinE_,
+      hc / (2451.63 * nm), hc / (2430.88 * nm),
+      hc / (2405.51 * nm), hc / (2380.14 * nm),
+      hc / (2354.77 * nm), hc / (2329.41 * nm),
+      hc / (2304.04 * nm), hc / (2278.67 * nm),
+      hc / (2253.3 * nm), hc / (2227.94 * nm),
+      hc / (2202.57 * nm), hc / (2177.2 * nm),
+      hc / (2151.83 * nm), hc / (2126.47 * nm),
+      hc / (2101.1 * nm), hc / (2075.73 * nm),
+      hc / (2050.36 * nm), hc / (2025.0 * nm),
+      hc / (1968.5 * nm), hc / (1951.2 * nm),
+      hc / (1925.83 * nm), hc / (1900.47 * nm),
+      hc / (1875.1 * nm), hc / (1849.73 * nm),
+      hc / (1824.36 * nm), hc / (1799.0 * nm),
+      hc / (1773.63 * nm), hc / (1747.6 * nm),
+      hc / (1722.89 * nm), hc / (1697.53 * nm),
+      hc / (1672.16 * nm), hc / (1646.79 * nm),
+      hc / (1621.42 * nm), hc / (1596.06 * nm),
+      hc / (1570.69 * nm), hc / (1545.32 * nm),
+      hc / (1519.95 * nm), hc / (1494.59 * nm),
+      hc / (1469.22 * nm), hc / (1443.85 * nm),
+      hc / (1418.49 * nm), hc / (1393.12 * nm),
+      hc / (1367.75 * nm), hc / (1342.38 * nm),
+      hc / (1317.02 * nm), hc / (1291.65 * nm),
+      hc / (1266.28 * nm), hc / (1240.91 * nm),
+      hc / (1215.55 * nm), hc / (1190.18 * nm),
+      hc / (1164.81 * nm), hc / (1139.44 * nm),
+      hc / (1114.08 * nm), hc / (1088.71 * nm),
+      hc / (1063.34 * nm), hc / (1037.97 * nm),
+      hc / (1012.61 * nm), hc / (987.24 * nm),
+      hc / (961.87 * nm), hc / (936.5 * nm),
+      hc / (911.14 * nm), hc / (885.77 * nm),
+      hc / (860.4 * nm), hc / (835.03 * nm),
+      hc / (809.67 * nm), hc / (784.3 * nm),
+      hc / (758.93 * nm), hc / (733.57 * nm),
+      hc / (708.2 * nm), hc / (682.83 * nm),
+      hc / (657.46 * nm), hc / (624.02 * nm),
+      hc / (606.73 * nm), hc / (587.13 * nm),
+      hc / (569.83 * nm), hc / (554.84 * nm),
+      hc / (541.0 * nm), hc / (519.1 * nm),
+      hc / (509.87 * nm), hc / (499.49 * nm),
+      hc / (490.27 * nm), hc / (481.04 * nm),
+      hc / (470.67 * nm), hc / (456.83 * nm),
+      hc / (451.06 * nm), hc / (442.99 * nm),
+      hc / (434.92 * nm), hc / (426.85 * nm),
+      hc / (417.63 * nm), hc / (401.48 * nm),
+      hc / (395.95 * nm), optPhotMaxE_
+     };
+
+     std::vector<G4double> rIndex = {
+       1.524,
+       1.524, 1.525,
+       1.525, 1.525,
+       1.525, 1.526,
+       1.526, 1.526,
+       1.526, 1.526,
+       1.527, 1.527,
+       1.527, 1.527,
+       1.527, 1.528,
+       1.528, 1.528,
+       1.528, 1.528,
+       1.528, 1.529,
+       1.529, 1.529,
+       1.529, 1.529,
+       1.53, 1.53,
+       1.53, 1.53,
+       1.531, 1.531,
+       1.531, 1.531,
+       1.532, 1.532,
+       1.532, 1.532,
+       1.533, 1.533,
+       1.533, 1.533,
+       1.534, 1.534,
+       1.534, 1.534,
+       1.535, 1.535,
+       1.535, 1.535,
+       1.536, 1.536,
+       1.536, 1.536,
+       1.536, 1.537,
+       1.537, 1.537,
+       1.538, 1.538,
+       1.539, 1.539,
+       1.54, 1.54,
+       1.541, 1.542,
+       1.543, 1.544,
+       1.545, 1.546,
+       1.547, 1.549,
+       1.55, 1.551,
+       1.552, 1.554,
+       1.555, 1.558,
+       1.559, 1.56,
+       1.562, 1.563,
+       1.565, 1.567,
+       1.568, 1.569,
+       1.57, 1.572,
+       1.573, 1.576,
+       1.577, 1.577
+     };
+
+    mpt->AddProperty("RINDEX", ri_energy, rIndex);
+
+    // ABSORPTION LENGTH
+    std::vector<G4double> abs_energy = {
+      optPhotMinE_, 2.000 * eV,
+      2.132 * eV,   2.735 * eV,  2.908 * eV,  3.119 * eV,
+      3.320 * eV,   3.476 * eV,  3.588 * eV,  3.749 * eV,
+      3.869 * eV,   3.973 * eV,  4.120 * eV,  4.224 * eV,
+      4.320 * eV,   4.420 * eV,  5.018 * eV
+    };
+
+    std::vector<G4double> absLength = {
+      noAbsLength_, noAbsLength_,
+      326.00 * mm,  117.68 * mm,  85.89 * mm,  50.93 * mm,
+      31.25 * mm,   17.19 * mm,  10.46 * mm,   5.26 * mm,
+        3.77 * mm,    2.69 * mm,   1.94 * mm,   1.33 * mm,
+        0.73 * mm,    0.32 * mm,   0.10 * mm
+    };
+    mpt->AddProperty("ABSLENGTH", abs_energy, absLength);
+
+    return mpt;
+  }
+
+
 
   /// ITO ///
   G4MaterialPropertiesTable* ITO()

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -256,11 +256,11 @@ namespace opticalprops {
 
     std::vector<G4double> energies = {
       optPhotMinE_,
-      hc_ / (1000. * nm),  hc_ / (800. * nm),   hc_ / ( 700. * nm),
-      hc_ / (600. * nm),   hc_ / ( 580. * nm),  hc_ / (560. * nm),
-      hc_ / ( 540. * nm),  hc_ / (520. * nm),   hc_ / ( 500. * nm),
-      hc_ / (480. * nm),   hc_ / ( 460. * nm),  hc_ / (440. * nm),
-      hc_ / ( 420. * nm),  hc_ / (400. * nm),
+      hc_ / (1000. * nm), hc_ / (800. * nm), hc_ / (700. * nm),
+      hc_ / ( 600. * nm), hc_ / (580. * nm), hc_ / (560. * nm),
+      hc_ / ( 540. * nm), hc_ / (520. * nm), hc_ / (500. * nm),
+      hc_ / ( 480. * nm), hc_ / (460. * nm), hc_ / (440. * nm),
+      hc_ / ( 420. * nm), hc_ / (400. * nm),
       optPhotMaxE_ };
 
     std::vector<G4double> rIndex = {
@@ -276,14 +276,14 @@ namespace opticalprops {
     // ABSORPTION LENGTH
     std::vector<G4double> abs_length = {
       (1000. * nm) / (4*pi * 0.0103),
-      (1000. * nm) / (4*pi * 0.0103),  (800. * nm) / (4*pi * 0.0049),
-      ( 700. * nm) / (4*pi * 0.0033),  (600. * nm) / (4*pi * 0.0023),
-      ( 580. * nm) / (4*pi * 0.0022),  (560. * nm) / (4*pi * 0.0022),
-      ( 540. * nm) / (4*pi * 0.0022),  (520. * nm) / (4*pi * 0.0023),
-      ( 500. * nm) / (4*pi * 0.0026),  (480. * nm) / (4*pi * 0.0031),
-      ( 460. * nm) / (4*pi * 0.0039),  (440. * nm) / (4*pi * 0.0053),
-      ( 420. * nm) / (4*pi * 0.0080),  (400. * nm) / (4*pi * 0.0125),
-      (400. * nm) / (4*pi * 0.0125) };
+      (1000. * nm) / (4*pi * 0.0103), (800. * nm) / (4*pi * 0.0049),
+      ( 700. * nm) / (4*pi * 0.0033), (600. * nm) / (4*pi * 0.0023),
+      ( 580. * nm) / (4*pi * 0.0022), (560. * nm) / (4*pi * 0.0022),
+      ( 540. * nm) / (4*pi * 0.0022), (520. * nm) / (4*pi * 0.0023),
+      ( 500. * nm) / (4*pi * 0.0026), (480. * nm) / (4*pi * 0.0031),
+      ( 460. * nm) / (4*pi * 0.0039), (440. * nm) / (4*pi * 0.0053),
+      ( 420. * nm) / (4*pi * 0.0080), (400. * nm) / (4*pi * 0.0125),
+      ( 400. * nm) / (4*pi * 0.0125) };
     mpt->AddProperty("ABSLENGTH", energies, abs_length);
 
     //G4cout << "*** ITO properties ...  " << G4endl;

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -115,46 +115,8 @@ namespace opticalprops {
 
     G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
 
-    // REFRACTIVE INDEX
-    // The range is chosen to be up to ~10.7 eV because Sellmeier's equation
-    // for fused silica is valid only in that range
-    const G4int ri_entries = 200;
-    G4double eWidth = (optPhotFusedSilicaMaxE_ - optPhotMinE_) / ri_entries;
-
-    std::vector<G4double> ri_energy;
-    for (int i=0; i<ri_entries; i++) {
-      ri_energy.push_back(optPhotMinE_ + i * eWidth);
-    }
-
-    // The following values for the refractive index have been calculated
-    // using Sellmeier's equation:
-    //    n^2 - 1 = B_1 * \lambda^2 / (\lambda^2 - C_1) +
-    //            + B_2 * \lambda^2 / (\lambda^2 - C_2) +
-    //            + B_3 * \lambda^2 / (\lambda^2 - C_3),
-    // with wavelength \lambda in micrometers and
-    //    B_1 = 4.73E-1, B_2 = 6.31E-1, B_3 = 9.06E-1
-    //    C_1 = 1.30E-2, C_2 = 4.13E-3, C_3 = 9.88E+1.
-
-    G4double B_1 = 4.73e-1;
-    G4double B_2 = 6.31e-1;
-    G4double B_3 = 9.06e-1;
-    G4double C_1 = 1.30e-2;
-    G4double C_2 = 4.13e-3;
-    G4double C_3 = 9.88e+1;
-
-    std::vector<G4double> rIndex;
-    for (int i=0; i<ri_entries; i++) {
-      G4double lambda = hc_/ri_energy[i]*1000; // in micron
-      G4double n2 = 1 + B_1*pow(lambda,2)/(pow(lambda,2)-C_1)
-        + B_2*pow(lambda,2)/(pow(lambda,2)-C_2)
-        + B_3*pow(lambda,2)/(pow(lambda,2)-C_3);
-      rIndex.push_back(sqrt(n2));
-      //G4cout << "* FakeFusedSilica rIndex:  " << std::setw(5)
-      //       << ri_energy[i]/eV << " eV -> " << rIndex[i] << G4endl;
-    }
-    ri_energy.push_back(optPhotMaxE_);          // This sets the refractive index between optPhotFusedSilicaMaxE_ and
-    rIndex.push_back(rIndex[rIndex.size()-1]);  // optPhotMaxE_ to the value obtained at optPhotFusedSilicaMaxE_
-    mpt->AddProperty("RINDEX", ri_energy, rIndex);
+    G4MaterialPropertiesTable* fused_sil_pt = opticalprops::FusedSilica();
+    mpt->AddProperty("RINDEX", fused_sil_pt->GetProperty("RINDEX"));
 
     // ABSORPTION LENGTH (Set to match the transparency)
     G4double abs_length     = -thickness / log(transparency);

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -75,7 +75,7 @@ namespace opticalprops {
 
     std::vector<G4double> rIndex;
     for (int i=0; i<ri_entries; i++) {
-      G4double lambda = h_Planck*c_light/ri_energy[i]*1000; // in micron
+      G4double lambda = hc_/ri_energy[i]*1000; // in micron
       G4double n2 = 1 + B_1*pow(lambda,2)/(pow(lambda,2)-C_1)
         + B_2*pow(lambda,2)/(pow(lambda,2)-C_2)
         + B_3*pow(lambda,2)/(pow(lambda,2)-C_3);
@@ -157,7 +157,7 @@ namespace opticalprops {
 
     std::vector<G4double> rIndex;
     for (int i=0; i<ri_entries; i++) {
-      G4double lambda = h_Planck*c_light/ri_energy[i]*1000; // in micron
+      G4double lambda = hc_/ri_energy[i]*1000; // in micron
       G4double n2 = 1 + B_1*pow(lambda,2)/(pow(lambda,2)-C_1)
         + B_2*pow(lambda,2)/(pow(lambda,2)-C_2)
         + B_3*pow(lambda,2)/(pow(lambda,2)-C_3);
@@ -197,101 +197,71 @@ namespace opticalprops {
     // REFRACTIVE INDEX
      std::vector<G4double> ri_energy = {
       optPhotMinE_,
-      hc / (2451.63 * nm), hc / (2430.88 * nm),
-      hc / (2405.51 * nm), hc / (2380.14 * nm),
-      hc / (2354.77 * nm), hc / (2329.41 * nm),
-      hc / (2304.04 * nm), hc / (2278.67 * nm),
-      hc / (2253.3 * nm), hc / (2227.94 * nm),
-      hc / (2202.57 * nm), hc / (2177.2 * nm),
-      hc / (2151.83 * nm), hc / (2126.47 * nm),
-      hc / (2101.1 * nm), hc / (2075.73 * nm),
-      hc / (2050.36 * nm), hc / (2025.0 * nm),
-      hc / (1968.5 * nm), hc / (1951.2 * nm),
-      hc / (1925.83 * nm), hc / (1900.47 * nm),
-      hc / (1875.1 * nm), hc / (1849.73 * nm),
-      hc / (1824.36 * nm), hc / (1799.0 * nm),
-      hc / (1773.63 * nm), hc / (1747.6 * nm),
-      hc / (1722.89 * nm), hc / (1697.53 * nm),
-      hc / (1672.16 * nm), hc / (1646.79 * nm),
-      hc / (1621.42 * nm), hc / (1596.06 * nm),
-      hc / (1570.69 * nm), hc / (1545.32 * nm),
-      hc / (1519.95 * nm), hc / (1494.59 * nm),
-      hc / (1469.22 * nm), hc / (1443.85 * nm),
-      hc / (1418.49 * nm), hc / (1393.12 * nm),
-      hc / (1367.75 * nm), hc / (1342.38 * nm),
-      hc / (1317.02 * nm), hc / (1291.65 * nm),
-      hc / (1266.28 * nm), hc / (1240.91 * nm),
-      hc / (1215.55 * nm), hc / (1190.18 * nm),
-      hc / (1164.81 * nm), hc / (1139.44 * nm),
-      hc / (1114.08 * nm), hc / (1088.71 * nm),
-      hc / (1063.34 * nm), hc / (1037.97 * nm),
-      hc / (1012.61 * nm), hc / (987.24 * nm),
-      hc / (961.87 * nm), hc / (936.5 * nm),
-      hc / (911.14 * nm), hc / (885.77 * nm),
-      hc / (860.4 * nm), hc / (835.03 * nm),
-      hc / (809.67 * nm), hc / (784.3 * nm),
-      hc / (758.93 * nm), hc / (733.57 * nm),
-      hc / (708.2 * nm), hc / (682.83 * nm),
-      hc / (657.46 * nm), hc / (624.02 * nm),
-      hc / (606.73 * nm), hc / (587.13 * nm),
-      hc / (569.83 * nm), hc / (554.84 * nm),
-      hc / (541.0 * nm), hc / (519.1 * nm),
-      hc / (509.87 * nm), hc / (499.49 * nm),
-      hc / (490.27 * nm), hc / (481.04 * nm),
-      hc / (470.67 * nm), hc / (456.83 * nm),
-      hc / (451.06 * nm), hc / (442.99 * nm),
-      hc / (434.92 * nm), hc / (426.85 * nm),
-      hc / (417.63 * nm), hc / (401.48 * nm),
-      hc / (395.95 * nm), optPhotMaxE_
+      hc_ / (2451.63 * nm), hc_ / (2430.88 * nm), hc_ / (2405.51 * nm),
+      hc_ / (2380.14 * nm), hc_ / (2354.77 * nm), hc_ / (2329.41 * nm),
+      hc_ / (2304.04 * nm), hc_ / (2278.67 * nm), hc_ / (2253.3 * nm),
+      hc_ / (2227.94 * nm), hc_ / (2202.57 * nm), hc_ / (2177.2 * nm),
+      hc_ / (2151.83 * nm), hc_ / (2126.47 * nm), hc_ / (2101.1 * nm),
+      hc_ / (2075.73 * nm), hc_ / (2050.36 * nm), hc_ / (2025.0 * nm),
+      hc_ / (1968.5 * nm),  hc_ / (1951.2 * nm),  hc_ / (1925.83 * nm),
+      hc_ / (1900.47 * nm), hc_ / (1875.1 * nm),  hc_ / (1849.73 * nm),
+      hc_ / (1824.36 * nm), hc_ / (1799.0 * nm),  hc_ / (1773.63 * nm),
+      hc_ / (1747.6 * nm),  hc_ / (1722.89 * nm), hc_ / (1697.53 * nm),
+      hc_ / (1672.16 * nm), hc_ / (1646.79 * nm), hc_ / (1621.42 * nm),
+      hc_ / (1596.06 * nm), hc_ / (1570.69 * nm), hc_ / (1545.32 * nm),
+      hc_ / (1519.95 * nm), hc_ / (1494.59 * nm), hc_ / (1469.22 * nm),
+      hc_ / (1443.85 * nm), hc_ / (1418.49 * nm), hc_ / (1393.12 * nm),
+      hc_ / (1367.75 * nm), hc_ / (1342.38 * nm), hc_ / (1317.02 * nm),
+      hc_ / (1291.65 * nm), hc_ / (1266.28 * nm), hc_ / (1240.91 * nm),
+      hc_ / (1215.55 * nm), hc_ / (1190.18 * nm), hc_ / (1164.81 * nm),
+      hc_ / (1139.44 * nm), hc_ / (1114.08 * nm), hc_ / (1088.71 * nm),
+      hc_ / (1063.34 * nm), hc_ / (1037.97 * nm), hc_ / (1012.61 * nm),
+      hc_ / (987.24 * nm),  hc_ / (961.87 * nm),  hc_ / (936.5 * nm),
+      hc_ / (911.14 * nm),  hc_ / (885.77 * nm),  hc_ / (860.4 * nm),
+      hc_ / (835.03 * nm),  hc_ / (809.67 * nm),  hc_ / (784.3 * nm),
+      hc_ / (758.93 * nm),  hc_ / (733.57 * nm),  hc_ / (708.2 * nm),
+      hc_ / (682.83 * nm),  hc_ / (657.46 * nm),  hc_ / (624.02 * nm),
+      hc_ / (606.73 * nm),  hc_ / (587.13 * nm),  hc_ / (569.83 * nm),
+      hc_ / (554.84 * nm),  hc_ / (541.0 * nm),   hc_ / (519.1 * nm),
+      hc_ / (509.87 * nm),  hc_ / (499.49 * nm),  hc_ / (490.27 * nm),
+      hc_ / (481.04 * nm),  hc_ / (470.67 * nm),  hc_ / (456.83 * nm),
+      hc_ / (451.06 * nm),  hc_ / (442.99 * nm),   hc_ / (434.92 * nm),
+      hc_ / (426.85 * nm),  hc_ / (417.63 * nm), hc_ / (401.48 * nm),
+      hc_ / (395.95 * nm), optPhotMaxE_
      };
 
      std::vector<G4double> rIndex = {
        1.524,
-       1.524, 1.525,
-       1.525, 1.525,
-       1.525, 1.526,
-       1.526, 1.526,
-       1.526, 1.526,
-       1.527, 1.527,
-       1.527, 1.527,
-       1.527, 1.528,
-       1.528, 1.528,
-       1.528, 1.528,
-       1.528, 1.529,
-       1.529, 1.529,
-       1.529, 1.529,
-       1.53, 1.53,
-       1.53, 1.53,
-       1.531, 1.531,
-       1.531, 1.531,
-       1.532, 1.532,
-       1.532, 1.532,
-       1.533, 1.533,
-       1.533, 1.533,
-       1.534, 1.534,
-       1.534, 1.534,
-       1.535, 1.535,
-       1.535, 1.535,
-       1.536, 1.536,
-       1.536, 1.536,
-       1.536, 1.537,
-       1.537, 1.537,
-       1.538, 1.538,
-       1.539, 1.539,
-       1.54, 1.54,
-       1.541, 1.542,
-       1.543, 1.544,
-       1.545, 1.546,
-       1.547, 1.549,
-       1.55, 1.551,
-       1.552, 1.554,
-       1.555, 1.558,
-       1.559, 1.56,
-       1.562, 1.563,
-       1.565, 1.567,
-       1.568, 1.569,
-       1.57, 1.572,
-       1.573, 1.576,
+       1.524, 1.525, 1.525,
+       1.525, 1.525, 1.526,
+       1.526, 1.526, 1.526,
+       1.526, 1.527, 1.527,
+       1.527, 1.527, 1.527,
+       1.528, 1.528, 1.528,
+       1.528, 1.528, 1.528,
+       1.529, 1.529, 1.529,
+       1.529, 1.529, 1.53,
+       1.53,  1.53,  1.53,
+       1.531, 1.531, 1.531,
+       1.531, 1.532, 1.532,
+       1.532, 1.532, 1.533,
+       1.533, 1.533, 1.533,
+       1.534, 1.534, 1.534,
+       1.534, 1.535, 1.535,
+       1.535, 1.535, 1.536,
+       1.536, 1.536, 1.536,
+       1.536, 1.537, 1.537,
+       1.537, 1.538, 1.538,
+       1.539, 1.539, 1.54,
+       1.54,  1.541, 1.542,
+       1.543, 1.544, 1.545,
+       1.546, 1.547, 1.549,
+       1.55,  1.551, 1.552,
+       1.554, 1.555, 1.558,
+       1.559, 1.56,  1.562,
+       1.563, 1.565, 1.567,
+       1.568, 1.569, 1.57,
+       1.572, 1.573, 1.576,
        1.577, 1.577
      };
 
@@ -331,23 +301,19 @@ namespace opticalprops {
 
     std::vector<G4double> energies = {
       optPhotMinE_,
-      h_Planck * c_light / (1000. * nm),  h_Planck * c_light / (800. * nm),
-      h_Planck * c_light / ( 700. * nm),  h_Planck * c_light / (600. * nm),
-      h_Planck * c_light / ( 580. * nm),  h_Planck * c_light / (560. * nm),
-      h_Planck * c_light / ( 540. * nm),  h_Planck * c_light / (520. * nm),
-      h_Planck * c_light / ( 500. * nm),  h_Planck * c_light / (480. * nm),
-      h_Planck * c_light / ( 460. * nm),  h_Planck * c_light / (440. * nm),
-      h_Planck * c_light / ( 420. * nm),  h_Planck * c_light / (400. * nm),
+      hc_ / (1000. * nm),  hc_ / (800. * nm),   hc_ / ( 700. * nm),
+      hc_ / (600. * nm),   hc_ / ( 580. * nm),  hc_ / (560. * nm),
+      hc_ / ( 540. * nm),  hc_ / (520. * nm),   hc_ / ( 500. * nm),
+      hc_ / (480. * nm),   hc_ / ( 460. * nm),  hc_ / (440. * nm),
+      hc_ / ( 420. * nm),  hc_ / (400. * nm),
       optPhotMaxE_ };
 
     std::vector<G4double> rIndex = {
       1.635,
-      1.635, 1.775,
-      1.835, 1.894,
-      1.906, 1.919,
-      1.931, 1.945,
-      1.960, 1.975,
-      1.993, 2.012,
+      1.635, 1.775, 1.835,
+      1.894, 1.906, 1.919,
+      1.931, 1.945, 1.960,
+      1.975, 1.993, 2.012,
       2.036, 2.064,
       2.064 };
     mpt->AddProperty("RINDEX", energies, rIndex);
@@ -389,38 +355,34 @@ namespace opticalprops {
 
     std::vector<G4double> energies = {
       optPhotMinE_,
-      h_Planck * c_light / (1097. * nm),  h_Planck * c_light / (1000. * nm),
-      h_Planck * c_light / ( 950. * nm),  h_Planck * c_light / ( 900. * nm),
-      h_Planck * c_light / ( 800. * nm),  h_Planck * c_light / ( 700. * nm),
-      h_Planck * c_light / ( 600. * nm),  h_Planck * c_light / ( 550. * nm),
-      h_Planck * c_light / ( 500. * nm),  h_Planck * c_light / ( 450. * nm),
-      h_Planck * c_light / ( 420. * nm),  h_Planck * c_light / ( 400. * nm),
-      h_Planck * c_light / ( 370. * nm),  h_Planck * c_light / ( 350. * nm),
-      h_Planck * c_light / ( 302. * nm),  optPhotMaxE_ };
+      hc_ / (1097. * nm),  hc_ / (1000. * nm),  hc_ / ( 950. * nm),
+      hc_ / ( 900. * nm),  hc_ / ( 800. * nm),  hc_ / ( 700. * nm),
+      hc_ / ( 600. * nm),  hc_ / ( 550. * nm),  hc_ / ( 500. * nm),
+      hc_ / ( 450. * nm),  hc_ / ( 420. * nm),  hc_ / ( 400. * nm),
+      hc_ / ( 370. * nm),  hc_ / ( 350. * nm),  hc_ / ( 302. * nm),
+      optPhotMaxE_ };
 
     std::vector<G4double> rIndex = {
       1.4760,
-      1.4760, 1.4662,
-      1.4665, 1.4693,
-      1.4802, 1.4935,
-      1.5080, 1.5155,
-      1.5235, 1.5328,
-      1.5391, 1.5439,
-      1.5522, 1.5587,
-      1.5805, 1.5805 };
+      1.4760, 1.4662, 1.4665,
+      1.4693, 1.4802, 1.4935,
+      1.5080, 1.5155, 1.5235,
+      1.5328, 1.5391, 1.5439,
+      1.5522, 1.5587, 1.5805,
+      1.5805 };
     mpt->AddProperty("RINDEX", energies, rIndex);
 
     // ABSORPTION LENGTH
     std::vector<G4double> abs_length = {
       (1097. * nm) / (4*pi * 0.1191),
-      (1097. * nm) / (4*pi * 0.1191),   (1000. * nm) / (4*pi * 0.0859),
-      ( 950. * nm) / (4*pi * 0.0701),   ( 900. * nm) / (4*pi * 0.0561),
-      ( 800. * nm) / (4*pi * 0.0340),   ( 700. * nm) / (4*pi * 0.0197),
-      ( 600. * nm) / (4*pi * 0.0107),   ( 550. * nm) / (4*pi * 0.0076),
-      ( 500. * nm) / (4*pi * 0.0051),   ( 450. * nm) / (4*pi * 0.0035),
-      ( 420. * nm) / (4*pi * 0.0025),   ( 400. * nm) / (4*pi * 0.00194),
-      ( 370. * nm) / (4*pi * 0.00135),  ( 350. * nm) / (4*pi * 0.00103),
-      ( 302. * nm) / (4*pi * 0.0004),   ( 302. * nm) / (4*pi * 0.0004) };
+      (1097. * nm) / (4*pi * 0.1191),  (1000. * nm) / (4*pi * 0.0859),
+      ( 950. * nm) / (4*pi * 0.0701),  ( 900. * nm) / (4*pi * 0.0561),
+      ( 800. * nm) / (4*pi * 0.0340),  ( 700. * nm) / (4*pi * 0.0197),
+      ( 600. * nm) / (4*pi * 0.0107),  ( 550. * nm) / (4*pi * 0.0076),
+      ( 500. * nm) / (4*pi * 0.0051),  ( 450. * nm) / (4*pi * 0.0035),
+      ( 420. * nm) / (4*pi * 0.0025),  ( 400. * nm) / (4*pi * 0.00194),
+      ( 370. * nm) / (4*pi * 0.00135), ( 350. * nm) / (4*pi * 0.00103),
+      ( 302. * nm) / (4*pi * 0.0004),  ( 302. * nm) / (4*pi * 0.0004) };
     mpt->AddProperty("ABSLENGTH", energies, abs_length);
 
     //G4cout << "*** PEDOT properties ...  " << G4endl;
@@ -458,7 +420,7 @@ namespace opticalprops {
 
     std::vector<G4double> rIndex;
     for (int i=0; i<ri_entries; i++) {
-      G4double lambda = h_Planck*c_light/ri_energy[i]*1000; // in micron
+      G4double lambda = hc_/ri_energy[i]*1000; // in micron
       G4double n2 = 2.291142 - 3.311944E-2*pow(lambda,2) - 1.630099E-2*pow(lambda,-2) +
                     7.265983E-3*pow(lambda,-4) - 6.806145E-4*pow(lambda,-6) +
                     1.960732E-5*pow(lambda,-8);
@@ -516,7 +478,7 @@ namespace opticalprops {
 
     std::vector<G4double> rIndex;
     for (int i=0; i<ri_entries; i++) {
-      rIndex.push_back(seq.RefractiveIndex(h_Planck*c_light/ri_energy[i]));
+      rIndex.push_back(seq.RefractiveIndex(hc_/ri_energy[i]));
       //G4cout << "* Sapphire rIndex:  " << std::setw(5)
       //       << ri_energy[i]/eV << " eV -> " << rIndex[i] << G4endl;
     }
@@ -570,7 +532,7 @@ namespace opticalprops {
 
     std::vector<G4double> rIndex;
     for (int i=0; i<ri_entries; i++) {
-      G4double wl = h_Planck * c_light / ri_energy[i];
+      G4double wl = hc_ / ri_energy[i];
       rIndex.push_back(constTerm + squareTerm/(wl*wl) + quadTerm/pow(wl,4));
       //G4cout << "* OptCoupler rIndex:  " << std::setw(5)
       //       << ri_energy[i]/eV << " eV -> " << rIndex[i] << G4endl;
@@ -605,7 +567,7 @@ namespace opticalprops {
   {
     // An argon gas proportional scintillation counter with UV avalanche photodiode scintillation
     // readout C.M.B. Monteiro, J.A.M. Lopes, P.C.P.S. Simoes, J.M.F. dos Santos, C.A.N. Conde
-    // 
+    //
     // May 2023:
     // Updated scintillation decay and yields from:
     // Triplet Lifetime in Gaseous Argon. Michael Akashi-Ronquest et al.
@@ -623,7 +585,7 @@ namespace opticalprops {
 
     std::vector<G4double> rIndex;
     for (int i=0; i<ri_entries; i++) {
-      G4double wl = h_Planck * c_light / ri_energy[i] * 1000; // in micron
+      G4double wl = hc_ / ri_energy[i] * 1000; // in micron
       // From refractiveindex.info
       rIndex.push_back(1 + 0.012055*(0.2075*pow(wl,2)/(91.012*pow(wl,2)-1) +
                                      0.0415*pow(wl,2)/(87.892*pow(wl,2)-1) +
@@ -641,8 +603,8 @@ namespace opticalprops {
     // EMISSION SPECTRUM
     G4double Wavelength_peak  = 128.000 * nm;
     G4double Wavelength_sigma =   2.929 * nm;
-    G4double Energy_peak  = (h_Planck*c_light / Wavelength_peak);
-    G4double Energy_sigma = (h_Planck*c_light * Wavelength_sigma / pow(Wavelength_peak,2));
+    G4double Energy_peak  = (hc_ / Wavelength_peak);
+    G4double Energy_sigma = (hc_ * Wavelength_sigma / pow(Wavelength_peak,2));
     //G4cout << "*** GAr Energy_peak: " << Energy_peak/eV << " eV   Energy_sigma: "
     //       << Energy_sigma/eV << " eV" << G4endl;
 
@@ -758,7 +720,7 @@ namespace opticalprops {
     LXe_mpt->AddProperty("RINDEX", ri_energy, ri_index);
 
     // for (G4int i=ri_entries-1; i>=0; i--) {
-    //   G4cout << h_Planck*c_light/ri_energy[i]/nanometer << " nm, " << rindex[i] << G4endl;
+    //   G4cout << hc_/ri_energy[i]/nanometer << " nm, " << rindex[i] << G4endl;
     // }
 
     // Sampling from ~151 nm to 200 nm <----> from 6.20625 eV to 8.21 eV
@@ -889,24 +851,22 @@ namespace opticalprops {
     G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
 
     std::vector<G4double> ENERGIES = {
-       h_Planck * c_light / (2456.42541 * nm), h_Planck * c_light / (2396.60266 * nm),
-       h_Planck * c_light / (2276.95716 * nm), h_Planck * c_light / (2159.52733 * nm),
-       h_Planck * c_light / (2037.66617 * nm), h_Planck * c_light / (1918.02068 * nm),
-       h_Planck * c_light / (1798.37518 * nm), h_Planck * c_light / (1676.51403 * nm),
-       h_Planck * c_light / (1559.08419 * nm), h_Planck * c_light / (1437.22304 * nm),
-       h_Planck * c_light / (1319.79321 * nm), h_Planck * c_light / (1197.93205 * nm),
-       h_Planck * c_light / (1078.28656 * nm), h_Planck * c_light / (956.42541 * nm),
-       h_Planck * c_light / (838.99557 * nm), h_Planck * c_light / (717.13442 * nm),
-       h_Planck * c_light / (597.48892 * nm), h_Planck * c_light / (477.84343 * nm),
-       h_Planck * c_light / (418.02068 * nm), h_Planck * c_light / (358.19793 * nm),
-       h_Planck * c_light / (293.94387 * nm)
+       hc_ / (2456.42541 * nm), hc_ / (2396.60266 * nm), hc_ / (2276.95716 * nm),
+       hc_ / (2159.52733 * nm), hc_ / (2037.66617 * nm), hc_ / (1918.02068 * nm),
+       hc_ / (1798.37518 * nm), hc_ / (1676.51403 * nm), hc_ / (1559.08419 * nm),
+       hc_ / (1437.22304 * nm), hc_ / (1319.79321 * nm), hc_ / (1197.93205 * nm),
+       hc_ / (1078.28656 * nm), hc_ / (956.42541 * nm),  hc_ / (838.99557 * nm),
+       hc_ / (717.13442 * nm),  hc_ / (597.48892 * nm),  hc_ / (477.84343 * nm),
+       hc_ / (418.02068 * nm),  hc_ / (358.19793 * nm),  hc_ / (293.94387 * nm)
     };
     std::vector<G4double> REFLECTIVITY = {
-      .99088, .99082, .98925, .98623, .98611,
-      .98163, .98006, .97849, .97401, .97098,
-      .96941, .96784, .96481, .96033, .96167,
-      .96301, .96289, .96278, .96126, .95830,
-      .94224
+      .99088, .99082, .98925,
+      .98623, .98611, .98163,
+      .98006, .97849, .97401,
+      .97098, .96941, .96784,
+      .96481, .96033, .96167,
+      .96301, .96289, .96278,
+      .96126, .95830, .94224
     };
     // DOI:10.4236/ampc.2015.511046
     mpt->AddProperty("REFLECTIVITY", ENERGIES, REFLECTIVITY);
@@ -973,18 +933,18 @@ namespace opticalprops {
     // the simulation energy limits set in the header.
 
     //G4double WLS_abs_energy[] = {
-    //  optPhotMinE_,                      h_Planck * c_light / (450. * nm),
-    //  h_Planck * c_light / (440. * nm),  h_Planck * c_light / (430. * nm),
-    //  h_Planck * c_light / (420. * nm),  h_Planck * c_light / (410. * nm),
-    //  h_Planck * c_light / (400. * nm),  h_Planck * c_light / (390. * nm),
-    //  h_Planck * c_light / (380. * nm),  h_Planck * c_light / (370. * nm),
-    //  h_Planck * c_light / (360. * nm),  h_Planck * c_light / (330. * nm),
-    //  h_Planck * c_light / (320. * nm),  h_Planck * c_light / (310. * nm),
-    //  h_Planck * c_light / (300. * nm),  h_Planck * c_light / (270. * nm),
-    //  h_Planck * c_light / (250. * nm),  h_Planck * c_light / (230. * nm),
-    //  h_Planck * c_light / (210. * nm),  h_Planck * c_light / (190. * nm),
-    //  h_Planck * c_light / (170. * nm),  h_Planck * c_light / (150. * nm),
-    //  h_Planck * c_light / (100. * nm),  optPhotMaxE_
+    //  optPhotMinE_,                      hc_ / (450. * nm),
+    //  hc_ / (440. * nm),  hc_ / (430. * nm),
+    //  hc_ / (420. * nm),  hc_ / (410. * nm),
+    //  hc_ / (400. * nm),  hc_ / (390. * nm),
+    //  hc_ / (380. * nm),  hc_ / (370. * nm),
+    //  hc_ / (360. * nm),  hc_ / (330. * nm),
+    //  hc_ / (320. * nm),  hc_ / (310. * nm),
+    //  hc_ / (300. * nm),  hc_ / (270. * nm),
+    //  hc_ / (250. * nm),  hc_ / (230. * nm),
+    //  hc_ / (210. * nm),  hc_ / (190. * nm),
+    //  hc_ / (170. * nm),  hc_ / (150. * nm),
+    //  hc_ / (100. * nm),  optPhotMaxE_
     //};
     //const G4int WLS_abs_entries = sizeof(WLS_abs_energy) / sizeof(G4double);
   //
@@ -1008,31 +968,26 @@ namespace opticalprops {
     // for wavelengths higher than 380 nm where the WLS emission spectrum starts.
     std::vector<G4double> WLS_abs_energy = {
       optPhotMinE_,
-      h_Planck * c_light / (380. * nm),  h_Planck * c_light / (370. * nm),
-      h_Planck * c_light / (360. * nm),  h_Planck * c_light / (330. * nm),
-      h_Planck * c_light / (320. * nm),  h_Planck * c_light / (310. * nm),
-      h_Planck * c_light / (300. * nm),  h_Planck * c_light / (270. * nm),
-      h_Planck * c_light / (250. * nm),  h_Planck * c_light / (230. * nm),
-      h_Planck * c_light / (210. * nm),  h_Planck * c_light / (190. * nm),
-      h_Planck * c_light / (170. * nm),  h_Planck * c_light / (150. * nm),
+      hc_ / (380. * nm),  hc_ / (370. * nm), hc_ / (360. * nm),
+      hc_ / (330. * nm),  hc_ / (320. * nm), hc_ / (310. * nm),
+      hc_ / (300. * nm),  hc_ / (270. * nm), hc_ / (250. * nm),
+      hc_ / (230. * nm),  hc_ / (210. * nm), hc_ / (190. * nm),
+      hc_ / (170. * nm),  hc_ / (150. * nm),
       optPhotMaxE_
     };
 
     std::vector<G4double> WLS_absLength = {
       noAbsLength_,                 // ~6200 nm
-      noAbsLength_,   50. * nm,     // 380 , 370 nm
-      30. * nm,      30. * nm,      // 360 , 330 nm
-      50. * nm,      80. * nm,      // 320 , 310 nm
-      100. * nm,     100. * nm,     // 300 , 270 nm
-      400. * nm,     400. * nm,     // 250 , 230 nm
-      350. * nm,     250. * nm,     // 210 , 190 nm
-      350. * nm,     400. * nm,     // 170 , 150 nm
-      400. * nm                     // ~108 nm
+      noAbsLength_, 50. * nm, 30. * nm, // 380, 370, 360 nm
+      30. * nm, 50. * nm, 80. * nm,     // 330, 320, 310 nm
+      100. * nm, 100. * nm, 400. * nm,  // 300, 270, 250 nm
+      400. * nm, 350. * nm, 250. * nm,  // 230, 210, 190 nm
+      350. * nm, 400. * nm, 400. * nm   // 170, 150, ~108 nm
     };
 
     //for (int i=0; i<WLS_abs_energy.size(); i++)
     //  G4cout << "* TPB WLS absLength:  " << std::setw(8) << WLS_abs_energy[i] / eV
-    //         << " eV  ==  " << std::setw(8) << (h_Planck * c_light / WLS_abs_energy[i]) / nm
+    //         << " eV  ==  " << std::setw(8) << (hc_ / WLS_abs_energy[i]) / nm
     //         << " nm  ->  " << std::setw(6) << WLS_absLength[i] / nm << " nm" << G4endl;
     mpt->AddProperty("WLSABSLENGTH", WLS_abs_energy, WLS_absLength);
 
@@ -1053,7 +1008,7 @@ namespace opticalprops {
     G4double mu2    = 411.2;
 
     for (int i=0; i<WLS_emi_entries; i++) {
-      G4double wl = (h_Planck * c_light / WLS_emi_energy[i]) / nm;
+      G4double wl = (hc_ / WLS_emi_energy[i]) / nm;
       WLS_emiSpectrum.push_back(A * (alpha/2.) * exp((alpha/2.) *
                           (2*mu1 + alpha*pow(sigma1,2) - 2*wl)) *
                           erfc((mu1 + alpha*pow(sigma1,2) - wl) / (sqrt(2)*sigma1)) +
@@ -1131,12 +1086,10 @@ namespace opticalprops {
     // Then, we scale accordingly to the absorption spectrum (which is in a.u.).
     std::vector<G4double> WLS_abs_energy = {
       optPhotMinE_,
-      h_Planck * c_light / (337. * nm),
-      h_Planck * c_light / (318. * nm), h_Planck * c_light / (292. * nm),
-      h_Planck * c_light / (276. * nm), h_Planck * c_light / (253. * nm),
-      h_Planck * c_light / (238. * nm), h_Planck * c_light / (222. * nm),
-      h_Planck * c_light / (204. * nm), h_Planck * c_light / (190. * nm),
-      h_Planck * c_light / (175. * nm), h_Planck * c_light / (169. * nm),
+      hc_ / (337. * nm), hc_ / (318. * nm), hc_ / (292. * nm),
+      hc_ / (276. * nm), hc_ / (253. * nm), hc_ / (238. * nm),
+      hc_ / (222. * nm), hc_ / (204. * nm), hc_ / (190. * nm),
+      hc_ / (175. * nm), hc_ / (169. * nm),
       optPhotMaxE_
     };
 
@@ -1144,12 +1097,10 @@ namespace opticalprops {
     float XePeakAbsLength = 21 * nm;
 
     std::vector<float> PTP_absorption = {
-      0.002, // 337
-      0.174, 0.414, // 318, 292
-      0.949, 0.540, // 276, 253
-      1.218, 1.858, // 238, 222
-      1.429, 1.716, // 204, 190
-      1.879, 1.803, // 175, 169
+      0.002, 0.174, 0.414, // 337, 318, 292
+      0.949, 0.540, 1.218, // 276, 253, 238
+      1.858, 1.429, 1.716, // 222, 204, 190
+      1.879, 1.803 // 175, 169
     };
 
     std::vector<G4double> WLS_absLength = {noAbsLength_};
@@ -1160,27 +1111,23 @@ namespace opticalprops {
 
     //for (int i=0; i<WLS_abs_entries; i++)
     //  G4cout << "* TPB WLS absLength:  " << std::setw(8) << WLS_abs_energy[i] / eV
-    //         << " eV  ==  " << std::setw(8) << (h_Planck * c_light / WLS_abs_energy[i]) / nm
+    //         << " eV  ==  " << std::setw(8) << (hc_ / WLS_abs_energy[i]) / nm
     //         << " nm  ->  " << std::setw(6) << WLS_absLength[i] / nm << " nm" << G4endl;
     mpt->AddProperty("WLSABSLENGTH", WLS_abs_energy, WLS_absLength);
 
     // WLS EMISSION SPECTRUM
     std::vector<G4double> WLS_emi_energy = {
       optPhotMinE_,
-      h_Planck * c_light / (452. * nm), h_Planck * c_light / (430. * nm),
-      h_Planck * c_light / (412. * nm), h_Planck * c_light / (398. * nm),
-      h_Planck * c_light / (385. * nm), h_Planck * c_light / (371. * nm),
-      h_Planck * c_light / (361. * nm), h_Planck * c_light / (354. * nm),
-      h_Planck * c_light / (336. * nm), h_Planck * c_light / (317. * nm),
+      hc_ / (452. * nm), hc_ / (430. * nm), hc_ / (412. * nm), hc_ / (398. * nm),
+      hc_ / (385. * nm), hc_ / (371. * nm), hc_ / (361. * nm), hc_ / (354. * nm),
+      hc_ / (336. * nm), hc_ / (317. * nm),
       optPhotMaxE_
     };
 
     std::vector<G4double> WLS_emiSpectrum = {
       0.,
-      0.044, 0.179,
-      0.351, 0.514,
-      0.849, 0.993,
-      0.745, 0.421,
+      0.044, 0.179, 0.351, 0.514,
+      0.849, 0.993, 0.745, 0.421,
       0.173, 0.022,
       0.
     };
@@ -1210,127 +1157,107 @@ namespace opticalprops {
     // REFRACTIVE INDEX
     std::vector<G4double> ri_energy = {
       optPhotMinE_,
-      h_Planck * c_light / (609. * nm),  h_Planck * c_light / (589.26 * nm),
-      h_Planck * c_light / (550. * nm),  h_Planck * c_light / (530.   * nm),
-      h_Planck * c_light / (500. * nm),  h_Planck * c_light / (490.   * nm),
-      h_Planck * c_light / (481. * nm),  h_Planck * c_light / (460.   * nm),
-      h_Planck * c_light / (435. * nm),  h_Planck * c_light / (425.   * nm),
+      hc_ / (609. * nm),  hc_ / (589.26 * nm), hc_ / (550. * nm),
+      hc_ / (530. * nm),  hc_ / (500. * nm),   hc_ / (490. * nm),
+      hc_ / (481. * nm),  hc_ / (460. * nm),   hc_ / (435. * nm),
+      hc_ / (425. * nm),
       optPhotMaxE_
     };
 
     std::vector<G4double> rIndex = {
       1.5780,
-      1.5780,  1.5800,   // 609 , 589.26 nm
-      1.5845,  1.5870,   // 550 , 530 nm
-      1.5913,  1.5929,   // 500 , 490 nm
-      1.5945,  1.5986,   // 481 , 460 nm
-      1.6050,  1.6080,   // 435 , 425 nm
+      1.5780, 1.5800, 1.5845,  // 609 , 589.26, 550 nm
+      1.5870, 1.5913, 1.5929,  // 530, 500, 490 nm
+      1.5945, 1.5986, 1.6050,  // 481, 460, 435 nm
+      1.6080,                  // 425 nm
       1.608
     };
     mpt->AddProperty("RINDEX", ri_energy, rIndex);
 
     // ABSORPTION LENGTH
     std::vector<G4double> abs_energy = {
-      optPhotMinE_,                      h_Planck * c_light / (750. * nm),
-      h_Planck * c_light / (740. * nm),  h_Planck * c_light / (380. * nm),
-      h_Planck * c_light / (370. * nm),  optPhotMaxE_
+      optPhotMinE_,
+      hc_ / (750. * nm), hc_ / (740. * nm), hc_ / (380. * nm), hc_ / (370. * nm),
+      optPhotMaxE_
     };
     std::vector<G4double> absLength = {
-      noAbsLength_,  noAbsLength_,
-      3.0 * m,       3.0 * m,
-      noAbsLength_,  noAbsLength_
+      noAbsLength_,
+      noAbsLength_, 3.0 * m, 3.0 * m, noAbsLength_,
+      noAbsLength_
     };
     mpt->AddProperty("ABSLENGTH", abs_energy, absLength);
 
     // WLS ABSORPTION LENGTH
     std::vector<G4double> WLS_abs_energy = {
-      optPhotMinE_,                      h_Planck * c_light / (500. * nm),
-      h_Planck * c_light / (495. * nm),  h_Planck * c_light / (490. * nm),
-      h_Planck * c_light / (485. * nm),  h_Planck * c_light / (480. * nm),
-      h_Planck * c_light / (475. * nm),  h_Planck * c_light / (470. * nm),
-      h_Planck * c_light / (465. * nm),  h_Planck * c_light / (460. * nm),
-      h_Planck * c_light / (455. * nm),  h_Planck * c_light / (450. * nm),
-      h_Planck * c_light / (445. * nm),  h_Planck * c_light / (440. * nm),
-      h_Planck * c_light / (435. * nm),  h_Planck * c_light / (430. * nm),
-      h_Planck * c_light / (425. * nm),  h_Planck * c_light / (420. * nm),
-      h_Planck * c_light / (415. * nm),  h_Planck * c_light / (410. * nm),
-      h_Planck * c_light / (405. * nm),  h_Planck * c_light / (400. * nm),
-      h_Planck * c_light / (395. * nm),  h_Planck * c_light / (390. * nm),
-      h_Planck * c_light / (385. * nm),  h_Planck * c_light / (380. * nm),
-      h_Planck * c_light / (375. * nm),  h_Planck * c_light / (370. * nm),
-      h_Planck * c_light / (365. * nm),  h_Planck * c_light / (360. * nm),
-      h_Planck * c_light / (355. * nm),  h_Planck * c_light / (350. * nm),
-      h_Planck * c_light / (345. * nm),  optPhotMaxE_
+      optPhotMinE_,
+      hc_ / (500. * nm), hc_ / (495. * nm), hc_ / (490. * nm),
+      hc_ / (485. * nm), hc_ / (480. * nm), hc_ / (475. * nm),
+      hc_ / (470. * nm), hc_ / (465. * nm), hc_ / (460. * nm),
+      hc_ / (455. * nm), hc_ / (450. * nm), hc_ / (445. * nm),
+      hc_ / (440. * nm), hc_ / (435. * nm), hc_ / (430. * nm),
+      hc_ / (425. * nm), hc_ / (420. * nm), hc_ / (415. * nm),
+      hc_ / (410. * nm), hc_ / (405. * nm), hc_ / (400. * nm),
+      hc_ / (395. * nm), hc_ / (390. * nm), hc_ / (385. * nm),
+      hc_ / (380. * nm), hc_ / (375. * nm), hc_ / (370. * nm),
+      hc_ / (365. * nm), hc_ / (360. * nm), hc_ / (355. * nm),
+      hc_ / (350. * nm), hc_ / (345. * nm),
+      optPhotMaxE_
     };
 
     std::vector<G4double> WLS_absLength = {
-      noAbsLength_,        noAbsLength_,
-      (1. / 0.0080) * cm,  (1. / 0.0165) * cm,    // 495 , 490 nm
-      (1. / 0.0325) * cm,  (1. / 0.0815) * cm,    // 485 , 480 nm
-      (1. / 0.2940) * cm,  (1. / 0.9640) * cm,    // 475 , 470 nm
-      (1. / 2.8600) * cm,  (1. / 6.3900) * cm,    // 465 , 460 nm
-      (1. / 9.9700) * cm,  (1. / 11.0645)* cm,    // 455 , 450 nm
-      (1. / 10.198) * cm,  (1. / 9.4465) * cm,    // 445 , 440 nm
-      (1. / 10.2145)* cm,  (1. / 12.240) * cm,    // 435 , 430 nm
-      (1. / 12.519) * cm,  (1. / 10.867) * cm,    // 425 , 420 nm
-      (1. / 9.0710) * cm,  (1. / 8.0895) * cm,    // 415 , 410 nm
-      (1. / 7.6650) * cm,  (1. / 6.7170) * cm,    // 405 , 400 nm
-      (1. / 5.2460) * cm,  (1. / 4.1185) * cm,    // 395 , 390 nm
-      (1. / 3.3175) * cm,  (1. / 2.6800) * cm,    // 385 , 380 nm
-      (1. / 1.9610) * cm,  (1. / 1.4220) * cm,    // 375 , 370 nm
-      (1. / 1.0295) * cm,  (1. / 0.7680) * cm,    // 365 , 360 nm
-      (1. / 0.6865) * cm,  (1. / 0.5885) * cm,    // 355 , 350 nm
-      noAbsLength_,        noAbsLength_
+      noAbsLength_,
+      noAbsLength_, (1. / 0.0080) * cm, (1. / 0.0165) * cm,
+      (1. / 0.0325) * cm, (1. / 0.0815) * cm, (1. / 0.2940) * cm,
+      (1. / 0.9640) * cm, (1. / 2.8600) * cm, (1. / 6.3900) * cm,
+      (1. / 9.9700) * cm, (1. / 11.0645)* cm, (1. / 10.198) * cm,
+      (1. / 9.4465) * cm, (1. / 10.2145)* cm, (1. / 12.240) * cm,
+      (1. / 12.519) * cm, (1. / 10.867) * cm, (1. / 9.0710) * cm,
+      (1. / 8.0895) * cm, (1. / 7.6650) * cm, (1. / 6.7170) * cm,
+      (1. / 5.2460) * cm, (1. / 4.1185) * cm, (1. / 3.3175) * cm,
+      (1. / 2.6800) * cm, (1. / 1.9610) * cm, (1. / 1.4220) * cm,
+      (1. / 1.0295) * cm, (1. / 0.7680) * cm, (1. / 0.6865) * cm,
+      (1. / 0.5885) * cm, noAbsLength_,
+      noAbsLength_
     };
     mpt->AddProperty("WLSABSLENGTH", WLS_abs_energy, WLS_absLength);
     //for (int i=0; i<WLS_abs_entries; i++)
     //  G4cout << "* EJ280 WLS absLength:  " << std::setw(8) << WLS_abs_energy[i] / eV
-    //         << " eV  ==  " << std::setw(8) << (h_Planck * c_light / WLS_abs_energy[i]) / nm
+    //         << " eV  ==  " << std::setw(8) << (hc_ / WLS_abs_energy[i]) / nm
     //         << " nm  ->  " << std::setw(6) << WLS_absLength[i] / mm << " mm" << G4endl;
 
     // WLS EMISSION SPECTRUM
     std::vector<G4double> WLS_emi_energy = {
-      optPhotMinE_,                      h_Planck * c_light / (610. * nm),
-      h_Planck * c_light / (605. * nm),  h_Planck * c_light / (600. * nm),
-      h_Planck * c_light / (595. * nm),  h_Planck * c_light / (590. * nm),
-      h_Planck * c_light / (585. * nm),  h_Planck * c_light / (580. * nm),
-      h_Planck * c_light / (575. * nm),  h_Planck * c_light / (570. * nm),
-      h_Planck * c_light / (565. * nm),  h_Planck * c_light / (560. * nm),
-      h_Planck * c_light / (555. * nm),  h_Planck * c_light / (550. * nm),
-      h_Planck * c_light / (545. * nm),  h_Planck * c_light / (540. * nm),
-      h_Planck * c_light / (535. * nm),  h_Planck * c_light / (530. * nm),
-      h_Planck * c_light / (525. * nm),  h_Planck * c_light / (520. * nm),
-      h_Planck * c_light / (515. * nm),  h_Planck * c_light / (510. * nm),
-      h_Planck * c_light / (505. * nm),  h_Planck * c_light / (500. * nm),
-      h_Planck * c_light / (495. * nm),  h_Planck * c_light / (490. * nm),
-      h_Planck * c_light / (485. * nm),  h_Planck * c_light / (480. * nm),
-      h_Planck * c_light / (475. * nm),  h_Planck * c_light / (470. * nm),
-      h_Planck * c_light / (465. * nm),  h_Planck * c_light / (460. * nm),
-      h_Planck * c_light / (455. * nm),  h_Planck * c_light / (450. * nm),
-      h_Planck * c_light / (445. * nm),  h_Planck * c_light / (440. * nm),
-      h_Planck * c_light / (435. * nm),  optPhotMaxE_
+      optPhotMinE_,
+      hc_ / (610. * nm), hc_ / (605. * nm), hc_ / (600. * nm),
+      hc_ / (595. * nm), hc_ / (590. * nm), hc_ / (585. * nm),
+      hc_ / (580. * nm), hc_ / (575. * nm), hc_ / (570. * nm),
+      hc_ / (565. * nm), hc_ / (560. * nm), hc_ / (555. * nm),
+      hc_ / (550. * nm), hc_ / (545. * nm), hc_ / (540. * nm),
+      hc_ / (535. * nm), hc_ / (530. * nm), hc_ / (525. * nm),
+      hc_ / (520. * nm), hc_ / (515. * nm), hc_ / (510. * nm),
+      hc_ / (505. * nm), hc_ / (500. * nm), hc_ / (495. * nm),
+      hc_ / (490. * nm), hc_ / (485. * nm), hc_ / (480. * nm),
+      hc_ / (475. * nm), hc_ / (470. * nm), hc_ / (465. * nm),
+      hc_ / (460. * nm), hc_ / (455. * nm), hc_ / (450. * nm),
+      hc_ / (445. * nm), hc_ / (440. * nm), hc_ / (435. * nm),
+      optPhotMaxE_
     };
 
     std::vector<G4double> WLS_emiSpectrum = {
-      0.000,    0.000,   //     , 610 nm
-      0.003,    0.006,   // 605 , 600 nm
-      0.007,    0.009,   // 595 , 590 nm
-      0.014,    0.017,   // 585 , 580 nm
-      0.024,    0.033,   // 575 , 570 nm
-      0.042,    0.051,   // 565 , 560 nm
-      0.063,    0.081,   // 555 , 550 nm
-      0.112,    0.157,   // 545 , 540 nm
-      0.211,    0.274,   // 535 , 530 nm
-      0.329,    0.341,   // 525 , 520 nm
-      0.325,    0.346,   // 515 , 510 nm
-      0.433,    0.578,   // 505 , 500 nm
-      0.792,    1.000,   // 495 , 490 nm
-      0.966,    0.718,   // 485 , 480 nm
-      0.604,    0.681,   // 475 , 470 nm
-      0.708,    0.525,   // 465 , 460 nm
-      0.242,    0.046,   // 455 , 450 nm
-      0.012,    0.003,   // 445 , 440 nm
-      0.000,    0.000    // 435 ,     nm
+      0.000,
+      0.000, 0.003, 0.006,  // 610, 605, 600 nm
+      0.007, 0.009, 0.014,  // 595, 590, 585 nm
+      0.017, 0.024, 0.033,  // 580, 575, 570 nm
+      0.042, 0.051, 0.063,  // 565, 560, 555 nm
+      0.081, 0.112, 0.157,  // 550, 545, 540 nm
+      0.211, 0.274, 0.329,  // 535, 530, 525 nm
+      0.341, 0.325, 0.346,  // 520, 515, 510 nm
+      0.433, 0.578, 0.792,  // 505, 500, 495 nm
+      1.000, 0.966, 0.718,  // 490, 485, 480 nm
+      0.604, 0.681, 0.708,  // 475, 470, 465 nm
+      0.525, 0.242, 0.046,  // 460, 455, 450 nm
+      0.012, 0.003, 0.000,  // 445, 440, 435 nm
+      0.000
     };
     mpt->AddProperty("WLSCOMPONENT",  WLS_emi_energy, WLS_emiSpectrum);
 
@@ -1355,135 +1282,107 @@ namespace opticalprops {
     // REFRACTIVE INDEX
     std::vector<G4double> ri_energy = {
       optPhotMinE_,
-      h_Planck * c_light / (609. * nm),    h_Planck * c_light / (589.26 * nm),
-      h_Planck * c_light / (550. * nm),    h_Planck * c_light / (530.   * nm),
-      h_Planck * c_light / (500. * nm),    h_Planck * c_light / (490.   * nm),
-      h_Planck * c_light / (481. * nm),    h_Planck * c_light / (460.   * nm),
-      h_Planck * c_light / (435. * nm),    h_Planck * c_light / (425.   * nm),
+      hc_ / (609. * nm), hc_ / (589.26 * nm), hc_ / (550. * nm),
+      hc_ / (530. * nm), hc_ / (500. * nm),   hc_ / (490. * nm),
+      hc_ / (481. * nm), hc_ / (460. * nm),   hc_ / (435. * nm),
+      hc_ / (425. * nm),
       optPhotMaxE_
     };
 
     std::vector<G4double> rIndex = {
       1.5780,
-      1.5780,  1.5800,   // 609 , 589.26 nm
-      1.5845,  1.5870,   // 550 , 530 nm
-      1.5913,  1.5929,   // 500 , 490 nm
-      1.5945,  1.5986,   // 481 , 460 nm
-      1.6050,  1.6080,   // 435 , 425 nm
+      1.5780, 1.5800, 1.5845,  // 609, 589.26, 550 nm
+      1.5870, 1.5913, 1.5929,  // 530, 500, 490 nm
+      1.5945, 1.5986, 1.6050,  // 481, 460, 435 nm
+      1.6080,                  // 425 nm
       1.6080
     };
     mpt->AddProperty("RINDEX", ri_energy, rIndex);
 
     // ABSORPTION LENGTH
     std::vector<G4double> abs_energy = {
-      optPhotMinE_,                      h_Planck * c_light / (750. * nm),
-      h_Planck * c_light / (740. * nm),  h_Planck * c_light / (380. * nm),
-      h_Planck * c_light / (370. * nm),  optPhotMaxE_
+      optPhotMinE_,
+      hc_ / (750. * nm), hc_ / (740. * nm), hc_ / (380. * nm), hc_ / (370. * nm),
+      optPhotMaxE_
     };
     std::vector<G4double> absLength = {
-      noAbsLength_,  noAbsLength_,
-      3.0 * m,       3.0 * m,
-      noAbsLength_,  noAbsLength_
+      noAbsLength_,
+      noAbsLength_, 3.0 * m, 3.0 * m, noAbsLength_,
+      noAbsLength_
     };
     mpt->AddProperty("ABSLENGTH", abs_energy, absLength);
 
     // WLS ABSORPTION LENGTH
     std::vector<G4double> WLS_abs_energy = {
-      optPhotMinE_,                      h_Planck * c_light / (445. * nm),
-                                        h_Planck * c_light / (440. * nm),
-      h_Planck * c_light / (435. * nm),  h_Planck * c_light / (430. * nm),
-      h_Planck * c_light / (425. * nm),  h_Planck * c_light / (420. * nm),
-      h_Planck * c_light / (415. * nm),  h_Planck * c_light / (410. * nm),
-      h_Planck * c_light / (405. * nm),  h_Planck * c_light / (400. * nm),
-      h_Planck * c_light / (395. * nm),  h_Planck * c_light / (390. * nm),
-      h_Planck * c_light / (385. * nm),  h_Planck * c_light / (380. * nm),
-      h_Planck * c_light / (375. * nm),  h_Planck * c_light / (370. * nm),
-      h_Planck * c_light / (365. * nm),  h_Planck * c_light / (360. * nm),
-      h_Planck * c_light / (355. * nm),  h_Planck * c_light / (350. * nm),
-      h_Planck * c_light / (345. * nm),  h_Planck * c_light / (340. * nm),
-      h_Planck * c_light / (335. * nm),  h_Planck * c_light / (330. * nm),
-      h_Planck * c_light / (325. * nm),  h_Planck * c_light / (320. * nm),
-      h_Planck * c_light / (315. * nm),  h_Planck * c_light / (310. * nm),
-      h_Planck * c_light / (305. * nm),  h_Planck * c_light / (300. * nm),
-      h_Planck * c_light / (295. * nm),  h_Planck * c_light / (290. * nm),
-      h_Planck * c_light / (285. * nm),  h_Planck * c_light / (280. * nm),
-      h_Planck * c_light / (275. * nm),  optPhotMaxE_
+      optPhotMinE_,
+      hc_ / (445. * nm), hc_ / (440. * nm), hc_ / (435. * nm),
+      hc_ / (430. * nm), hc_ / (425. * nm), hc_ / (420. * nm),
+      hc_ / (415. * nm), hc_ / (410. * nm), hc_ / (405. * nm),
+      hc_ / (400. * nm), hc_ / (395. * nm), hc_ / (390. * nm),
+      hc_ / (385. * nm), hc_ / (380. * nm), hc_ / (375. * nm),
+      hc_ / (370. * nm), hc_ / (365. * nm), hc_ / (360. * nm),
+      hc_ / (355. * nm), hc_ / (350. * nm), hc_ / (345. * nm),
+      hc_ / (340. * nm), hc_ / (335. * nm), hc_ / (330. * nm),
+      hc_ / (325. * nm), hc_ / (320. * nm), hc_ / (315. * nm),
+      hc_ / (310. * nm), hc_ / (305. * nm), hc_ / (300. * nm),
+      hc_ / (295. * nm), hc_ / (290. * nm), hc_ / (285. * nm),
+      hc_ / (280. * nm), hc_ / (275. * nm),
+      optPhotMaxE_
     };
 
     std::vector<G4double> WLS_absLength = {
-      noAbsLength_,         noAbsLength_,
-                            (1. / 0.00007) * cm,    //       440 nm
-      (1. /  0.0003) * cm,  (1. / 0.00104) * cm,    // 435 , 430 nm
-      (1. / 0.00223) * cm,  (1. / 0.00408) * cm,    // 425 , 420 nm
-      (1. /  0.0104) * cm,  (1. / 0.18544) * cm,    // 415 , 410 nm
-      (1. /  1.4094) * cm,  (1. /  3.7088) * cm,    // 405 , 400 nm
-      (1. /  7.4176) * cm,  (1. / 11.8682) * cm,    // 395 , 390 nm
-      (1. / 16.6155) * cm,  (1. / 22.2529) * cm,    // 385 , 380 nm
-      (1. / 27.8162) * cm,  (1. / 33.3794) * cm,    // 375 , 370 nm
-      (1. / 37.8671) * cm,  (1. / 40.4262) * cm,    // 365 , 360 nm
-      (1. / 41.5388) * cm,  (1. / 41.1679) * cm,    // 355 , 350 nm
-      (1. / 38.9426) * cm,  (1. / 35.0113) * cm,    // 345 , 340 nm
-      (1. / 31.1541) * cm,  (1. / 27.4453) * cm,    // 335 , 330 nm
-      (1. / 23.4398) * cm,  (1. / 20.0276) * cm,    // 325 , 320 nm
-      (1. / 16.3188) * cm,  (1. / 13.3518) * cm,    // 315 , 310 nm
-      (1. / 10.5331) * cm,  (1. /  8.1594) * cm,    // 305 , 300 nm
-      (1. /  6.1196) * cm,  (1. /  4.6731) * cm,    // 295 , 290 nm
-      (1. /  3.6346) * cm,  (1. /  3.0412) * cm,    // 285 , 280 nm
-      noAbsLength_,         noAbsLength_
+      noAbsLength_,
+      noAbsLength_,        (1. / 0.00007) * cm, (1. /  0.0003) * cm,
+      (1. / 0.00104) * cm, (1. / 0.00223) * cm, (1. / 0.00408) * cm,
+      (1. /  0.0104) * cm, (1. / 0.18544) * cm, (1. /  1.4094) * cm,
+      (1. /  3.7088) * cm, (1. /  7.4176) * cm, (1. / 11.8682) * cm,
+      (1. / 16.6155) * cm, (1. / 22.2529) * cm, (1. / 27.8162) * cm,
+      (1. / 33.3794) * cm, (1. / 37.8671) * cm, (1. / 40.4262) * cm,
+      (1. / 41.5388) * cm, (1. / 41.1679) * cm, (1. / 38.9426) * cm,
+      (1. / 35.0113) * cm, (1. / 31.1541) * cm, (1. / 27.4453) * cm,
+      (1. / 23.4398) * cm, (1. / 20.0276) * cm, (1. / 16.3188) * cm,
+      (1. / 13.3518) * cm, (1. / 10.5331) * cm, (1. /  8.1594) * cm,
+      (1. /  6.1196) * cm, (1. /  4.6731) * cm, (1. /  3.6346) * cm,
+      (1. /  3.0412) * cm,  noAbsLength_,
+      noAbsLength_
     };
     // XXX We are assuming that EJ286 doesn't absorb wave lengths shorter than 280 nm
     // although the spectrum continues ...
     mpt->AddProperty("WLSABSLENGTH", WLS_abs_energy, WLS_absLength);
     //for (int i=0; i<WLS_abs_entries; i++)
     //  G4cout << "* EJ286 WLS absLength:  " << std::setw(8) << WLS_abs_energy[i] / eV
-    //         << " eV  ==  " << std::setw(8) << (h_Planck * c_light / WLS_abs_energy[i]) / nm
+    //         << " eV  ==  " << std::setw(8) << (hc_ / WLS_abs_energy[i]) / nm
     //         << " nm  ->  " << std::setw(6) << WLS_absLength[i] / mm << " mm" << G4endl;
 
     // WLS EMISSION SPECTRUM
     std::vector<G4double> WLS_emi_energy = {
       optPhotMinE_,
-      h_Planck * c_light / (535. * nm),  h_Planck * c_light / (530. * nm),
-      h_Planck * c_light / (525. * nm),  h_Planck * c_light / (520. * nm),
-      h_Planck * c_light / (515. * nm),  h_Planck * c_light / (510. * nm),
-      h_Planck * c_light / (505. * nm),  h_Planck * c_light / (500. * nm),
-      h_Planck * c_light / (495. * nm),  h_Planck * c_light / (490. * nm),
-      h_Planck * c_light / (485. * nm),  h_Planck * c_light / (480. * nm),
-      h_Planck * c_light / (475. * nm),  h_Planck * c_light / (470. * nm),
-      h_Planck * c_light / (465. * nm),  h_Planck * c_light / (460. * nm),
-      h_Planck * c_light / (455. * nm),  h_Planck * c_light / (450. * nm),
-      h_Planck * c_light / (445. * nm),  h_Planck * c_light / (440. * nm),
-      h_Planck * c_light / (435. * nm),  h_Planck * c_light / (430. * nm),
-      h_Planck * c_light / (425. * nm),  h_Planck * c_light / (420. * nm),
-      h_Planck * c_light / (415. * nm),  h_Planck * c_light / (410. * nm),
-      h_Planck * c_light / (405. * nm),  h_Planck * c_light / (400. * nm),
-      h_Planck * c_light / (395. * nm),  h_Planck * c_light / (390. * nm),
-      h_Planck * c_light / (385. * nm),  h_Planck * c_light / (380. * nm),
-      h_Planck * c_light / (375. * nm),  h_Planck * c_light / (370. * nm),
-      h_Planck * c_light / (365. * nm),  h_Planck * c_light / (360. * nm),
-      h_Planck * c_light / (355. * nm),  optPhotMaxE_
+      hc_ / (535. * nm), hc_ / (530. * nm), hc_ / (525. * nm), hc_ / (520. * nm),
+      hc_ / (515. * nm), hc_ / (510. * nm), hc_ / (505. * nm), hc_ / (500. * nm),
+      hc_ / (495. * nm), hc_ / (490. * nm), hc_ / (485. * nm), hc_ / (480. * nm),
+      hc_ / (475. * nm), hc_ / (470. * nm), hc_ / (465. * nm), hc_ / (460. * nm),
+      hc_ / (455. * nm), hc_ / (450. * nm), hc_ / (445. * nm), hc_ / (440. * nm),
+      hc_ / (435. * nm), hc_ / (430. * nm), hc_ / (425. * nm), hc_ / (420. * nm),
+      hc_ / (415. * nm), hc_ / (410. * nm), hc_ / (405. * nm), hc_ / (400. * nm),
+      hc_ / (395. * nm), hc_ / (390. * nm), hc_ / (385. * nm), hc_ / (380. * nm),
+      hc_ / (375. * nm), hc_ / (370. * nm), hc_ / (365. * nm), hc_ / (360. * nm),
+      hc_ / (355. * nm),
+      optPhotMaxE_
     };
 
     std::vector<G4double> WLS_emiSpectrum = {
       0.0000,
-      0.0000,  0.0089,   // 535 , 530 nm
-      0.0100,  0.0181,   // 525 , 520 nm
-      0.0210,  0.0270,   // 515 , 510 nm
-      0.0380,  0.0496,   // 505 , 500 nm
-      0.0600,  0.0721,   // 495 , 490 nm
-      0.0900,  0.1125,   // 485 , 480 nm
-      0.1500,  0.1848,   // 475 , 470 nm
-      0.2100,  0.2388,   // 465 , 460 nm
-      0.2800,  0.3289,   // 455 , 450 nm
-      0.4000,  0.4956,   // 445 , 440 nm
-      0.5700,  0.6230,   // 435 , 430 nm
-      0.6450,  0.6667,   // 425 , 420 nm
-      0.8000,  0.9800,   // 415 , 410 nm
-      0.9900,  0.8559,   // 405 , 400 nm
-      0.7118,  0.7400,   // 395 , 390 nm
-      0.8000,  0.6702,   // 385 , 380 nm
-      0.3800,  0.1082,   // 375 , 370 nm
-      0.0400,  0.0089,   // 365 , 360 nm
-      0.0000,  0.0000    // 355 ,     nm
+      0.0000, 0.0089, 0.0100, 0.0181, // 535, 530, 525, 520 nm
+      0.0210, 0.0270, 0.0380, 0.0496, // 515, 510, 505, 500 nm
+      0.0600, 0.0721, 0.0900, 0.1125, // 495, 490, 485, 480 nm
+      0.1500, 0.1848, 0.2100, 0.2388, // 475, 470, 465, 460 nm
+      0.2800, 0.3289, 0.4000, 0.4956, // 455, 450, 445, 440 nm
+      0.5700, 0.6230, 0.6450, 0.6667, // 435, 430, 425, 420 nm
+      0.8000, 0.9800, 0.9900, 0.8559, // 415, 410, 405, 400 nm
+      0.7118, 0.7400, 0.8000, 0.6702, // 395, 390, 385, 380 nm
+      0.3800, 0.1082, 0.0400, 0.0089, // 375, 370, 365, 360 nm
+      0.0000,                         // 355 nm
+      0.0000
     };
     mpt->AddProperty("WLSCOMPONENT",  WLS_emi_energy, WLS_emiSpectrum);
 
@@ -1517,69 +1416,61 @@ namespace opticalprops {
 
     // ABSORPTION LENGTH
     std::vector<G4double> abs_energy = {
-      optPhotMinE_,                      h_Planck * c_light / (750. * nm),
-      h_Planck * c_light / (740. * nm),  h_Planck * c_light / (380. * nm),
-      h_Planck * c_light / (370. * nm),  optPhotMaxE_
+      optPhotMinE_,
+      hc_ / (750. * nm), hc_ / (740. * nm), hc_ / (380. * nm), hc_ / (370. * nm),
+      optPhotMaxE_
     };
     std::vector<G4double> absLength = {
-      noAbsLength_,  noAbsLength_,
-      3.5 * m,       3.5 * m,
-      noAbsLength_,  noAbsLength_
+      noAbsLength_,
+      noAbsLength_, 3.5 * m, 3.5 * m, noAbsLength_,
+      noAbsLength_
     };
     mpt->AddProperty("ABSLENGTH", abs_energy, absLength);
 
     // WLS ABSORPTION LENGTH
     std::vector<G4double> WLS_abs_energy = {
-      optPhotMinE_,                      h_Planck * c_light / (490. * nm),
-      h_Planck * c_light / (485. * nm),  h_Planck * c_light / (475. * nm),
-      h_Planck * c_light / (454. * nm),  h_Planck * c_light / (443. * nm),
-      h_Planck * c_light / (430. * nm),  h_Planck * c_light / (410. * nm),
-      h_Planck * c_light / (405. * nm),  h_Planck * c_light / (359. * nm),
-      h_Planck * c_light / (350. * nm),  h_Planck * c_light / (345. * nm),
+      optPhotMinE_,
+      hc_ / (490. * nm), hc_ / (485. * nm), hc_ / (475. * nm), hc_ / (454. * nm),
+      hc_ / (443. * nm), hc_ / (430. * nm), hc_ / (410. * nm), hc_ / (405. * nm),
+      hc_ / (359. * nm), hc_ / (350. * nm), hc_ / (345. * nm),
       optPhotMaxE_
     };
     std::vector<G4double> WLS_absLength = {
-      noAbsLength_,  noAbsLength_,    //     , 490 nm
-      44.2  * mm,    5.39 * mm,       // 485 , 475 nm
-      0.395 * mm,    0.462 * mm,      // 454 , 443 nm
-      0.354 * mm,    0.571 * mm,      // 430 , 410 nm
-      0.612 * mm,    4.51 * mm,       // 405 , 359 nm
-      4.81  * mm,    noAbsLength_,    // 350 , 345 nm
+      noAbsLength_,
+      noAbsLength_, 44.2 * mm, 5.39 * mm, 0.395 * mm, // 490, 485, 475, 454 nm
+      0.462 * mm, 0.354 * mm, 0.571 * mm, 0.612 * mm, // 443, 430, 410, 405 nm
+      4.51 * mm,  4.81  * mm, noAbsLength_,           // 359, 350, 345  nm
       noAbsLength_
     };
     mpt->AddProperty("WLSABSLENGTH", WLS_abs_energy, WLS_absLength);
     //for (int i=0; i<WLS_abs_entries; i++)
     //  G4cout << "* Y11 WLS absLength:  " << std::setw(8) << WLS_abs_energy[i] / eV
-    //         << " eV  ==  " << std::setw(8) << (h_Planck * c_light / WLS_abs_energy[i]) / nm
+    //         << " eV  ==  " << std::setw(8) << (hc_ / WLS_abs_energy[i]) / nm
     //         << " nm  ->  " << std::setw(6) << WLS_absLength[i] / mm << " mm" << G4endl;
 
     // WLS EMISSION SPECTRUM
     std::vector<G4double> WLS_emi_energy = {
-      optPhotMinE_,                      h_Planck * c_light / (580. * nm),
-      h_Planck * c_light / (550. * nm),  h_Planck * c_light / (530. * nm),
-      h_Planck * c_light / (525. * nm),  h_Planck * c_light / (520. * nm),
-      h_Planck * c_light / (515. * nm),  h_Planck * c_light / (510. * nm),
-      h_Planck * c_light / (505. * nm),  h_Planck * c_light / (500. * nm),
-      h_Planck * c_light / (495. * nm),  h_Planck * c_light / (490. * nm),
-      h_Planck * c_light / (485. * nm),  h_Planck * c_light / (480. * nm),
-      h_Planck * c_light / (475. * nm),  h_Planck * c_light / (470. * nm),
-      h_Planck * c_light / (465. * nm),  h_Planck * c_light / (460. * nm),
-      h_Planck * c_light / (455. * nm),  h_Planck * c_light / (450. * nm),
-      h_Planck * c_light / (445. * nm),  optPhotMaxE_
+      optPhotMinE_,
+      hc_ / (580. * nm), hc_ / (550. * nm), hc_ / (530. * nm),
+      hc_ / (525. * nm), hc_ / (520. * nm), hc_ / (515. * nm),
+      hc_ / (510. * nm), hc_ / (505. * nm), hc_ / (500. * nm),
+      hc_ / (495. * nm), hc_ / (490. * nm), hc_ / (485. * nm),
+      hc_ / (480. * nm), hc_ / (475. * nm), hc_ / (470. * nm),
+      hc_ / (465. * nm), hc_ / (460. * nm), hc_ / (455. * nm),
+      hc_ / (450. * nm), hc_ / (445. * nm),
+      optPhotMaxE_
     };
 
     std::vector<G4double> WLS_emiSpectrum = {
-      0.000,    0.000,   //     , 580 nm
-      0.200,    0.300,   // 550 , 530 nm
-      0.400,    0.600,   // 525 , 520 nm
-      0.750,    0.750,   // 515 , 510 nm
-      0.720,    0.700,   // 505 , 500 nm
-      0.680,    0.650,   // 495 , 490 nm
-      0.700,    0.900,   // 485 , 480 nm
-      1.000,    0.950,   // 475 , 470 nm
-      0.500,    0.300,   // 465 , 460 nm
-      0.100,    0.050,   // 455 , 450 nm
-      0.000,    0.000    // 445 ,     nm
+      0.000,
+      0.000, 0.200, 0.300, // 580, 550, 530 nm
+      0.400, 0.600, 0.750, // 525, 520, 515 nm
+      0.750, 0.720, 0.700, // 510, 505, 500 nm
+      0.680, 0.650, 0.700, // 495, 490, 485 nm
+      0.900, 1.000, 0.950, // 480, 475, 470 nm
+      0.500, 0.300, 0.100, // 465, 460, 455 nm
+      0.050, 0.000,        // 450, 445 nm
+      0.000
     };
     mpt->AddProperty("WLSCOMPONENT",  WLS_emi_energy, WLS_emiSpectrum);
 
@@ -1612,14 +1503,14 @@ namespace opticalprops {
 
     // ABSORPTION LENGTH
     std::vector<G4double> abs_energy = {
-      optPhotMinE_,                      h_Planck * c_light / (750. * nm),
-      h_Planck * c_light / (740. * nm),  h_Planck * c_light / (380. * nm),
-      h_Planck * c_light / (370. * nm),  optPhotMaxE_
+      optPhotMinE_,
+      hc_ / (750. * nm), hc_ / (740. * nm), hc_ / (380. * nm), hc_ / (370. * nm),
+      optPhotMaxE_
     };
     std::vector<G4double> absLength = {
-      noAbsLength_,  noAbsLength_,
-      3.5 * m,       3.5 * m,
-      noAbsLength_,  noAbsLength_
+      noAbsLength_,
+      noAbsLength_, 3.5 * m, 3.5 * m, noAbsLength_,
+      noAbsLength_
     };
     mpt->AddProperty("ABSLENGTH", abs_energy, absLength);
 
@@ -1633,32 +1524,22 @@ namespace opticalprops {
 
     std::vector<G4double> WLS_abs_energy = {
       optPhotMinE_,
-      h_Planck * c_light / (418. * nm), h_Planck * c_light / (412. * nm),
-      h_Planck * c_light / (405. * nm), h_Planck * c_light / (400. * nm),
-      h_Planck * c_light / (394. * nm), h_Planck * c_light / (387. * nm),
-      h_Planck * c_light / (384. * nm), h_Planck * c_light / (382. * nm),
-      h_Planck * c_light / (378. * nm), h_Planck * c_light / (370. * nm),
-      h_Planck * c_light / (361. * nm), h_Planck * c_light / (353. * nm),
-      h_Planck * c_light / (345. * nm), h_Planck * c_light / (341. * nm),
-      h_Planck * c_light / (336. * nm), h_Planck * c_light / (331. * nm),
-      h_Planck * c_light / (316. * nm), h_Planck * c_light / (301. * nm),
-      h_Planck * c_light / (280. * nm),
+      hc_ / (418. * nm), hc_ / (412. * nm), hc_ / (405. * nm), hc_ / (400. * nm),
+      hc_ / (394. * nm), hc_ / (387. * nm), hc_ / (384. * nm), hc_ / (382. * nm),
+      hc_ / (378. * nm), hc_ / (370. * nm), hc_ / (361. * nm), hc_ / (353. * nm),
+      hc_ / (345. * nm), hc_ / (341. * nm), hc_ / (336. * nm), hc_ / (331. * nm),
+      hc_ / (316. * nm), hc_ / (301. * nm), hc_ / (280. * nm),
       optPhotMaxE_
     };
 
     float minAbsLength = 0.395 * mm;
 
     std::vector<float> B2_absorption {
-      -0.01,        // 418
-      -0.06, -0.26, // 405, 412
-      -0.44, -0.59, // 394, 400
-      -0.59, -0.64, // 384, 387
-      -0.77, -0.92, // 378, 382
-      -1.00, -0.93, // 361, 370
-      -0.85, -0.87, // 345, 353
-      -0.87, -0.77, // 336, 341
-      -0.56, -0.35, // 316, 331
-      -0.22, -0.12  // 280, 301
+      -0.01, -0.06, -0.26, -0.44, // 418, 412, 405, 400
+      -0.59, -0.59, -0.64, -0.77, // 394, 387, 384, 382
+      -0.92, -1.00, -0.93, -0.85, // 378, 370, 361, 353
+      -0.87, -0.87, -0.77, -0.56, // 345, 341, 336, 331
+      -0.35, -0.22, -0.12         // 316, 301, 280
     };
 
     std::vector<G4double> WLS_absLength {noAbsLength_};
@@ -1673,45 +1554,29 @@ namespace opticalprops {
     // WLS EMISSION SPECTRUM
     std::vector<G4double> WLS_emi_energy = {
       optPhotMinE_,
-      h_Planck * c_light / (542 * nm), h_Planck * c_light / (525 * nm),
-      h_Planck * c_light / (508 * nm), h_Planck * c_light / (497 * nm),
-      h_Planck * c_light / (488 * nm), h_Planck * c_light / (479 * nm),
-      h_Planck * c_light / (473 * nm), h_Planck * c_light / (467 * nm),
-      h_Planck * c_light / (463 * nm), h_Planck * c_light / (458 * nm),
-      h_Planck * c_light / (454 * nm), h_Planck * c_light / (449 * nm),
-      h_Planck * c_light / (445 * nm), h_Planck * c_light / (442 * nm),
-      h_Planck * c_light / (440 * nm), h_Planck * c_light / (438 * nm),
-      h_Planck * c_light / (433 * nm), h_Planck * c_light / (429 * nm),
-      h_Planck * c_light / (424 * nm), h_Planck * c_light / (420 * nm),
-      h_Planck * c_light / (418 * nm), h_Planck * c_light / (416 * nm),
-      h_Planck * c_light / (411 * nm), h_Planck * c_light / (404 * nm),
-      h_Planck * c_light / (402 * nm), h_Planck * c_light / (399 * nm),
-      h_Planck * c_light / (398 * nm), h_Planck * c_light / (396 * nm),
-      h_Planck * c_light / (395 * nm), h_Planck * c_light / (394 * nm),
-      h_Planck * c_light / (392 * nm), h_Planck * c_light / (391 * nm),
-      h_Planck * c_light / (386 * nm), h_Planck * c_light / (380 * nm),
+      hc_ / (542 * nm), hc_ / (525 * nm), hc_ / (508 * nm), hc_ / (497 * nm),
+      hc_ / (488 * nm), hc_ / (479 * nm), hc_ / (473 * nm), hc_ / (467 * nm),
+      hc_ / (463 * nm), hc_ / (458 * nm), hc_ / (454 * nm), hc_ / (449 * nm),
+      hc_ / (445 * nm), hc_ / (442 * nm), hc_ / (440 * nm), hc_ / (438 * nm),
+      hc_ / (433 * nm), hc_ / (429 * nm), hc_ / (424 * nm), hc_ / (420 * nm),
+      hc_ / (418 * nm), hc_ / (416 * nm), hc_ / (411 * nm), hc_ / (404 * nm),
+      hc_ / (402 * nm), hc_ / (399 * nm), hc_ / (398 * nm), hc_ / (396 * nm),
+      hc_ / (395 * nm), hc_ / (394 * nm), hc_ / (392 * nm), hc_ / (391 * nm),
+      hc_ / (386 * nm), hc_ / (380 * nm),
       optPhotMaxE_
     };
 
     std::vector<G4double> WLS_emiSpectrum = {
       0.000,
-      0.053, 0.070, // 542, 525
-      0.109, 0.143, // 508, 497
-      0.199, 0.270, // 488, 479
-      0.337, 0.423, // 473, 467
-      0.497, 0.582, // 463, 458
-      0.615, 0.645, // 454, 449
-      0.679, 0.750, // 445, 442
-      0.801, 0.857, // 440, 438
-      0.957, 0.999, // 433, 429
-      0.949, 0.906, // 424, 420
-      0.855, 0.809, // 418, 416
-      0.750, 0.750, // 411, 404
-      0.719, 0.671, // 402, 399
-      0.590, 0.500, // 398, 396
-      0.421, 0.327, // 395, 394
-      0.217, 0.138, // 392, 391
-      0.065, 0.023, // 386, 380
+      0.053, 0.070, 0.109, 0.143, // 542, 525, 508, 497
+      0.199, 0.270, 0.337, 0.423, // 488, 479, 473, 467
+      0.497, 0.582, 0.615, 0.645, // 463, 458, 454, 449
+      0.679, 0.750, 0.801, 0.857, // 445, 442, 440, 438
+      0.957, 0.999, 0.949, 0.906, // 433, 429, 424, 420
+      0.855, 0.809, 0.750, 0.750, // 418, 416, 411, 404
+      0.719, 0.671, 0.590, 0.500, // 402, 399, 398, 396
+      0.421, 0.327, 0.217, 0.138, // 395, 394, 392, 391
+      0.065, 0.023,               // 386, 380
       0.000
     };
 

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -269,7 +269,7 @@ namespace opticalprops {
 
     // ABSORPTION LENGTH
     // We don't have information about the absorption length,
-    // therefore we use that of GlassEpoxym since it is virtually infinite
+    // therefore we use that of GlassEpoxy since it is virtually infinite
     // for the TPB emission wavelengths.
     std::vector<G4double> abs_energy = {
       optPhotMinE_, 2.000 * eV,
@@ -459,7 +459,7 @@ namespace opticalprops {
   {
     // Input data: Sellmeier equation coeficients extracted from:
     // https://refractiveindex.info/?shelf=3d&book=crystals&page=sapphire
-    //C[i] coeficients at line 362 are squared.
+    // C[i] coeficients at line 362 are squared.
 
     G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
 
@@ -470,7 +470,7 @@ namespace opticalprops {
     SellmeierEquation seq(B, C);
 
     const G4int ri_entries = 100;
-    G4double eWidth = (optPhotMaxE_ - optPhotMinE_) / ri_entries;
+    G4double eWidth = (optPhotSapphireMaxE_ - optPhotMinE_) / ri_entries;
 
     std::vector<G4double> ri_energy;
     for (int i=0; i<ri_entries; i++) {
@@ -480,9 +480,15 @@ namespace opticalprops {
     std::vector<G4double> rIndex;
     for (int i=0; i<ri_entries; i++) {
       rIndex.push_back(seq.RefractiveIndex(hc_/ri_energy[i]));
-      //G4cout << "* Sapphire rIndex:  " << std::setw(5)
-      //       << ri_energy[i]/eV << " eV -> " << rIndex[i] << G4endl;
     }
+    // This sets the refractive index between optPhotSapphireMaxE_ and
+    // optPhotMaxE_ to the value obtained at optPhotSapphireMaxE_
+    ri_energy.push_back(optPhotMaxE_);
+    rIndex.push_back(rIndex[rIndex.size()-1]);
+    // for (unsigned int i=0; i<ri_energy.size(); i++) {
+    //   G4cout << "* Sapphire rIndex:  " << std::setw(5)
+    //          << ri_energy[i]/eV << " eV -> " << rIndex[i] << G4endl;
+    // }
     mpt->AddProperty("RINDEX", ri_energy, rIndex);
 
     // ABSORPTION LENGTH
@@ -492,7 +498,8 @@ namespace opticalprops {
       2.585 * eV,   3.088 * eV,  3.709 * eV,  4.385 * eV,
       4.972 * eV,   5.608 * eV,  6.066 * eV,  6.426 * eV,
       6.806 * eV,   7.135 * eV,  7.401 * eV,  7.637 * eV,
-      7.880 * eV,   8.217 * eV
+      7.880 * eV,   8.217 * eV,
+      optPhotMaxE_
     };
 
     std::vector<G4double> absLength = {
@@ -501,7 +508,8 @@ namespace opticalprops {
       3455.0  * mm,  3140.98 * mm,  2283.30 * mm,  1742.11 * mm,
       437.06 * mm,   219.24 * mm,  117.773 * mm,   80.560 * mm,
       48.071 * mm,   28.805 * mm,   17.880 * mm,   11.567 * mm,
-        7.718 * mm,    4.995 * mm
+      7.718 * mm,    4.995 * mm,
+      4.995 * mm
     };
     mpt->AddProperty("ABSLENGTH", abs_energy, absLength);
 

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -12,7 +12,6 @@
 
 #include <G4MaterialPropertiesTable.hh>
 
-#include <assert.h>
 
 using namespace nexus;
 using namespace CLHEP;

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -48,6 +48,12 @@ namespace opticalprops {
     // REFRACTIVE INDEX
     // The range is chosen to be up to ~10.7 eV because Sellmeier's equation
     // for fused silica is valid only in that range
+    G4double um2 = micrometer*micrometer;
+    G4double B[3] = {4.73e-1, 6.31e-1, 9.06e-1};
+    G4double C[3] = {1.30e-2 * um2, 4.13e-3 * um2, 9.88e+1 * um2};
+    SellmeierEquation seq(B, C);
+
+
     const G4int ri_entries = 200;
     G4double eWidth = (optPhotFusedSilicaMaxE_ - optPhotMinE_) / ri_entries;
 
@@ -56,34 +62,17 @@ namespace opticalprops {
       ri_energy.push_back(optPhotMinE_ + i * eWidth);
     }
 
-    // The following values for the refractive index have been calculated
-    // using Sellmeier's equation:
-    //    n^2 - 1 = B_1 * \lambda^2 / (\lambda^2 - C_1) +
-    //            + B_2 * \lambda^2 / (\lambda^2 - C_2) +
-    //            + B_3 * \lambda^2 / (\lambda^2 - C_3),
-    // with wavelength \lambda in micrometers and
-    //    B_1 = 4.73E-1, B_2 = 6.31E-1, B_3 = 9.06E-1
-    //    C_1 = 1.30E-2, C_2 = 4.13E-3, C_3 = 9.88E+1.
-
-    G4double B_1 = 4.73e-1;
-    G4double B_2 = 6.31e-1;
-    G4double B_3 = 9.06e-1;
-    G4double C_1 = 1.30e-2;
-    G4double C_2 = 4.13e-3;
-    G4double C_3 = 9.88e+1;
-
     std::vector<G4double> rIndex;
     for (int i=0; i<ri_entries; i++) {
-      G4double lambda = hc_/ri_energy[i]*1000; // in micron
-      G4double n2 = 1 + B_1*pow(lambda,2)/(pow(lambda,2)-C_1)
-        + B_2*pow(lambda,2)/(pow(lambda,2)-C_2)
-        + B_3*pow(lambda,2)/(pow(lambda,2)-C_3);
-      rIndex.push_back(sqrt(n2));
-      // G4cout << "* FusedSilica rIndex:  " << std::setw(5) << ri_energy[i]/eV
-      //       << " eV -> " << rIndex[i] << G4endl;
+      rIndex.push_back(seq.RefractiveIndex(hc_/ri_energy[i]));
     }
     ri_energy.push_back(optPhotMaxE_);          // This sets the refractive index between optPhotFusedSilicaMaxE_ and
     rIndex.push_back(rIndex[rIndex.size()-1]);  // optPhotMaxE_ to the value obtained at optPhotFusedSilicaMaxE_
+
+    // for (unsigned int i=0; i<ri_energy.size(); i++) {
+    // G4cout << "* FusedSilica rIndex:  " << std::setw(5) << ri_energy[i]/eV
+    //       << " eV -> " << rIndex[i] << G4endl;
+    // }
     mpt->AddProperty("RINDEX", ri_energy, rIndex);
 
     // ABSORPTION LENGTH

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -18,7 +18,7 @@ using namespace nexus;
 using namespace CLHEP;
 
 namespace opticalprops {
-  /// Vacuum ///
+
   G4MaterialPropertiesTable* Vacuum()
   {
     G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
@@ -38,7 +38,6 @@ namespace opticalprops {
 
 
 
-  /// Fused Silica ///
   G4MaterialPropertiesTable* FusedSilica()
   {
     // Optical properties of Suprasil 311/312(c) synthetic fused silica.
@@ -119,9 +118,8 @@ namespace opticalprops {
 
 
 
-  /// Fake Fused Silica ///
   G4MaterialPropertiesTable* FakeFusedSilica(G4double transparency,
-                                            G4double thickness)
+                                             G4double thickness)
   {
     // Optical properties of Suprasil 311/312(c) synthetic fused silica.
     // Obtained from http://heraeus-quarzglas.com
@@ -297,7 +295,6 @@ namespace opticalprops {
 
 
 
-  /// ITO ///
   G4MaterialPropertiesTable* ITO()
   {
     // Input data: complex refraction index obtained from:
@@ -351,7 +348,6 @@ namespace opticalprops {
 
 
 
-  /// PEDOT ///
   G4MaterialPropertiesTable* PEDOT()
   {
     // Input data: complex refraction index obtained from:
@@ -405,7 +401,6 @@ namespace opticalprops {
 
 
 
-  /// Glass Epoxy ///
   G4MaterialPropertiesTable* GlassEpoxy()
   {
     // Optical properties of Optorez 1330 glass epoxy.
@@ -460,7 +455,6 @@ namespace opticalprops {
 
 
 
-  /// Sapphire ///
   G4MaterialPropertiesTable* Sapphire()
   {
     // Input data: Sellmeier equation coeficients extracted from:
@@ -516,7 +510,6 @@ namespace opticalprops {
 
 
 
-  /// Optical Coupler ///
   G4MaterialPropertiesTable* OptCoupler()
   {
     // gel NyoGel OCK-451
@@ -568,7 +561,7 @@ namespace opticalprops {
 
 
 
-  /// Gaseous Argon ///
+  /// Gaseous argon ///
   G4MaterialPropertiesTable* GAr(G4double sc_yield,
                                 G4double e_lifetime)
   {
@@ -644,7 +637,7 @@ namespace opticalprops {
 
 
 
-  /// Gaseous Xenon ///
+  /// Gaseous xenon ///
   G4MaterialPropertiesTable* GXe(G4double pressure,
                                 G4double temperature,
                                 G4int    sc_yield,
@@ -706,6 +699,9 @@ namespace opticalprops {
     return mpt;
   }
 
+
+
+  /// Liquid xenon ///
   G4MaterialPropertiesTable* LXe()
   {
     /// The time constants are taken from E. Hogenbirk et al 2018 JINST 13 P10031
@@ -770,7 +766,6 @@ namespace opticalprops {
 
 
 
-  /// Fake Grid ///
   G4MaterialPropertiesTable* FakeGrid(G4double pressure,
                                       G4double temperature,
                                       G4double transparency,
@@ -852,7 +847,8 @@ namespace opticalprops {
     return mpt;
   }
 
-  /// PolishedAl ///
+
+
   G4MaterialPropertiesTable* PolishedAl()
   {
     G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
@@ -912,6 +908,8 @@ namespace opticalprops {
 
     return mpt;
   }
+
+
 
   /// TPB (tetraphenyl butadiene) ///
   G4MaterialPropertiesTable* TPB()
@@ -1040,10 +1038,9 @@ namespace opticalprops {
 
 
 
-  /// Degraded TPB ///
   G4MaterialPropertiesTable* DegradedTPB(G4double wls_eff)
   {
-    // It has all the same properties of TPB except the WaveLengthShifting robability
+    // It has all the same properties of TPB except the WaveLengthShifting probability
     // that is set by parameter, trying to model a degraded behaviour of the TPB coating
 
     G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
@@ -1060,6 +1057,7 @@ namespace opticalprops {
 
     return mpt;
   }
+
 
 
   /// TPH (p-terphenyl) ///
@@ -1154,7 +1152,6 @@ namespace opticalprops {
 
 
 
-  /// EJ-280 ///
   G4MaterialPropertiesTable* EJ280()
   {
     // https://eljentechnology.com/products/wavelength-shifting-plastics/ej-280-ej-282-ej-284-ej-286
@@ -1279,7 +1276,6 @@ namespace opticalprops {
 
 
 
-  /// EJ-286 ///
   G4MaterialPropertiesTable* EJ286()
   {
     // https://eljentechnology.com/products/wavelength-shifting-plastics/ej-280-ej-282-ej-284-ej-286
@@ -1404,7 +1400,6 @@ namespace opticalprops {
 
 
 
-  /// Y-11 ///
   G4MaterialPropertiesTable* Y11()
   {
     // http://kuraraypsf.jp/psf/index.html
@@ -1491,7 +1486,7 @@ namespace opticalprops {
   }
 
 
-/// B-2 ///
+
   G4MaterialPropertiesTable* B2()
   {
     // http://kuraraypsf.jp/psf/index.html
@@ -1600,7 +1595,6 @@ namespace opticalprops {
 
 
 
-  /// Pethylene ///
   G4MaterialPropertiesTable* Pethylene()
   {
     // Fiber cladding material.
@@ -1622,7 +1616,6 @@ namespace opticalprops {
 
 
 
-  /// FPethylene ///
   G4MaterialPropertiesTable* FPethylene()
   {
     // Fiber cladding material.
@@ -1676,7 +1669,7 @@ namespace opticalprops {
 
 
 
-  /// XXX ///
+  /// Generic material, to be modifed by the user ///
   G4MaterialPropertiesTable* XXX()
   {
     // Playing material properties

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -182,6 +182,10 @@ namespace opticalprops {
   G4MaterialPropertiesTable* Epoxy()
   {
     // This is the material used as a window for NEXT-100 SiPMs.
+
+    G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
+
+    // REFRACTIVE INDEX
     // The only information we have is that n = 1.55 at a
     // not specified wavelength. It seems that it's common to measure
     // the refractive index at the D line of sodium (590 nm),
@@ -191,10 +195,6 @@ namespace opticalprops {
     // shifting the whole graphs in y down to match 1.55 at 590 nm.
     // We fill the values outside the range of the plot withg the
     // minimum and maximum values.
-
-    G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
-
-    // REFRACTIVE INDEX
      std::vector<G4double> ri_energy = {
       optPhotMinE_,
       hc_ / (2451.63 * nm), hc_ / (2430.88 * nm), hc_ / (2405.51 * nm),
@@ -270,6 +270,9 @@ namespace opticalprops {
     mpt->AddProperty("RINDEX", ri_energy, rIndex);
 
     // ABSORPTION LENGTH
+    // We don't have information about the absorption length,
+    // therefore we use that of GlassEpoxym since it is virtually infinite
+    // for the TPB emission wavelengths.
     std::vector<G4double> abs_energy = {
       optPhotMinE_, 2.000 * eV,
       2.132 * eV,   2.735 * eV,  2.908 * eV,  3.119 * eV,

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -141,7 +141,7 @@ namespace opticalprops {
     // The dependence of n on the wavelength is taken from
     // https://www.epotek.com/docs/en/Related/Tech%20Tip%2018%20Understanding%20Optical%20Properties%20of%20Epoxy%20Applications.pdf,
     // shifting the whole graphs in y down to match 1.55 at 590 nm.
-    // We fill the values outside the range of the plot withg the
+    // We fill the values outside the range of the plot with the
     // minimum and maximum values.
      std::vector<G4double> ri_energy = {
       optPhotMinE_,

--- a/source/materials/OpticalMaterialProperties.h
+++ b/source/materials/OpticalMaterialProperties.h
@@ -29,7 +29,7 @@ namespace opticalprops {
   G4MaterialPropertiesTable* FusedSilica();
 
   G4MaterialPropertiesTable* FakeFusedSilica(G4double transparency = .9,
-                                            G4double thickness    = 1. * mm);
+                                             G4double thickness    = 1. * mm);
 
   G4MaterialPropertiesTable* Epoxy();
 
@@ -42,12 +42,12 @@ namespace opticalprops {
   G4MaterialPropertiesTable* OptCoupler();
 
   G4MaterialPropertiesTable* GAr(G4double sc_yield,
-                                G4double e_lifetime=1000.*ms);
+                                 G4double e_lifetime=1000.*ms);
 
   G4MaterialPropertiesTable* GXe(G4double pressure=1.*bar,
-                                G4double temperature=STP_Temperature,
-                                G4int sc_yield=25510/MeV,
-                                G4double e_lifetime=1000.*ms);
+                                 G4double temperature=STP_Temperature,
+                                 G4int sc_yield=25510/MeV,
+                                 G4double e_lifetime=1000.*ms);
 
   G4MaterialPropertiesTable* LXe();
 

--- a/source/materials/OpticalMaterialProperties.h
+++ b/source/materials/OpticalMaterialProperties.h
@@ -89,6 +89,7 @@ namespace opticalprops {
   constexpr G4double optPhotMinE_ =  0.2  * eV;
   constexpr G4double optPhotMaxE_ = 11.5  * eV;
   constexpr G4double optPhotFusedSilicaMaxE_ = 10.7  * eV; // formulas for fused silica are valid up to this energy
+  constexpr G4double optPhotSapphireMaxE_ = 10.3  * eV; // formulas for sapphire are valid up to this energy
   constexpr G4double noAbsLength_ = 1.e8  * m;
 
   constexpr G4double hc_ = h_Planck * c_light;

--- a/source/materials/OpticalMaterialProperties.h
+++ b/source/materials/OpticalMaterialProperties.h
@@ -91,9 +91,7 @@ namespace opticalprops {
   constexpr G4double optPhotFusedSilicaMaxE_ = 10.7  * eV; // formulas for fused silica are valid up to this energy
   constexpr G4double noAbsLength_ = 1.e8  * m;
 
-  // Constant that allows to convert nm to eV:
-  // nm_to_eV_ / wavelength (nm) = energy (eV)
-  constexpr G4double nm_to_eV_ = h_Planck * c_light * 1.e6;
+  constexpr G4double hc_ = h_Planck * c_light;
 
 
 } // end namespace opticalprops

--- a/source/materials/OpticalMaterialProperties.h
+++ b/source/materials/OpticalMaterialProperties.h
@@ -31,6 +31,8 @@ namespace opticalprops {
   G4MaterialPropertiesTable* FakeFusedSilica(G4double transparency = .9,
                                             G4double thickness    = 1. * mm);
 
+  G4MaterialPropertiesTable* Epoxy();
+
   G4MaterialPropertiesTable* ITO();
 
   G4MaterialPropertiesTable* PEDOT();


### PR DESCRIPTION
This PR adds new optical properties to be used in the epoxy resine in front of the NEXT-100 SiPMs. This is the best we can do with the information we have. 
The datasheet of the SiPM model can be found here:
[K30-I50426_specification sheet(S13372-1350TE).pdf](https://github.com/next-exp/nexus/files/13479087/K30-I50426_specification.sheet.S13372-1350TE.pdf)


I have also reorganized the code to try to reduce its length and to optimize it.
