### PR TITLE
Add reflections on copper and SS

### DIFF
--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -219,6 +219,16 @@ namespace nexus {
     copper_plate_posz_ = GetCoordOrigin().z()
       + gate_sapphire_wdw_dist_ + stand_out_length + copper_plate_thickn_/2.;
 
+    // Add optical surface
+    G4OpticalSurface* gas_copperplate_opsur = new G4OpticalSurface("GAS_COPPER_PLATE_OPSURF");
+    gas_copperplate_opsur->SetType(dielectric_metal);
+    gas_copperplate_opsur->SetModel(unified);
+    gas_copperplate_opsur->SetFinish(ground);
+    gas_copperplate_opsur->SetSigmaAlpha(0.0);
+    gas_copperplate_opsur->SetMaterialPropertiesTable(opticalprops::Copper());
+    new G4LogicalSkinSurface("GAS_COPPER_PLATE_OPSURF",
+                            copper_plate_logic, gas_copperplate_opsur);
+
     new G4PVPlacement(0, G4ThreeVector(0., 0., copper_plate_posz_),
                       copper_plate_logic, "EP_COPPER_PLATE", mother_logic_, false, 0, false);
 

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -455,6 +455,16 @@ void Next100FieldCage::BuildCathode()
                                          cathode_grid_logic,  "CATHODE_GRID", mother_logic_,
                                          false, 0, false);
 
+      // Add optical surface
+      G4OpticalSurface* gas_mesh_opsur = new G4OpticalSurface("GAS_CATHODE_MESH_OPSURF");
+      gas_mesh_opsur->SetType(dielectric_metal);
+      gas_mesh_opsur->SetModel(unified);
+      gas_mesh_opsur->SetFinish(ground);
+      gas_mesh_opsur->SetSigmaAlpha(0.0);
+      gas_mesh_opsur->SetMaterialPropertiesTable(opticalprops::Steel());
+      new G4LogicalSkinSurface("GAS_CATHODE_MESH_OPSURF",
+                              cathode_grid_logic, gas_mesh_opsur);
+
   }
 
   // Cathode ring vertex generator
@@ -685,6 +695,15 @@ void Next100FieldCage::BuildELRegion()
     // Place GXe hexagons in the disk to make the mesh
     PlaceHexagons(n_hex, el_mesh_diam_, grid_thickn_, el_grid_logic, el_hex_logic, gate_int_diam_);
 
+    // Add optical surface
+    G4OpticalSurface* gas_mesh_opsur = new G4OpticalSurface("GAS_EL_MESH_OPSURF");
+    gas_mesh_opsur->SetType(dielectric_metal);
+    gas_mesh_opsur->SetModel(unified);
+    gas_mesh_opsur->SetFinish(ground);
+    gas_mesh_opsur->SetSigmaAlpha(0.0);
+    gas_mesh_opsur->SetMaterialPropertiesTable(opticalprops::Steel());
+    new G4LogicalSkinSurface("GAS_EL_MESH_OPSURF",
+                             el_grid_logic, gas_mesh_opsur);
 
   }
 

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -1625,7 +1625,53 @@ namespace opticalprops {
     return mpt;
   }
 
+  // Copper Optical Properties Table
+  G4MaterialPropertiesTable * Copper()
+  {
+       G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
 
+      // Reflectivity
+      std::vector<G4double> refl_energies = {
+              optPhotMinE_, hc_ / (700. * nm), hc_ / (650. * nm),
+                            hc_ / (600. * nm), hc_ / (500. * nm),
+                            hc_ / (400. * nm), hc_ / (300. * nm),
+                            hc_ / (170. * nm), optPhotMaxE_ };
+
+      // We assume a reflectivity of the copper of 20% at VUV
+      // Measurements may be required to update these values
+      // Visible spectrum taken from: E. Hecht, Optics, 5th edn., Pg 142, Fig 4.69
+      std::vector<G4double> reflectivities = { 0.90, 0.90, 0.70, 0.60, 0.40, 0.35, 0.30, 0.20, 0.20};
+
+      // Add Properties
+      mpt->AddProperty("SPECULARLOBECONSTANT", {optPhotMinE_, optPhotMaxE_}, {0., 0.});
+      mpt->AddProperty("SPECULARSPIKECONSTANT",{optPhotMinE_, optPhotMaxE_}, {0., 0.});
+      mpt->AddProperty("BACKSCATTERCONSTANT",  {optPhotMinE_, optPhotMaxE_}, {0., 0.});
+      mpt->AddProperty("REFLECTIVITY", refl_energies, reflectivities);
+      return mpt;
+  }
+
+  // Stainles Steel Optical Properties Table
+  G4MaterialPropertiesTable * Steel()
+  {
+      G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
+
+      // Reflectivity
+      std::vector<G4double> refl_energies = {
+              optPhotMinE_, hc_ / (500. * nm), hc_ / (350. * nm),
+                            hc_ / (300. * nm), hc_ / (170. * nm),  optPhotMaxE_ };
+
+      // We assume a reflectivity of the stainless steel of 20% at VUV
+      // Measurements may be required to update these values
+      // Visible spectrum taken from: https://doi.org/10.1063/1.331503
+      std::vector<G4double> reflectivities = { 0.60, 0.60, 0.50, 0.40, 0.20, 0.20};
+
+      // Add properties
+      mpt->AddProperty("SPECULARLOBECONSTANT", {optPhotMinE_, optPhotMaxE_}, {0., 0.});
+      mpt->AddProperty("SPECULARSPIKECONSTANT",{optPhotMinE_, optPhotMaxE_}, {0., 0.});
+      mpt->AddProperty("BACKSCATTERCONSTANT",  {optPhotMinE_, optPhotMaxE_}, {0., 0.});
+      mpt->AddProperty("REFLECTIVITY", refl_energies, reflectivities);
+      return mpt;
+  }
 
   /// Generic material, to be modifed by the user ///
   G4MaterialPropertiesTable* XXX()

--- a/source/materials/OpticalMaterialProperties.h
+++ b/source/materials/OpticalMaterialProperties.h
@@ -83,6 +83,10 @@ namespace opticalprops {
 
   G4MaterialPropertiesTable* PMMA();
 
+  G4MaterialPropertiesTable* Copper();
+
+  G4MaterialPropertiesTable* Steel();
+
   G4MaterialPropertiesTable* XXX();
 
 


### PR DESCRIPTION
This PR adds the reflections on the copper on the energy plane and on the stainless steel meshes. 

Absolute reflectivities are currently implemented without any angular dependence. References are provided in the comments.