### PR TITLE
Allow projection only with specific regions

### DIFF
--- a/source/generators/MuonGenerator.cc
+++ b/source/generators/MuonGenerator.cc
@@ -247,7 +247,12 @@ void MuonGenerator::GeneratePrimaryVertex(G4Event* event)
     }
   }
 
-  G4ThreeVector position = ProjectToVertex(p_dir);
+  G4ThreeVector position;
+  if ((region_ == "HALLA_INNER") || (region_ == "HALLA_OUTER")) {
+    position = ProjectToVertex(p_dir);
+  } else {
+    position = geom_->GenerateVertex(region_);
+  }
 
   G4double pmod   = std::sqrt(energy*energy - mass*mass);
   G4double px = pmod * p_dir.x();

--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -289,10 +289,7 @@ namespace nexus {
     // Project along dir from point to find the first intersection
     // with region.
     G4ThreeVector vertex(0., 0., 0.);
-    if (region == "EXTERNAL"){
-      return shielding_->ProjectToRegion(region, point, dir);
-    }
-    else if ((region == "HALLA_OUTER") || (region == "HALLA_INNER")){
+    if ((region == "HALLA_OUTER") || (region == "HALLA_INNER")){
       if (!lab_walls_)
 	G4Exception("[Next100]", "ProjectToRegion()", FatalException,
                     "To project to this region you need lab_walls == true!");


### PR DESCRIPTION
This PR modifies the muon generator in the following way.
When simulating muons from the LSC rock (`HALLA_INNER` and `HALL_OUTER` regions), the method of projection is used to improve the efficiency and simulate only muons in the directions that cross the detector.
For any other region, a normal generation is applied.
The problem was twofold: on the one hand, the `EXTERNAL` region produced an exception when used together with the muon generator; on the other hand, the muon generator employed the projection with any regions, while the Next100 geometry only accepted three (`EXTERNAL`, `HALLA_INNER` and `HALL_OUTER`) and other geometries did not accept any, which made impossible to use the muon generator together with other geometries or regions. After discussing with @pnovella we came to the conclusion that the only regions where we want to boost the efficiency (therefore use the projection method) are those related to the LSC rock.
With this modification, one can use the muon generator without projection with custom-made regions without the need of modifying the code, while before it was not possible.