### PR TITLE
Remove `sipm_pos` from if-loop.

### DIFF
--- a/source/geometries/BlackBoxSiPMBoard.cc
+++ b/source/geometries/BlackBoxSiPMBoard.cc
@@ -134,8 +134,8 @@ void BlackBoxSiPMBoard::Construct()
   G4ThreeVector sipm_pos;
 
   for (G4int sipm_id=0; sipm_id<num_sipms_; sipm_id++) {
+    sipm_pos = sipm_positions_[sipm_id] + G4ThreeVector(0., 0., sipm_posz);
     if (verbosity_){
-       sipm_pos = sipm_positions_[sipm_id] + G4ThreeVector(0., 0., sipm_posz);
        G4cout << "SiPM" << sipm_id << ":" << sipm_pos << G4endl;
     }
 


### PR DESCRIPTION
This PR defines `sipm_pos` outside the `verbosity_` if-loop. This corrects all the overlaps in this volume encountered when running the overlap checks.