### PR TITLE
Improve the error message when using opt photons as primary

### DIFF
--- a/source/actions/DefaultEventAction.cc
+++ b/source/actions/DefaultEventAction.cc
@@ -91,7 +91,8 @@ REGISTER_CLASS(DefaultEventAction, G4UserEventAction)
         Trajectory* trj = dynamic_cast<Trajectory*>((*tc)[0]);
         if (trj == nullptr){
           G4Exception("[DefaultEventAction]", "EndOfEventAction()", FatalException,
-                      "DefaultTrackingAction is required when using DefaultEventAction");
+                      "The trajectory container is empty. If you are simulating optical photons as primary particles,"
+                      " and not using OpticalTrackingAction, you should use the G4 default event action.");
         }
         for (unsigned int i=0; i<tc->size(); ++i) {
           Trajectory* tr = dynamic_cast<Trajectory*>((*tc)[i]);
@@ -100,7 +101,9 @@ REGISTER_CLASS(DefaultEventAction, G4UserEventAction)
       }
       else {
         G4Exception("[DefaultEventAction]", "EndOfEventAction()", FatalException,
-                    "DefaultTrackingAction is required when using DefaultEventAction");
+                    "The trajectory container doesn't exist. Check that you are using DefaultTrackingAction."
+                    " Notice that, if you are simulating optical photons as primary particles, "
+                    "and not using OpticalTrackingAction, you should not specify any event actions.");
       }
 
       PersistencyManager* pm = dynamic_cast<PersistencyManager*>


### PR DESCRIPTION
Optical photons' trajectories are not stored in the simulation when using `DefaultTrackingAction`, to avoid creating huge output files. If one wants to save them, `OpticalTrackingAction` should be used instead, only for small productions and debugging.
On the other hand, `DefaultEventAction` tries to access the trajectory container, to look for the hits associated with every particle and make a cut on the total deposited energy.
As a consequence, the combination of `DefaultTrackingAction` and `DefaultEventAction` produces a segmentation fault in simulations of optical photons as primary particles, since no other particles are present in the simulation.
For the same reason, using `DefaultEventAction` but not `DefaultTrackingAction` in standard simulations also causes a segmentation fault.
This PR tries to improve the error message to cover these two cases, which are the most common causes of that particular segmentation fault.