### PR TITLE
Use dielectric grids for automatic overlap checks

### DIFF
--- a/macros/NEXT100_ovlp.config.mac
+++ b/macros/NEXT100_ovlp.config.mac
@@ -1,0 +1,37 @@
+## ----------------------------------------------------------------------------
+## nexus | NEXT100_ovlp.config.mac
+##
+## Configuration macro to simulate Tl-208 radioactive decays from the
+## copper plate of the tracking plane in the NEXT-100 detector.
+## Grids are implemented as dielectric, with the purpose of checking
+## for overlaps in a reasonable amount of time.
+##
+## The NEXT Collaboration
+## ----------------------------------------------------------------------------
+
+##### VERBOSITY #####
+/run/verbose 0
+/event/verbose 0
+/tracking/verbose 0
+
+/process/em/verbose 0
+/process/had/verbose 0
+
+##### GEOMETRY #####
+/Geometry/Next100/elfield false
+/Geometry/Next100/max_step_size 1. mm
+/Geometry/Next100/use_dielectric_grid true
+
+##### GENERATOR #####
+/Generator/IonGenerator/atomic_number 81
+/Generator/IonGenerator/mass_number 208
+/Generator/IonGenerator/region TP_COPPER_PLATE
+
+##### PHYSICS #####
+## No full simulation
+/PhysicsList/Nexus/clustering          false
+/PhysicsList/Nexus/drift               false
+/PhysicsList/Nexus/electroluminescence false
+
+##### PERSISTENCY #####
+/nexus/persistency/output_file Next100_ovlp.next

--- a/macros/NEXT100_ovlp.init.mac
+++ b/macros/NEXT100_ovlp.init.mac
@@ -1,0 +1,28 @@
+## ----------------------------------------------------------------------------
+## nexus | NEXT100_ovlp.init.mac
+##
+## Initialization macro to simulate Tl-208 radioactive decays from the
+## copper plate of the tracking plane in the NEXT-100 detector.
+## Grids are implemented as dielectric, with the purpose of checking
+## for overlaps in a reasonable amount of time.
+##
+## The NEXT Collaboration
+## ----------------------------------------------------------------------------
+
+/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
+/PhysicsList/RegisterPhysics G4DecayPhysics
+/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
+/PhysicsList/RegisterPhysics NexusPhysics
+/PhysicsList/RegisterPhysics G4StepLimiterPhysics
+
+/nexus/RegisterGeometry Next100
+
+/nexus/RegisterGenerator IonGenerator
+
+/nexus/RegisterPersistencyManager PersistencyManager
+
+/nexus/RegisterRunAction DefaultRunAction
+/nexus/RegisterEventAction DefaultEventAction
+/nexus/RegisterTrackingAction DefaultTrackingAction
+
+/nexus/RegisterMacro macros/NEXT100_ovlp.config.mac

--- a/macros/NEXT100opt_ovlp.config.mac
+++ b/macros/NEXT100opt_ovlp.config.mac
@@ -1,0 +1,34 @@
+## ----------------------------------------------------------------------------
+## nexus | NEXT100opt_ovlp.config.mac
+##
+## Initialization macro to simulate Kr-83 decays in the NEXT-100 geometry
+## with fast simulation and grids implemented as dielectric,
+## with the purpose of checking for overlaps in a reasonable amount of time.
+##
+## The NEXT Collaboration
+## ----------------------------------------------------------------------------
+
+##### VERBOSITY #####
+/run/verbose 1
+/event/verbose 0
+/tracking/verbose 0
+
+/process/em/verbose 0
+
+##### GEOMETRY #####
+/Geometry/Next100/elfield false
+/Geometry/Next100/pressure 10. bar
+/Geometry/Next100/max_step_size 1. mm
+/Geometry/Next100/use_dielectric_grid true
+
+##### GENERATOR #####
+/Generator/Kr83mGenerator/region ACTIVE
+
+##### PHYSICS #####
+## No full simulation
+/PhysicsList/Nexus/clustering          false
+/PhysicsList/Nexus/drift               false
+/PhysicsList/Nexus/electroluminescence false
+
+##### PERSISTENCY #####
+/nexus/persistency/output_file Next100opt_ovlp.next

--- a/macros/NEXT100opt_ovlp.init.mac
+++ b/macros/NEXT100opt_ovlp.init.mac
@@ -1,0 +1,27 @@
+## ----------------------------------------------------------------------------
+## nexus | NEXT100opt_ovlp.init.mac
+##
+## Initialization macro to simulate Kr-83 decays in the NEXT-100 geometry
+## with fast simulation and grids implemented as dielectric,
+## with the purpose of checking for overlaps in a reasonable amount of time.
+##
+## The NEXT Collaboration
+## ----------------------------------------------------------------------------
+
+/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
+/PhysicsList/RegisterPhysics G4DecayPhysics
+/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
+/PhysicsList/RegisterPhysics NexusPhysics
+/PhysicsList/RegisterPhysics G4StepLimiterPhysics
+
+/nexus/RegisterGeometry Next100OpticalGeometry
+
+/nexus/RegisterGenerator Kr83mGenerator
+
+/nexus/RegisterPersistencyManager PersistencyManager
+
+/nexus/RegisterRunAction DefaultRunAction
+/nexus/RegisterEventAction DefaultEventAction
+/nexus/RegisterTrackingAction DefaultTrackingAction
+
+/nexus/RegisterMacro macros/NEXT100opt_ovlp.config.mac

--- a/macros/NextFlex_ovlp.config.mac
+++ b/macros/NextFlex_ovlp.config.mac
@@ -1,0 +1,81 @@
+## ----------------------------------------------------------------------------
+## nexus | NextFlex.config.mac
+##
+## Initialization macro to check overlaps in the NextFlex detector.
+##
+## The NEXT Collaboration
+## ----------------------------------------------------------------------------
+
+### GEOMETRY
+
+# GAS SETTING
+/Geometry/NextFlex/gas              enrichedXe
+/Geometry/NextFlex/gas_pressure     15. bar
+/Geometry/NextFlex/gas_temperature  300. kelvin
+
+# ACTIVE
+/Geometry/NextFlex/active_length      116. cm
+/Geometry/NextFlex/active_diam        100. cm
+
+# FIELD CAGE
+/Geometry/NextFlex/buffer_length    280. mm
+
+/Geometry/NextFlex/cathode_transparency .98
+/Geometry/NextFlex/anode_transparency   .88
+/Geometry/NextFlex/gate_transparency    .88
+
+/Geometry/NextFlex/el_gap_length    10.  mm
+/Geometry/NextFlex/el_field_on      false
+
+/Geometry/NextFlex/fc_wls_mat       TPB
+
+/Geometry/NextFlex/fc_with_fibers   true
+/Geometry/NextFlex/fiber_mat        EJ280
+/Geometry/NextFlex/fiber_claddings  2
+
+# ENERGY PLANE
+/Geometry/NextFlex/ep_with_PMTs         false
+/Geometry/NextFlex/ep_with_teflon       true
+/Geometry/NextFlex/ep_copper_thickness  12. cm
+/Geometry/NextFlex/ep_wls_mat           TPB
+
+# TRACKING PLANE
+/Geometry/NextFlex/tp_copper_thickness  12. cm
+/Geometry/NextFlex/tp_teflon_thickness   5. mm
+/Geometry/NextFlex/tp_teflon_hole_diam   7. mm
+/Geometry/NextFlex/tp_wls_mat           TPB
+/Geometry/NextFlex/tp_kapton_anode_dist 12. mm
+/Geometry/NextFlex/tp_sipm_sizeX        1.3 mm
+/Geometry/NextFlex/tp_sipm_sizeY        1.3 mm
+/Geometry/NextFlex/tp_sipm_sizeZ        2.0 mm
+/Geometry/NextFlex/tp_sipm_pitchX       15. mm
+/Geometry/NextFlex/tp_sipm_pitchY       15. mm
+
+# ICS
+/Geometry/NextFlex/ics_thickness  12. cm
+
+### GENERATOR
+# Kripton
+/Generator/Kr83mGenerator/region  AD_HOC
+/Geometry/NextFlex/specific_vertex  0. 0. 580. mm
+
+
+### PHYSICS
+/PhysicsList/Nexus/clustering           false
+/PhysicsList/Nexus/drift                false
+/PhysicsList/Nexus/electroluminescence  false
+
+
+### VERBOSITY
+/control/verbose   0
+/run/verbose       0
+/event/verbose     0
+/tracking/verbose  0
+
+/process/em/verbose 0
+
+
+### CONTROL
+/nexus/random_seed            -1
+/nexus/persistency/start_id   0
+/nexus/persistency/output_file NextFlex_ovlp.next

--- a/macros/NextFlex_ovlp.init.mac
+++ b/macros/NextFlex_ovlp.init.mac
@@ -1,0 +1,36 @@
+## ----------------------------------------------------------------------------
+## nexus | NextFlex_ovlp.init.mac
+##
+## Initialization macro to check overlaps in the NextFlex detector.
+##
+## The NEXT Collaboration
+## ----------------------------------------------------------------------------
+
+### GEOMETRY
+/nexus/RegisterGeometry NextFlex
+
+
+### GENERATOR
+/nexus/RegisterGenerator Kr83mGenerator
+
+
+### PERSISTENCY MANAGER
+/nexus/RegisterPersistencyManager PersistencyManager
+
+
+### ACTIONS
+/nexus/RegisterRunAction      DefaultRunAction
+/nexus/RegisterEventAction    DefaultEventAction
+/nexus/RegisterTrackingAction DefaultTrackingAction
+
+
+### PHYSICS
+/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
+/PhysicsList/RegisterPhysics G4DecayPhysics
+/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
+/PhysicsList/RegisterPhysics NexusPhysics
+/PhysicsList/RegisterPhysics G4StepLimiterPhysics
+
+
+### EXTRA CONFIGURATION
+/nexus/RegisterMacro macros/NextFlex_ovlp.config.mac

--- a/pytest/macros_test.py
+++ b/pytest/macros_test.py
@@ -20,8 +20,8 @@ def check_list(NEXUSDIR):
     macro_list = [NEXUSDIR + "/macros/DEMOPP_grid.init.mac",
                   NEXUSDIR + "/macros/DEMOPP_plate.init.mac",
                   NEXUSDIR + "/macros/NEW.init.mac",
-                  NEXUSDIR + "/macros/NEXT100.init.mac",
-                  NEXUSDIR + "/macros/NEXT100_full.init.mac",
+                  NEXUSDIR + "/macros/NEXT100_ovlp.init.mac",
+                  NEXUSDIR + "/macros/NEXT100opt_ovlp.init.mac",
                   NEXUSDIR + "/macros/NextFlex_fullKr.init.mac",
                   NEXUSDIR + "/macros/NextTonScale.init.mac",
                   NEXUSDIR + "/macros/black_box.init.mac"]

--- a/pytest/macros_test.py
+++ b/pytest/macros_test.py
@@ -22,7 +22,7 @@ def check_list(NEXUSDIR):
                   NEXUSDIR + "/macros/NEW.init.mac",
                   NEXUSDIR + "/macros/NEXT100_ovlp.init.mac",
                   NEXUSDIR + "/macros/NEXT100opt_ovlp.init.mac",
-                  NEXUSDIR + "/macros/NextFlex_fullKr.init.mac",
+                  NEXUSDIR + "/macros/NextFlex_ovlp.init.mac",
                   NEXUSDIR + "/macros/NextTonScale.init.mac",
                   NEXUSDIR + "/macros/black_box.init.mac"]
 


### PR DESCRIPTION
The automatic tests that perform the overlap checks were taking ages to be executed, since the implementation of stainless steel grids as the default option in NEXT-100. This PR replaces the macros used for the overlap checks with others that use dielectric grids (the other option).