### PR TITLE
Add Qt to docker image used in github action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/next/nexus-base:2022-07-13
+FROM registry.cern.ch/next/nexus-base:2024-01-25
 
 COPY . /nexus
 WORKDIR /nexus

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:jammy
 
 RUN apt-get update -y && \
-    apt-get install -y cmake g++ libexpat1-dev libgsl27 libgsl-dev &&\ 
+    apt-get install -y cmake g++ libexpat1-dev libgsl27 libgsl-dev libqt5core5a qtbase5-dev &&\
     apt-get autoremove -y && \
     apt-get clean -y && \
     rm -rf /var/cache/apt/archives/* && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=registry.cern.ch/next/geant4:11.0.2           /opt/geant4       /opt/geant4
+COPY --from=registry.cern.ch/next/geant4:11.0.2-qt        /opt/geant4       /opt/geant4
 COPY --from=registry.cern.ch/next/root:6.26.04            /opt/root/install /opt/root/install
 COPY --from=registry.cern.ch/next/python-nexus:2022-07-13 /opt/conda        /opt/conda

--- a/docker/geant4/Dockerfile
+++ b/docker/geant4/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:jammy
 ENV G4_VERSION v11.0.2
 
 RUN apt-get update -y && \
-    apt-get install -y cmake curl g++ libexpat1-dev
+    apt-get install -y cmake curl g++ libexpat1-dev libqt5core5a qtbase5-dev
 RUN mkdir -p /opt/geant4/src && \
     mkdir -p /opt/geant4/build && \
     mkdir -p /opt/geant4/install && \
@@ -14,6 +14,7 @@ RUN mkdir -p /opt/geant4/src && \
     cmake -DCMAKE_INSTALL_PREFIX=/opt/geant4/install \
           -DGEANT4_BUILD_MULTITHREADED=ON \
           -DGEANT4_INSTALL_EXAMPLES=OFF \
+          -DGEANT4_USE_QT=ON \
           ../src/geant4-${G4_VERSION} && \
     make -j`nproc` && \
     make install  && \


### PR DESCRIPTION
This PR modifies the docker container used in the Github action to include Qt as a dependency and uses a Geant4 compilation with Qt enabled.