### PR TITLE
Geant4-v11.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/next/nexus-base:2024-01-25
+FROM registry.cern.ch/next/nexus-base:2024-02-20
 
 COPY . /nexus
 WORKDIR /nexus

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update -y && \
     rm -rf /var/cache/apt/archives/* && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=registry.cern.ch/next/geant4:11.0.2-qt        /opt/geant4       /opt/geant4
+COPY --from=registry.cern.ch/next/geant4:11.2.1-qt        /opt/geant4       /opt/geant4
 COPY --from=registry.cern.ch/next/root:6.26.04            /opt/root/install /opt/root/install
 COPY --from=registry.cern.ch/next/python-nexus:2022-07-13 /opt/conda        /opt/conda

--- a/docker/env.sh
+++ b/docker/env.sh
@@ -10,13 +10,13 @@ export PATH=$G4INSTALL/bin:$PATH
 export LD_LIBRARY_PATH=$G4INSTALL/lib:$LD_LIBRARY_PATH
 
 export G4LEVELGAMMADATA=/opt/geant4/data/PhotonEvaporation5.7
-export G4LEDATA=/opt/geant4/data/G4EMLOW8.0
+export G4LEDATA=/opt/geant4/data/G4EMLOW8.5
 export G4RADIOACTIVEDATA=/opt/geant4/data/RadioactiveDecay5.6
 export G4ENSDFSTATEDATA=/opt/geant4/data/G4ENSDFSTATE2.3
 export G4SAIDXSDATA=/opt/geant4/data/G4SAIDDATA2.0
 export G4PARTICLEXSDATA=/opt/geant4/data/G4PARTICLEXS4.0
-export G4NEUTRONHPDATA=/opt/geant4/data/G4NDL4.6
-export G4INCLDATA=/opt/geant4/data/G4INCL1.0
+export G4NEUTRONHPDATA=/opt/geant4/data/G4NDL4.7
+export G4INCLDATA=/opt/geant4/data/G4INCL1.2
 
 export NEXUSDIR=/nexus
 #export HDF5_DISABLE_VERSION_CHECK=1 # find out why is needed 

--- a/docker/geant4/Dockerfile
+++ b/docker/geant4/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 
-ENV G4_VERSION v11.0.2
+ENV G4_VERSION v11.2.1
 
 RUN apt-get update -y && \
     apt-get install -y cmake curl g++ libexpat1-dev libqt5core5a qtbase5-dev

--- a/docker/geant4/download_dataset.sh
+++ b/docker/geant4/download_dataset.sh
@@ -4,16 +4,16 @@ DATASETDIR=$1
 DATASETDIR=${DATASETDIR:=data}
 
 DATASETS="
-G4NDL.4.6.tar.gz
-G4EMLOW.8.0.tar.gz
+G4NDL.4.7.tar.gz
+G4EMLOW.8.5.tar.gz
 G4PhotonEvaporation.5.7.tar.gz
 G4RadioactiveDecay.5.6.tar.gz
 G4PARTICLEXS.4.0.tar.gz
 G4PII.1.3.tar.gz
 G4RealSurface.2.2.tar.gz
 G4SAIDDATA.2.0.tar.gz
-G4ABLA.3.1.tar.gz
-G4INCL.1.0.tar.gz
+G4ABLA.3.3.tar.gz
+G4INCL.1.2.tar.gz
 G4ENSDFSTATE.2.3.tar.gz
 "
 

--- a/source/sensdet/SensorSD.h
+++ b/source/sensdet/SensorSD.h
@@ -15,7 +15,6 @@
 
 class G4Step;
 class G4HCofThisEvent;
-class G4VTouchable;
 class G4TouchableHistory;
 class G4OpBoundaryProcess;
 


### PR DESCRIPTION
This PR modifies the code to work with Geant4-v11.2.
Beyond the removal of an unnecessary forward declaration, an explicit dependence on Qt is added in the `SConstruct` file, due to a bug in Geant4 (https://bugzilla-geant4.kek.jp/show_bug.cgi?id=2589). 
I'll mark this PR as a draft, because if they solve the bug before we decide to start using Geant4-v11.2, there will be no need of this change.
The v11.2.1 patch solves the issue, therefore this explicit dependence is removed.