### PR TITLE
Assign attachment to electric field

### DIFF
--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -561,7 +561,7 @@ void Next100FieldCage::BuildELRegion()
                                                                el_grid_transparency_,
                                                                grid_thickn_,
                                                                sc_yield_,
-                                                               1.e9*s,
+                                                               1000.*ms,
                                                                photoe_prob_));
 
   /// Dimensions & position: the grids are simulated inside the EL gap.

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -333,6 +333,7 @@ void Next100FieldCage::BuildActive()
   field->SetDriftVelocity(1. * mm/microsecond);
   field->SetTransverseDiffusion(drift_transv_diff_);
   field->SetLongitudinalDiffusion(drift_long_diff_);
+  field->SetLifetime(e_lifetime_);
   G4Region* drift_region = new G4Region("DRIFT");
   drift_region->SetUserInformation(field);
   drift_region->AddRootLogicalVolume(active_logic);

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -189,6 +189,9 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
                           "Maximum Z range of the EL gap vertex generation disk.");
   el_gap_gen_disk_zmax_cmd.SetParameterName("el_gap_gen_disk_zmax", false);
   el_gap_gen_disk_zmax_cmd.SetRange("el_gap_gen_disk_zmax>=0.0 && el_gap_gen_disk_zmax<=1.0");
+
+  msg_->DeclareProperty("photoe_prob", photoe_prob_,
+                        "Probability of photon to ie- conversion");
 }
 
 
@@ -252,6 +255,8 @@ void Next100FieldCage::DefineMaterials()
   gas_         = mother_logic_->GetMaterial();
   pressure_    = gas_->GetPressure();
   temperature_ = gas_->GetTemperature();
+  sc_yield_    = gas_->GetMaterialPropertiesTable()->GetConstProperty("SCINTILLATIONYIELD");
+  e_lifetime_  = gas_->GetMaterialPropertiesTable()->GetConstProperty("ATTACHMENT");
 
   /// High density polyethylene for the field cage
   hdpe_ = materials::HDPE();
@@ -553,7 +558,10 @@ void Next100FieldCage::BuildELRegion()
   fgrid_mat->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_,
                                                                temperature_,
                                                                el_grid_transparency_,
-                                                               grid_thickn_));
+                                                               grid_thickn_,
+                                                               sc_yield_,
+                                                               1.e9*s,
+                                                               photoe_prob_));
 
   /// Dimensions & position: the grids are simulated inside the EL gap.
   /// Their thickness is symbolic.

--- a/source/geometries/Next100FieldCage.h
+++ b/source/geometries/Next100FieldCage.h
@@ -121,6 +121,9 @@ namespace nexus {
     G4Material* gas_;
     G4double pressure_;
     G4double temperature_;
+    G4double sc_yield_;
+    G4double e_lifetime_;
+    G4double photoe_prob_;
 
     // Pointers to materials definition
     G4Material* hdpe_;

--- a/source/geometries/Next1EL.cc
+++ b/source/geometries/Next1EL.cc
@@ -740,10 +740,12 @@ void Next1EL::BuildFieldCage()
 
   G4Material* fgrid = materials::FakeDielectric(gxe_, "grid_mat");
   fgrid->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_, 303,
-									elgrid_transparency_, diel_thickn, sc_yield_, e_lifetime_));
+                                                           elgrid_transparency_,
+                                                           diel_thickn, sc_yield_));
   G4Material* fgrid_gate = materials::FakeDielectric(gxe_, "grid_mat");
   fgrid_gate->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_, 303,
-									gate_transparency_, diel_thickn, sc_yield_, e_lifetime_));
+                                                                gate_transparency_,
+                                                                diel_thickn, sc_yield_));
 
   G4Tubs* diel_grid =
     new G4Tubs("GRID", 0., elgap_ring_diam_/2., diel_thickn/2., 0, twopi);

--- a/source/geometries/Next1EL.cc
+++ b/source/geometries/Next1EL.cc
@@ -821,7 +821,7 @@ void Next1EL::BuildFieldCage()
   field->SetDriftVelocity(1.*mm/microsecond);
   field->SetTransverseDiffusion(1.*mm/sqrt(cm));
   field->SetLongitudinalDiffusion(.3*mm/sqrt(cm));
-
+  field->SetLifetime(e_lifetime_);
   G4Region* drift_region = new G4Region("DRIFT");
   drift_region->SetUserInformation(field);
   drift_region->AddRootLogicalVolume(active_logic);

--- a/source/geometries/NextDemoFieldCage.cc
+++ b/source/geometries/NextDemoFieldCage.cc
@@ -401,7 +401,7 @@ namespace nexus {
                                                                 gate_transparency_,
                                                                 grid_thickn_,
                                                                 sc_yield_,
-                                                                e_lifetime_));
+                                                                1000*ms));
 
     G4Tubs* gate_grid_solid =
       new G4Tubs("GATE_GRID", 0., elgap_ring_diam_/2., grid_thickn_/2.,
@@ -474,7 +474,7 @@ namespace nexus {
                                                                    anode_transparency_,
                                                                    grid_thickn_,
                                                                    sc_yield_,
-                                                                   e_lifetime_));
+                                                                   1000*ms));
       G4Tubs* anode_grid_solid =
         new G4Tubs("ANODE_GRID", 0., elgap_ring_diam_/2., grid_thickn_/2., 0, twopi);
 

--- a/source/geometries/NextDemoFieldCage.cc
+++ b/source/geometries/NextDemoFieldCage.cc
@@ -280,6 +280,7 @@ namespace nexus {
     field->SetDriftVelocity(1.*mm/microsecond);
     field->SetTransverseDiffusion(drift_transv_diff_);
     field->SetLongitudinalDiffusion(drift_long_diff_);
+    field->SetLifetime(e_lifetime_);
     G4Region* drift_region = new G4Region("DRIFT");
     drift_region->SetUserInformation(field);
     drift_region->AddRootLogicalVolume(active_logic);

--- a/source/geometries/NextDemoFieldCage.cc
+++ b/source/geometries/NextDemoFieldCage.cc
@@ -223,6 +223,8 @@ namespace nexus {
     gas_         = mother_logic_->GetMaterial();
     pressure_    = gas_->GetPressure();
     temperature_ = gas_->GetTemperature();
+    sc_yield_    = gas_->GetMaterialPropertiesTable()->GetConstProperty("SCINTILLATIONYIELD");
+    e_lifetime_  = gas_->GetMaterialPropertiesTable()->GetConstProperty("ATTACHMENT");
 
     aluminum_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_Al");
     aluminum_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
@@ -296,9 +298,9 @@ namespace nexus {
     G4Material* cathode_mat =
       materials::FakeDielectric(gas_, "cathode_mat");
     cathode_mat->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_,
-                                                                                temperature_,
-                                                                                cathode_transparency_,
-                                                                                grid_thickn_));
+                                                                   temperature_,
+                                                                   cathode_transparency_,
+                                                                   grid_thickn_));
 
     G4double cath_zplane[2] = {-grid_thickn_/2., grid_thickn_/2.};
     G4double rinner[2]      = {0., 0.};
@@ -394,9 +396,11 @@ namespace nexus {
     // Building the GATE
     G4Material* gate_mat = materials::FakeDielectric(gas_, "gate_mat");
     gate_mat->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_,
-                                                                             temperature_,
-                                                                             gate_transparency_,
-                                                                             grid_thickn_));
+                                                                temperature_,
+                                                                gate_transparency_,
+                                                                grid_thickn_,
+                                                                sc_yield_,
+                                                                e_lifetime_));
 
     G4Tubs* gate_grid_solid =
       new G4Tubs("GATE_GRID", 0., elgap_ring_diam_/2., grid_thickn_/2.,
@@ -467,7 +471,9 @@ namespace nexus {
       anode_mat->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_,
                                                                    temperature_,
                                                                    anode_transparency_,
-                                                                   grid_thickn_));
+                                                                   grid_thickn_,
+                                                                   sc_yield_,
+                                                                   e_lifetime_));
       G4Tubs* anode_grid_solid =
         new G4Tubs("ANODE_GRID", 0., elgap_ring_diam_/2., grid_thickn_/2., 0, twopi);
 

--- a/source/geometries/NextDemoFieldCage.h
+++ b/source/geometries/NextDemoFieldCage.h
@@ -66,6 +66,7 @@ namespace nexus {
     G4LogicalVolume* mother_logic_;
     G4VPhysicalVolume* mother_phys_;
     G4double pressure_, temperature_;
+    G4double sc_yield_, e_lifetime_;
 
 
     // Pointers to materials definition

--- a/source/geometries/NextDemoVessel.cc
+++ b/source/geometries/NextDemoVessel.cc
@@ -104,11 +104,10 @@ void NextDemoVessel::Construct()
   G4String gas_name = "GAS";
 
   G4Material* gas_material = materials::GXe(gas_pressure_, gas_temperature_);
-  gas_material->
-    SetMaterialPropertiesTable(opticalprops::GXe(gas_pressure_,
-                                                              gas_temperature_,
-                                                              sc_yield_,
-                                                              e_lifetime_));
+  gas_material->SetMaterialPropertiesTable(opticalprops::GXe(gas_pressure_,
+                                                             gas_temperature_,
+                                                             sc_yield_,
+                                                             e_lifetime_));
 
   G4Tubs* gas_solid_vol =
     new G4Tubs(gas_name, 0., vessel_diam_/2., vessel_length_/2., 0, twopi);

--- a/source/geometries/NextFlexFieldCage.cc
+++ b/source/geometries/NextFlexFieldCage.cc
@@ -315,17 +315,17 @@ void NextFlexFieldCage::DefineMaterials()
   cathode_mat_ = materials::FakeDielectric(xenon_gas_, "cathode_mat");
   cathode_mat_->SetMaterialPropertiesTable(opticalprops::FakeGrid(gas_pressure_,
                 gas_temperature_, cathode_transparency_, cathode_thickness_,
-                gas_sc_yield_, gas_e_lifetime_, photoe_prob_));
+                gas_sc_yield_, gas_e_lifetime_));
 
   gate_mat_ = materials::FakeDielectric(xenon_gas_, "gate_mat");
   gate_mat_->SetMaterialPropertiesTable(opticalprops::FakeGrid(gas_pressure_,
              gas_temperature_, gate_transparency_, gate_thickness_,
-             gas_sc_yield_, gas_e_lifetime_, photoe_prob_));
+             gas_sc_yield_, 1.e9*s, photoe_prob_));
 
   anode_mat_ = materials::FakeDielectric(xenon_gas_, "anode_mat");
   anode_mat_->SetMaterialPropertiesTable(opticalprops::FakeGrid(gas_pressure_,
               gas_temperature_, anode_transparency_, anode_thickness_,
-              gas_sc_yield_, gas_e_lifetime_, photoe_prob_));
+              gas_sc_yield_, 1.e9*s, photoe_prob_));
 
 
   // Fiber core material

--- a/source/geometries/NextFlexFieldCage.cc
+++ b/source/geometries/NextFlexFieldCage.cc
@@ -320,12 +320,12 @@ void NextFlexFieldCage::DefineMaterials()
   gate_mat_ = materials::FakeDielectric(xenon_gas_, "gate_mat");
   gate_mat_->SetMaterialPropertiesTable(opticalprops::FakeGrid(gas_pressure_,
              gas_temperature_, gate_transparency_, gate_thickness_,
-             gas_sc_yield_, 1.e9*s, photoe_prob_));
+             gas_sc_yield_, 1000*ms, photoe_prob_));
 
   anode_mat_ = materials::FakeDielectric(xenon_gas_, "anode_mat");
   anode_mat_->SetMaterialPropertiesTable(opticalprops::FakeGrid(gas_pressure_,
               gas_temperature_, anode_transparency_, anode_thickness_,
-              gas_sc_yield_, 1.e9*s, photoe_prob_));
+              gas_sc_yield_, 1000*ms, photoe_prob_));
 
 
   // Fiber core material

--- a/source/geometries/NextFlexFieldCage.cc
+++ b/source/geometries/NextFlexFieldCage.cc
@@ -420,6 +420,7 @@ void NextFlexFieldCage::BuildActive()
   field->SetDriftVelocity(1. * mm/microsecond);
   field->SetTransverseDiffusion(drift_transv_diff_);
   field->SetLongitudinalDiffusion(drift_long_diff_);
+  field->SetLifetime(gas_e_lifetime_);
   G4Region* drift_region = new G4Region("DRIFT");
   drift_region->SetUserInformation(field);
   drift_region->AddRootLogicalVolume(active_logic);

--- a/source/geometries/NextNewFieldCage.cc
+++ b/source/geometries/NextNewFieldCage.cc
@@ -456,7 +456,7 @@ void NextNewFieldCage::BuildBuffer()
                                                                  gate_transparency_,
                                                                  grid_thickness_,
                                                                  sc_yield_,
-                                                                 1.e9*s,
+                                                                 1000*ms,
                                                                  photoe_prob_));
 
     // Dimensions & position: the grids are simulated inside the EL gap.

--- a/source/geometries/NextNewFieldCage.cc
+++ b/source/geometries/NextNewFieldCage.cc
@@ -360,6 +360,7 @@ namespace nexus {
     field->SetDriftVelocity(1. * mm/microsecond);
     field->SetTransverseDiffusion(drift_transv_diff_);
     field->SetLongitudinalDiffusion(drift_long_diff_);
+    field->SetLifetime(e_lifetime_);
     G4Region* drift_region = new G4Region("DRIFT");
     drift_region->SetUserInformation(field);
     drift_region->AddRootLogicalVolume(active_logic);

--- a/source/geometries/NextNewFieldCage.cc
+++ b/source/geometries/NextNewFieldCage.cc
@@ -307,9 +307,9 @@ namespace nexus {
     G4Material* fgrid_mat =
       materials::FakeDielectric(gas_, "cath_grid_mat");
     fgrid_mat->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_,
-                                                                              temperature_,
-                                                                              cathode_grid_transparency_,
-                                                                              cathode_thickness_));
+                                                                 temperature_,
+                                                                 cathode_grid_transparency_,
+                                                                 cathode_thickness_));
     // Dimensions & position
     G4double grid_diam = tube_in_diam_;
 
@@ -451,12 +451,12 @@ void NextNewFieldCage::BuildBuffer()
     // We have to set the defaults explicitely because C++ doesn't support
     // named arguments
     fgate_mat->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_,
-                                                                              temperature_,
-                                                                              gate_transparency_,
-                                                                              grid_thickness_,
-                                                                              sc_yield_,
-                                                                              e_lifetime_,
-                                                                              photoe_prob_));
+                                                                 temperature_,
+                                                                 gate_transparency_,
+                                                                 grid_thickness_,
+                                                                 sc_yield_,
+                                                                 1.e9*s,
+                                                                 photoe_prob_));
 
     // Dimensions & position: the grids are simulated inside the EL gap.
     // Their thickness is symbolic.

--- a/source/physics/IonizationDrift.cc
+++ b/source/physics/IonizationDrift.cc
@@ -79,23 +79,6 @@ namespace nexus {
     ParticleChange_->Initialize(track);
 
     if (step.GetStepLength() > 0) {
-
-      // Simulate attachment by impurities
-      
-      G4MaterialPropertiesTable* mpt = 
-        track.GetMaterial()->GetMaterialPropertiesTable();
-
-      if (!mpt || !(mpt->ConstPropertyExists("ATTACHMENT"))) { 
-        G4Exception("[IonizationDrift]", "AlongStepDoIt()", JustWarning,
-          "No material properties table found. Assuming no attachment.");
-      }
-      else {
-        const G4double attach = mpt->GetConstProperty("ATTACHMENT");
-        G4double rnd = -attach * log(G4UniformRand());
-        if (xyzt_.t() > rnd) 
-          ParticleChange_->ProposeTrackStatus(fStopAndKill);
-      }
-
       ParticleChange_->ProposeGlobalTime(xyzt_.t());
       ParticleChange_->ProposePosition(xyzt_.vect());
     }

--- a/source/physics/UniformElectricDriftField.cc
+++ b/source/physics/UniformElectricDriftField.cc
@@ -64,7 +64,6 @@ namespace nexus {
 
     G4ThreeVector position;
     G4double time;
-    G4double time_diff;
 
     for (G4int i=0; i<3; i++) {
       if (i != axis_)  {     // Transverse coordinate
@@ -74,13 +73,11 @@ namespace nexus {
         position[i] = anode_pos_ + secmargin;
         G4double deltat = G4RandGauss::shoot(0, time_sigma);
         time = xyzt.t() + drift_time + deltat;
-        time_diff = drift_time + deltat;
-        if (time < 0.) {
-          time = xyzt.t() + drift_time;
-          time_diff = drift_time;
-        }
+        if (time < 0.) time = xyzt.t() + drift_time;
       }
     }
+
+    G4double time_diff = time - xyzt.t();
 
     // Calculate step length as euclidean distance between initial
     // and final positions

--- a/source/physics/UniformElectricDriftField.h
+++ b/source/physics/UniformElectricDriftField.h
@@ -61,9 +61,6 @@ namespace nexus {
     void SetLightYield(G4double);
     virtual G4double LightYield() const;
 
-    void SetNumberOfPhotons(G4double);
-    G4double GetNumberOfPhotons() const;
-
     virtual G4double GetTotalDriftLength() const;
 
   private:
@@ -82,9 +79,8 @@ namespace nexus {
     G4double drift_velocity_; ///< Drift velocity of the charge carrier
     G4double transv_diff_;    ///< Transverse diffusion
     G4double longit_diff_;    ///< Longitudinal diffusion
-    G4double lifetime_;
-    G4double light_yield_;
-    G4double num_ph_;
+    G4double lifetime_;       ///< Electron lifetime
+    G4double light_yield_;    ///< EL light yield
 
     SegmentPointSampler* rnd_;
 
@@ -134,10 +130,6 @@ namespace nexus {
 
   inline G4double UniformElectricDriftField::LightYield() const
   { return light_yield_; }
-
-  inline void UniformElectricDriftField::SetNumberOfPhotons(G4double nph)
-  { num_ph_ = nph; }
-
 
 
 } // end namespace nexus

--- a/source/physics/UniformElectricDriftField.h
+++ b/source/physics/UniformElectricDriftField.h
@@ -55,8 +55,8 @@ namespace nexus {
     void SetTransverseDiffusion(G4double);
     G4double GetTransverseDiffusion() const;
 
-    void SetAttachment(G4double);
-    G4double GetAttachment() const;
+    void SetLifetime(G4double);
+    G4double GetLifetime() const;
 
     void SetLightYield(G4double);
     virtual G4double LightYield() const;
@@ -82,7 +82,7 @@ namespace nexus {
     G4double drift_velocity_; ///< Drift velocity of the charge carrier
     G4double transv_diff_;    ///< Transverse diffusion
     G4double longit_diff_;    ///< Longitudinal diffusion
-    G4double attachment_;
+    G4double lifetime_;
     G4double light_yield_;
     G4double num_ph_;
 
@@ -123,11 +123,11 @@ namespace nexus {
   inline G4double UniformElectricDriftField::GetTransverseDiffusion() const
   { return transv_diff_; }
 
-  inline void UniformElectricDriftField::SetAttachment(G4double a)
-  { attachment_ = a; }
+  inline void UniformElectricDriftField::SetLifetime(G4double a)
+  { lifetime_ = a; }
 
-  inline G4double UniformElectricDriftField::GetAttachment() const
-  { return attachment_; }
+  inline G4double UniformElectricDriftField::GetLifetime() const
+  { return lifetime_; }
 
   inline void UniformElectricDriftField::SetLightYield(G4double ly)
   { light_yield_ = ly; }


### PR DESCRIPTION
With this PR we change the way we simulate the electron lifetime in our gas (a.k.a. `attachment`). 
In the current code, the value is read by the `ATTACHMENT` optical property of the material where the ionization electrons start their drift. However, this is a problem if we simulate the grids as made of steel instead of as made of a thin dielectric gas with the same properties as xenon, as done so far.
One way of solving this issue is to assign the lifetime property directly to the electric field; it is still read from the optical property of the xenon gas, but now it is decoupled from the specific material the grids are made of.

I also changed the term `attachment` to `lifetime` in the code, because I think it describes better what it represents.