### PR TITLE
Fix vertices

### DIFF
--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -248,7 +248,6 @@ namespace nexus {
              (region == "TP_COPPER_PLATE") ||
              (region == "SIPM_BOARD") ||
              (region == "DB_PLUG") ||
-             (region == "EL_TABLE") ||
              (region == "FIELD_RING") ||
              (region == "GATE_RING") ||
              (region == "ANODE_RING") ||

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -7,8 +7,6 @@
 // ----------------------------------------------------------------------------
 
 #include "Next100.h"
-#include "BoxPointSampler.h"
-#include "MuonsPointSampler.h"
 #include "LSCHallA.h"
 #include "Next100Shielding.h"
 #include "Next100Vessel.h"
@@ -88,7 +86,6 @@ namespace nexus {
     delete ics_;
     delete vessel_;
     delete shielding_;
-    delete lab_gen_;
     delete hallA_walls_;
   }
 
@@ -200,12 +197,6 @@ namespace nexus {
       }
     }
 
-    //// VERTEX GENERATORS
-    lab_gen_ =
-      new BoxPointSampler(lab_size_ - 1.*m, lab_size_ - 1.*m,
-                          lab_size_  - 1.*m, 1.*m,
-                          G4ThreeVector(0., 0., 0.), 0);
-
   }
 
 
@@ -213,20 +204,15 @@ namespace nexus {
   {
     G4ThreeVector vertex(0.,0.,0.);
 
-    // Air around shielding
-    if (region == "LAB") {
-      vertex = lab_gen_->GenerateVertex("INSIDE");
-    }
-
     // Shielding regions
-    else if ((region == "SHIELDING_LEAD")  ||
-             (region == "SHIELDING_STEEL") ||
-             (region == "INNER_AIR") ||
-             (region == "EXTERNAL") ||
-             (region == "SHIELDING_STRUCT") ||
-             (region == "PEDESTAL") ||
-             (region == "BUBBLE_SEAL") ||
-             (region == "EDPM_SEAL")) {
+    if ((region == "SHIELDING_LEAD")  ||
+        (region == "SHIELDING_STEEL") ||
+        (region == "INNER_AIR") ||
+        (region == "EXTERNAL") ||
+        (region == "SHIELDING_STRUCT") ||
+        (region == "PEDESTAL") ||
+        (region == "BUBBLE_SEAL") ||
+        (region == "EDPM_SEAL")) {
       vertex = shielding_->GenerateVertex(region);
     }
 

--- a/source/geometries/Next100.h
+++ b/source/geometries/Next100.h
@@ -14,8 +14,6 @@
 class G4LogicalVolume;
 class G4GenericMessenger;
 
-namespace nexus {class BoxPointSampler;}
-
 
 namespace nexus {
 
@@ -72,8 +70,6 @@ namespace nexus {
     Next100Vessel*    vessel_;
     Next100Ics*       ics_;
     Next100InnerElements* inner_elements_;
-
-    BoxPointSampler* lab_gen_; ///< Vertex generator
 
     /// Messenger for the definition of control commands
     G4GenericMessenger* msg_;

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -883,7 +883,8 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
   G4ThreeVector vertex(0., 0., 0.);
 
   if (region == "CENTER") {
-    vertex = G4ThreeVector(0., 0., active_zpos_);
+    vertex = G4ThreeVector(GetCoordOrigin().x(), GetCoordOrigin().y(),
+                           active_zpos_);
   }
 
   else if (region == "ACTIVE") {


### PR DESCRIPTION
This PR removes a vertex which did not behave as intended (and it was not used) and fixes the vertex placed in the center of the NEXT100 geometry, which is now displaced from xy = (0, 0).
Finally, a region that was not used anymore has been removed.