### PR TITLE
Add necessity of env variable for Qt headers

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -154,6 +154,12 @@ vars.AddVariables(
                  'Path to hdf5 installation directory.',
                  NULL_PATH),
 
+    ## Qt
+
+    PathVariable('QT_DIR',
+                 'Path to Qt installation directory.',
+                 NULL_PATH),
+
     ## installation directory
 
     PathVariable('PREFIX',
@@ -270,6 +276,14 @@ if not env['LIBPATH']:
 
     if not conf.CheckLib(library='hdf5', language='CXX', autoadd=0):
         Abort('HDF5 library not found.')
+
+    ## Qt configuration ----------------------------------
+    if env['QT_DIR'] == NULL_PATH:
+        try:
+            env['QT_DIR'] = os.environ['QT_DIR']
+        except KeyError:
+            Abort('QT installation directory could not be found.')
+    env.Append(CPPPATH = [env['QT_DIR']+'/include'])
 
 ## ##################################################################
 


### PR DESCRIPTION
This PR fixes an issue with how `scons` deals (or, better, doesn't) with the new `-F`  flags which fixes Qt compilation starting from geant4-v11.2.1. 
The user will need to define a new environment variable, `QT_DIR`, in order to be able to do only incremental compilations and not be forced to compile every time from scratch when using `scons`.