### PR TITLE
Fix latest tag

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -281,9 +281,10 @@ if not env['LIBPATH']:
     if env['QT_DIR'] == NULL_PATH:
         try:
             env['QT_DIR'] = os.environ['QT_DIR']
+            env.Append(CPPPATH = [env['QT_DIR']+'/include'])
         except KeyError:
-            Abort('QT installation directory could not be found.')
-    env.Append(CPPPATH = [env['QT_DIR']+'/include'])
+            print('Env variable for QT installation directory could not be found.'
+                  'The compilation usually succeeds anyway, except for some MacOS versions.')
 
 ## ##################################################################
 

--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -1642,9 +1642,11 @@ namespace opticalprops {
       // Visible spectrum taken from: E. Hecht, Optics, 5th edn., Pg 142, Fig 4.69
       std::vector<G4double> reflectivities = { 0.90, 0.90, 0.70, 0.60, 0.40, 0.35, 0.30, 0.20, 0.20};
 
+      // We assume that the reflectivity is mostly specular.
+      // Measurements may be required to update these values
       // Add Properties
       mpt->AddProperty("SPECULARLOBECONSTANT", {optPhotMinE_, optPhotMaxE_}, {0., 0.});
-      mpt->AddProperty("SPECULARSPIKECONSTANT",{optPhotMinE_, optPhotMaxE_}, {0., 0.});
+      mpt->AddProperty("SPECULARSPIKECONSTANT",{optPhotMinE_, optPhotMaxE_}, {0.75, 0.75});
       mpt->AddProperty("BACKSCATTERCONSTANT",  {optPhotMinE_, optPhotMaxE_}, {0., 0.});
       mpt->AddProperty("REFLECTIVITY", refl_energies, reflectivities);
       return mpt;
@@ -1665,9 +1667,11 @@ namespace opticalprops {
       // Visible spectrum taken from: https://doi.org/10.1063/1.331503
       std::vector<G4double> reflectivities = { 0.60, 0.60, 0.50, 0.40, 0.20, 0.20};
 
+      // We assume that the reflectivity is mostly specular.
+      // Measurements may be required to update these values
       // Add properties
       mpt->AddProperty("SPECULARLOBECONSTANT", {optPhotMinE_, optPhotMaxE_}, {0., 0.});
-      mpt->AddProperty("SPECULARSPIKECONSTANT",{optPhotMinE_, optPhotMaxE_}, {0., 0.});
+      mpt->AddProperty("SPECULARSPIKECONSTANT",{optPhotMinE_, optPhotMaxE_}, {0.75, 0.75});
       mpt->AddProperty("BACKSCATTERCONSTANT",  {optPhotMinE_, optPhotMaxE_}, {0., 0.});
       mpt->AddProperty("REFLECTIVITY", refl_energies, reflectivities);
       return mpt;


### PR DESCRIPTION
This PR fixes two things:
- Turns an exception into a warning when looking for Qt libraries through an environment variable. This variable is only needed in some MacOS versions, so we don't want an error on any machines.
- Changes the metal reflectivity from 100% Lambertian to 75% specular/25% Lambertian. This seems a reasonable assumption, until we obtain our own measurements.