### PR TITLE
Add protection for wrong keys in object factory

### DIFF
--- a/source/base/FactoryBase.h
+++ b/source/base/FactoryBase.h
@@ -43,8 +43,11 @@ public:
     }
   }
 
-  //
   std::unique_ptr<T> CreateObject(const std::string& tag) {
+    if (registry_.find(tag) == registry_.end()) {
+      auto msg = std::string("Unknown key for ") + typeid(T).name() + ": " + tag;
+      G4Exception("ObjFactory::CreateObject()", "", FatalException, msg.c_str());
+    }
     return registry_[tag]->CreateObject();
   }
 


### PR DESCRIPTION
If the wrong name is used for, say, a generator, the user gets a wild segfault with zero information about what went wrong. This PR adds protection against bad strings and provides a more helpful message.

Bear in mind that part of the message is compiler-dependent. There are no guarantees that `typeid(x).name()` gives a human-readable output. Thankfully, most compilers do provide a sensible output, so this might be a good enough compromise between simplicity and correctness.

I also added a test that verifies that the exception is raised.

