### PR TITLE
Generic material properties

### DIFF
--- a/source/generators/ScintillationGenerator.cc
+++ b/source/generators/ScintillationGenerator.cc
@@ -12,7 +12,7 @@
 
 #include "DetectorConstruction.h"
 #include "GeometryBase.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "FactoryBase.h"
 
 #include <G4GenericMessenger.hh>

--- a/source/geometries/BlackBox.cc
+++ b/source/geometries/BlackBox.cc
@@ -13,7 +13,7 @@
 
 #include "MaterialsList.h"
 #include "IonizationSD.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "Visibilities.h"
 
 #include <G4Box.hh>
@@ -120,7 +120,7 @@ namespace nexus {
 
   G4Material* world_mat = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
 
-  world_mat->SetMaterialPropertiesTable(opticalprops::Vacuum());
+  world_mat->SetMaterialPropertiesTable(materialprops::Vacuum());
 
   G4Box* world_solid_vol =
     new G4Box(world_name, world_xy_/2., world_xy_/2., world_z_/2.);
@@ -170,7 +170,7 @@ namespace nexus {
 
     G4Material* sapphire_mat = materials::Sapphire();
 
-    sapphire_mat->SetMaterialPropertiesTable(opticalprops::Sapphire());
+    sapphire_mat->SetMaterialPropertiesTable(materialprops::Sapphire());
 
     G4double pedot_thickn  = 150. *nm;
     G4double window_thickn  = 6. *mm;
@@ -198,7 +198,7 @@ namespace nexus {
 
       G4Material* pedot_mat = materials::PEDOT();
 
-      pedot_mat->SetMaterialPropertiesTable(opticalprops::PEDOT());
+      pedot_mat->SetMaterialPropertiesTable(materialprops::PEDOT());
 
       G4Tubs* pedot_solid_vol =
         new G4Tubs(pedot_name, 0, sapphire_diam/2., pedot_thickn/2., 0, twopi);

--- a/source/geometries/BlackBoxSiPMBoard.cc
+++ b/source/geometries/BlackBoxSiPMBoard.cc
@@ -8,7 +8,7 @@
 
 #include "MaterialsList.h"
 #include "SiPMSensl.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "BoxPointSamplerLegacy.h"
 #include "Visibilities.h"
 
@@ -184,7 +184,7 @@ void BlackBoxSiPMBoard::Construct()
     // Adding the optical surface
     G4OpticalSurface* mask_opsurf =
       new G4OpticalSurface(mask_name, unified, ground, dielectric_metal);
-    mask_opsurf->SetMaterialPropertiesTable(opticalprops::PTFE());
+    mask_opsurf->SetMaterialPropertiesTable(materialprops::PTFE());
     new G4LogicalSkinSurface(mask_name + "_OPSURF", mask_logic, mask_opsurf);
 
     new G4PVPlacement(nullptr, G4ThreeVector(0., 0., mask_posz), mask_logic,

--- a/source/geometries/CylindricChamber.cc
+++ b/source/geometries/CylindricChamber.cc
@@ -11,7 +11,7 @@
 #include "PmtR11410.h"
 #include "NextNewKDB.h"
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "UniformElectricDriftField.h"
 #include "IonizationSD.h"
 #include "FactoryBase.h"
@@ -70,7 +70,7 @@ namespace nexus {
       new G4Tubs("GAS", 0., chamber_diam/2., chamber_length/2., 0., twopi);
 
     G4Material* gxe = materials::GXe(10.*bar);
-    gxe->SetMaterialPropertiesTable(opticalprops::GXe(10.*bar, 303));
+    gxe->SetMaterialPropertiesTable(materialprops::GXe(10.*bar, 303));
 
     G4LogicalVolume* gas_logic = new G4LogicalVolume(gas_solid, gxe, "GAS");
 

--- a/source/geometries/GenericPhotosensor.cc
+++ b/source/geometries/GenericPhotosensor.cc
@@ -10,7 +10,7 @@
 
 #include "MaterialsList.h"
 #include "SensorSD.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "Visibilities.h"
 
 #include <G4Box.hh>
@@ -104,7 +104,7 @@ void GenericPhotosensor::DefineMaterials()
                   "Window rindex set, but NOT USED. Using TPB rindex.");
 
     window_optProp->AddProperty("RINDEX",
-                                opticalprops::TPB()->GetProperty("RINDEX"));
+                                materialprops::TPB()->GetProperty("RINDEX"));
     window_mat_->SetMaterialPropertiesTable(window_optProp);
   }
 
@@ -125,7 +125,7 @@ void GenericPhotosensor::DefineMaterials()
 
   // WLS coating /////
   wls_mat_ = materials::TPB();
-  wls_mat_->SetMaterialPropertiesTable(opticalprops::TPB());
+  wls_mat_->SetMaterialPropertiesTable(materialprops::TPB());
 }
 
 

--- a/source/geometries/GenericWLSFiber.cc
+++ b/source/geometries/GenericWLSFiber.cc
@@ -9,7 +9,7 @@
 #include "GenericWLSFiber.h"
 
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "Visibilities.h"
 
 #include <G4Tubs.hh>
@@ -91,12 +91,12 @@ void GenericWLSFiber::DefineMaterials()
   // FPethylene: for outer in muticladding
 
   iclad_mat_ = materials::PMMA();
-  iclad_mat_->SetMaterialPropertiesTable(opticalprops::PMMA());
+  iclad_mat_->SetMaterialPropertiesTable(materialprops::PMMA());
 
   // If 2 claddings, defining the outer cladding material
   if (doubleclad_) {
     oclad_mat_ = materials::FPethylene();
-    oclad_mat_->SetMaterialPropertiesTable(opticalprops::FPethylene());
+    oclad_mat_->SetMaterialPropertiesTable(materialprops::FPethylene());
   }
 
   // If optical properties of coating are set explicitly, use them
@@ -255,7 +255,7 @@ void GenericWLSFiber::BuildSquareFiber()
       new G4PVPlacement(nullptr, G4ThreeVector(0., 0., 0.), oclad_logic,
                         oclad_name, innermost_logic, false, 0, false);
 
-    innermost_logic = oclad_logic; 
+    innermost_logic = oclad_logic;
   }
 
   // Inner Cladding (always built)

--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -8,7 +8,7 @@
 
 #include "Next100EnergyPlane.h"
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "Visibilities.h"
 #include "CylinderPointSampler.h"
 
@@ -225,7 +225,7 @@ namespace nexus {
     gas_copperplate_opsur->SetModel(unified);
     gas_copperplate_opsur->SetFinish(ground);
     gas_copperplate_opsur->SetSigmaAlpha(0.0);
-    gas_copperplate_opsur->SetMaterialPropertiesTable(opticalprops::Copper());
+    gas_copperplate_opsur->SetMaterialPropertiesTable(materialprops::Copper());
     new G4LogicalSkinSurface("GAS_COPPER_PLATE_OPSURF",
                             copper_plate_logic, gas_copperplate_opsur);
 
@@ -234,14 +234,14 @@ namespace nexus {
 
     /// Assign optical properties to materials ///
     G4Material* sapphire = materials::Sapphire();
-    sapphire->SetMaterialPropertiesTable(opticalprops::Sapphire());
+    sapphire->SetMaterialPropertiesTable(materialprops::Sapphire());
     G4Material* tpb = materials::TPB();
-    tpb->SetMaterialPropertiesTable(opticalprops::TPB());
+    tpb->SetMaterialPropertiesTable(materialprops::TPB());
     G4Material* vacuum =
       G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic");
-    vacuum->SetMaterialPropertiesTable(opticalprops::Vacuum());
+    vacuum->SetMaterialPropertiesTable(materialprops::Vacuum());
     G4Material* optical_coupler = materials::OpticalSilicone();
-    optical_coupler->SetMaterialPropertiesTable(opticalprops::OptCoupler());
+    optical_coupler->SetMaterialPropertiesTable(materialprops::OptCoupler());
 
 
     /// Vacuum volume that encapsulates all elements related to PMTs. ///

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -11,7 +11,7 @@
 #include "MaterialsList.h"
 #include "Visibilities.h"
 #include "IonizationSD.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "UniformElectricDriftField.h"
 #include "XenonProperties.h"
 #include "CylinderPointSampler.h"
@@ -273,7 +273,7 @@ void Next100FieldCage::DefineMaterials()
 
   /// TPB coating
   tpb_ = materials::TPB();
-  tpb_->SetMaterialPropertiesTable(opticalprops::TPB());
+  tpb_->SetMaterialPropertiesTable(materialprops::TPB());
 
   /// Steel
   steel_ = materials::Steel316Ti();
@@ -369,7 +369,7 @@ void Next100FieldCage::BuildCathode()
   G4LogicalVolume* cathode_logic;
 
   G4Material* fgrid_mat = materials::FakeDielectric(gas_, "cath_grid_mat");
-  fgrid_mat->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_,
+  fgrid_mat->SetMaterialPropertiesTable(materialprops::FakeGrid(pressure_,
                                                                temperature_,
                                                                cath_grid_transparency_,
                                                                grid_thickn_));
@@ -448,7 +448,7 @@ void Next100FieldCage::BuildCathode()
       gas_mesh_opsur->SetModel(unified);
       gas_mesh_opsur->SetFinish(ground);
       gas_mesh_opsur->SetSigmaAlpha(0.0);
-      gas_mesh_opsur->SetMaterialPropertiesTable(opticalprops::Steel());
+      gas_mesh_opsur->SetMaterialPropertiesTable(materialprops::Steel());
       new G4LogicalSkinSurface("GAS_CATHODE_MESH_OPSURF",
                               cathode_grid_logic, gas_mesh_opsur);
 
@@ -613,7 +613,7 @@ void Next100FieldCage::BuildELRegion()
 
     /// EL grids
     G4Material* fgrid_mat = materials::FakeDielectric(gas_, "el_grid_mat");
-    fgrid_mat->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_,
+    fgrid_mat->SetMaterialPropertiesTable(materialprops::FakeGrid(pressure_,
                                                                temperature_,
                                                                el_grid_transparency_,
                                                                grid_thickn_,
@@ -688,7 +688,7 @@ void Next100FieldCage::BuildELRegion()
     gas_mesh_opsur->SetModel(unified);
     gas_mesh_opsur->SetFinish(ground);
     gas_mesh_opsur->SetSigmaAlpha(0.0);
-    gas_mesh_opsur->SetMaterialPropertiesTable(opticalprops::Steel());
+    gas_mesh_opsur->SetMaterialPropertiesTable(materialprops::Steel());
     new G4LogicalSkinSurface("GAS_EL_MESH_OPSURF",
                              el_grid_logic, gas_mesh_opsur);
 
@@ -873,7 +873,7 @@ void Next100FieldCage::BuildLightTube()
   /// Optical surface on teflon ///
   G4OpticalSurface* refl_Surf =
     new G4OpticalSurface("refl_Surf", unified, ground, dielectric_metal, .01);
-  refl_Surf->SetMaterialPropertiesTable(opticalprops::PTFE());
+  refl_Surf->SetMaterialPropertiesTable(materialprops::PTFE());
   new G4LogicalSkinSurface("refl_teflon_surf", teflon_drift_logic, refl_Surf);
   new G4LogicalSkinSurface("refl_teflon_surf", teflon_buffer_logic, refl_Surf);
 

--- a/source/geometries/Next100OpticalGeometry.cc
+++ b/source/geometries/Next100OpticalGeometry.cc
@@ -9,7 +9,7 @@
 
 #include "Next100OpticalGeometry.h"
 #include "Next100InnerElements.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "MaterialsList.h"
 #include "FactoryBase.h"
 
@@ -105,19 +105,19 @@ namespace nexus {
 
   if (gas_ == "naturalXe") {
     gas_mat = materials::GXe(pressure_, temperature_);
-    gas_mat->SetMaterialPropertiesTable(opticalprops::GXe(pressure_,
+    gas_mat->SetMaterialPropertiesTable(materialprops::GXe(pressure_,
                                                           temperature_,
                                                           sc_yield_,
                                                           e_lifetime_));
   } else if (gas_ == "enrichedXe") {
     gas_mat =  materials::GXeEnriched(pressure_, temperature_);
-    gas_mat->SetMaterialPropertiesTable(opticalprops::GXe(pressure_,
+    gas_mat->SetMaterialPropertiesTable(materialprops::GXe(pressure_,
                                                           temperature_,
                                                           sc_yield_,
                                                           e_lifetime_));
   } else if  (gas_ == "depletedXe") {
     gas_mat =  materials::GXeDepleted(pressure_, temperature_);
-    gas_mat->SetMaterialPropertiesTable(opticalprops::GXe(pressure_,
+    gas_mat->SetMaterialPropertiesTable(materialprops::GXe(pressure_,
                                                           temperature_,
                                                           sc_yield_,
                                                           e_lifetime_));

--- a/source/geometries/Next100SiPM.cc
+++ b/source/geometries/Next100SiPM.cc
@@ -10,7 +10,7 @@
 #include "Next100SiPM.h"
 
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "Visibilities.h"
 #include "SensorSD.h"
 
@@ -82,7 +82,7 @@ void Next100SiPM::Construct()
       new G4Box(coating_name, sipm_width/2., sipm_length/2., coating_thickn_/2.);
 
     G4Material* coating_mt = materials::TPB();
-    coating_mt->SetMaterialPropertiesTable(opticalprops::TPB());
+    coating_mt->SetMaterialPropertiesTable(materialprops::TPB());
 
     G4LogicalVolume* coating_logic_vol =
       new G4LogicalVolume(coating_solid_vol, coating_mt, coating_name);
@@ -112,7 +112,7 @@ void Next100SiPM::Construct()
   G4double window_zpos   = sipm_thickn/2. - coating_thickn_ - window_thickn/2.;
 
   G4Material* optical_silicone = materials::OpticalSilicone();
-  optical_silicone->SetMaterialPropertiesTable(opticalprops::Epoxy());
+  optical_silicone->SetMaterialPropertiesTable(materialprops::Epoxy());
 
   G4Box* window_solid_vol =
     new G4Box(window_name, window_width/2., window_length/2., window_thickn/2.);

--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -11,7 +11,7 @@
 #include "Next100SiPMBoard.h"
 
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "BoxPointSampler.h"
 #include "Visibilities.h"
 #include "Next100SiPM.h"
@@ -124,7 +124,7 @@ void Next100SiPMBoard::Construct()
 
   G4OpticalSurface* mask_opsurf =
     new G4OpticalSurface(mask_name+"_OPSURF", unified, ground, dielectric_metal);
-  mask_opsurf->SetMaterialPropertiesTable(opticalprops::PTFE());
+  mask_opsurf->SetMaterialPropertiesTable(materialprops::PTFE());
   new G4LogicalSkinSurface(mask_name+"_OPSURF", mask_logic_vol, mask_opsurf);
 
 
@@ -138,7 +138,7 @@ void Next100SiPMBoard::Construct()
     new G4Box(mask_wls_name, size_/2., size_/2., wls_thickness/2.);
 
   G4Material* tpb = materials::TPB();
-  tpb->SetMaterialPropertiesTable(opticalprops::TPB());
+  tpb->SetMaterialPropertiesTable(materialprops::TPB());
 
   G4LogicalVolume* mask_wls_logic_vol =
     new G4LogicalVolume(mask_wls_solid_vol, tpb, mask_wls_name);

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -9,7 +9,7 @@
 #include "Next100Vessel.h"
 #include "MaterialsList.h"
 #include "Visibilities.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "CylinderPointSampler.h"
 #include "SpherePointSampler.h"
 #include "Next100Th228Source.h"
@@ -348,7 +348,7 @@ namespace nexus {
                   "natural, enriched, depleted, or XeHe.");
     }
 
-    vessel_gas_mat->SetMaterialPropertiesTable(opticalprops::GXe(pressure_,
+    vessel_gas_mat->SetMaterialPropertiesTable(materialprops::GXe(pressure_,
                                                                  temperature_,
                                                                  sc_yield_,
                                                                  e_lifetime_));

--- a/source/geometries/Next1EL.cc
+++ b/source/geometries/Next1EL.cc
@@ -9,7 +9,7 @@
 #include "Next1EL.h"
 
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "PmtR7378A.h"
 #include "IonizationSD.h"
 #include "PolygonPointSampler.h"
@@ -258,7 +258,7 @@ void Next1EL::DefineMaterials()
   air_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
   // GASEOUS XENON
   gxe_ = materials::GXe(pressure_, 303);
-  gxe_->SetMaterialPropertiesTable(opticalprops::GXe(pressure_, 303, sc_yield_, e_lifetime_));
+  gxe_->SetMaterialPropertiesTable(materialprops::GXe(pressure_, 303, sc_yield_, e_lifetime_));
   // PTFE (TEFLON)
   teflon_ = G4NistManager::Instance()->FindOrBuildMaterial("G4_TEFLON");
   teflon_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
@@ -276,7 +276,7 @@ void Next1EL::DefineMaterials()
   plastic_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
   //TPB
   tpb_ = materials::TPB();
-  tpb_->SetMaterialPropertiesTable(opticalprops::TPB());
+  tpb_->SetMaterialPropertiesTable(materialprops::TPB());
 }
 
 
@@ -741,11 +741,11 @@ void Next1EL::BuildFieldCage()
   G4double diel_thickn = .1*mm;
 
   G4Material* fgrid = materials::FakeDielectric(gxe_, "grid_mat");
-  fgrid->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_, 303,
+  fgrid->SetMaterialPropertiesTable(materialprops::FakeGrid(pressure_, 303,
                                                            elgrid_transparency_,
                                                            diel_thickn, sc_yield_));
   G4Material* fgrid_gate = materials::FakeDielectric(gxe_, "grid_mat");
-  fgrid_gate->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_, 303,
+  fgrid_gate->SetMaterialPropertiesTable(materialprops::FakeGrid(pressure_, 303,
                                                                 gate_transparency_,
                                                                 diel_thickn, sc_yield_));
 
@@ -936,7 +936,7 @@ void Next1EL::BuildFieldCage()
   G4double transparency = 0.98;
 
   G4Material* fcathode = materials::FakeDielectric(gxe_, "cathode_mat");
-  fcathode->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_, 303,
+  fcathode->SetMaterialPropertiesTable(materialprops::FakeGrid(pressure_, 303,
   									transparency, diel_thickn, sc_yield_, e_lifetime_));
 
   G4Tubs* diel_cathd =
@@ -995,14 +995,14 @@ void Next1EL::BuildFieldCage()
   ltubeup_opsur->SetModel(unified);
   ltubeup_opsur->SetFinish(ground);
   ltubeup_opsur->SetSigmaAlpha(0.1);
-  ltubeup_opsur->SetMaterialPropertiesTable(opticalprops::PTFE());
+  ltubeup_opsur->SetMaterialPropertiesTable(materialprops::PTFE());
 
   G4OpticalSurface* ltubebt_opsur = new G4OpticalSurface("LIGHT_TUBE_BOTTOM");
   ltubebt_opsur->SetType(dielectric_metal);
   ltubebt_opsur->SetModel(unified);
   ltubebt_opsur->SetFinish(ground);
   ltubebt_opsur->SetSigmaAlpha(0.1);
-  ltubebt_opsur->SetMaterialPropertiesTable(opticalprops::PTFE());
+  ltubebt_opsur->SetMaterialPropertiesTable(materialprops::PTFE());
 
   new G4LogicalSkinSurface("LIGHT_TUBE_UP",     ltube_up_logic, ltubeup_opsur);
   new G4LogicalSkinSurface("LIGHT_TUBE_BOTTOM", ltube_bt_logic, ltubebt_opsur);
@@ -1105,7 +1105,7 @@ void Next1EL::BuildEnergyPlane()
   pmtholder_cath_opsur->SetModel(unified);
   pmtholder_cath_opsur->SetFinish(ground);
   pmtholder_cath_opsur->SetSigmaAlpha(0.1);
-  pmtholder_cath_opsur->SetMaterialPropertiesTable(opticalprops::PTFE());
+  pmtholder_cath_opsur->SetMaterialPropertiesTable(materialprops::PTFE());
 
   new G4LogicalSkinSurface("PMT_HOLDER_CATHODE", pmtholder_logic, pmtholder_cath_opsur);
 
@@ -1116,7 +1116,7 @@ void Next1EL::BuildEnergyPlane()
   G4double transparency = 0.96;
 
   G4Material* fshield = materials::FakeDielectric(gxe_, "shield_mat");
-  fshield->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_, 303,
+  fshield->SetMaterialPropertiesTable(materialprops::FakeGrid(pressure_, 303,
   									transparency, shield_thickn, sc_yield_, e_lifetime_));
 
   G4Tubs* shield_solid =
@@ -1333,7 +1333,7 @@ void Next1EL::BuildPMTTrackingPlane()
   pmtholder_anode_opsur->SetModel(unified);
   pmtholder_anode_opsur->SetFinish(ground);
   pmtholder_anode_opsur->SetSigmaAlpha(0.1);
-  pmtholder_anode_opsur->SetMaterialPropertiesTable(opticalprops::PTFE());
+  pmtholder_anode_opsur->SetMaterialPropertiesTable(materialprops::PTFE());
 
   new G4LogicalSkinSurface("PMT_HOLDER_ANODE", pmtholder_logic, pmtholder_anode_opsur);
 }
@@ -1422,7 +1422,7 @@ void Next1EL::CalculateELTableVertices(G4double radius,
 }
 
 
-void Next1EL::TesselateWithFixedPitch (G4double pitch, std::vector<G4ThreeVector>& vpos, 
+void Next1EL::TesselateWithFixedPitch (G4double pitch, std::vector<G4ThreeVector>& vpos,
                                       G4double apothem, G4ThreeVector origin, G4RotationMatrix* rotation) {
   G4double cell_radius = pitch / sqrt(3.);
   G4double cell_apothem = sqrt(3.)/2. * cell_radius;
@@ -1436,7 +1436,7 @@ void Next1EL::TesselateWithFixedPitch (G4double pitch, std::vector<G4ThreeVector
 }
 
 void Next1EL::PlaceCells(std::vector<G4ThreeVector>& vp, G4int order, G4double cell_apothem, G4ThreeVector origin, G4RotationMatrix* rotation){
-  
+
   // Place the central cell
   G4ThreeVector position(0.,0.,0.);
   vp.push_back(RotateAndTranslate(position, origin, rotation));
@@ -1460,7 +1460,7 @@ void Next1EL::PlaceCells(std::vector<G4ThreeVector>& vp, G4int order, G4double c
       // the honeycomb.
       for (G4int j=0; j<5; j++)
         vp.push_back(RotateAndTranslate(position.rotateZ(pi/3.), origin, rotation));
-    
+
     }
   }
 }

--- a/source/geometries/Next1ELDBO.cc
+++ b/source/geometries/Next1ELDBO.cc
@@ -10,7 +10,7 @@
 
 #include "SiPM11.h"
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 
 #include <G4Box.hh>
 #include <G4NistManager.hh>
@@ -79,7 +79,7 @@ namespace nexus {
       new G4Box("WLS_COATING", dbo_x/2., dbo_y/2., coating_thickn/2.);
 
     G4Material* TPB = materials::TPB();
-    TPB->SetMaterialPropertiesTable(opticalprops::TPB());
+    TPB->SetMaterialPropertiesTable(materialprops::TPB());
 
     G4LogicalVolume* coating_logic =
       new G4LogicalVolume(coating_solid, TPB, "WLS_COATING");
@@ -120,7 +120,7 @@ namespace nexus {
     dboard_opsur->SetModel(unified);
     dboard_opsur->SetFinish(ground);
     dboard_opsur->SetSigmaAlpha(0.1);
-    dboard_opsur->SetMaterialPropertiesTable(opticalprops::PTFE());
+    dboard_opsur->SetMaterialPropertiesTable(materialprops::PTFE());
 
     new G4LogicalSkinSurface("DBO", board_logic, dboard_opsur);
 

--- a/source/geometries/NextDemoEnergyPlane.cc
+++ b/source/geometries/NextDemoEnergyPlane.cc
@@ -8,7 +8,7 @@
 
 #include "NextDemoEnergyPlane.h"
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "Visibilities.h"
 
 #include <G4GenericMessenger.hh>
@@ -136,23 +136,23 @@ namespace nexus {
 
     /// Assign optical properties to materials ///
     G4Material* tpb = materials::TPB();
-    tpb->SetMaterialPropertiesTable(opticalprops::TPB());
+    tpb->SetMaterialPropertiesTable(materialprops::TPB());
 
     G4Material* sapphire = materials::Sapphire();
-    sapphire->SetMaterialPropertiesTable(opticalprops::Sapphire());
+    sapphire->SetMaterialPropertiesTable(materialprops::Sapphire());
 
     G4Material* copper = G4NistManager::Instance()->FindOrBuildMaterial("G4_Cu");
     copper->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
     G4Material* vacuum =
       G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic");
-    vacuum->SetMaterialPropertiesTable(opticalprops::Vacuum());
+    vacuum->SetMaterialPropertiesTable(materialprops::Vacuum());
 
     G4Material* optical_coupler = materials::OpticalSilicone();
-    optical_coupler->SetMaterialPropertiesTable(opticalprops::OptCoupler());
+    optical_coupler->SetMaterialPropertiesTable(materialprops::OptCoupler());
 
     G4Material* pedot = materials::PEDOT();
-    pedot->SetMaterialPropertiesTable(opticalprops::PEDOT());
+    pedot->SetMaterialPropertiesTable(materialprops::PEDOT());
 
     /// A volume of vacuum is constructed to hold the elements ///
     /// that are replicated ///

--- a/source/geometries/NextDemoFieldCage.cc
+++ b/source/geometries/NextDemoFieldCage.cc
@@ -9,7 +9,7 @@
 
 #include "NextDemoFieldCage.h"
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "IonizationSD.h"
 #include "UniformElectricDriftField.h"
 #include "XenonProperties.h"
@@ -236,15 +236,15 @@ namespace nexus {
 
     /// Quartz
     quartz_ =  materials::FusedSilica();
-    quartz_->SetMaterialPropertiesTable(opticalprops::FusedSilica());
+    quartz_->SetMaterialPropertiesTable(materialprops::FusedSilica());
 
     /// TPB coating
     tpb_ = materials::TPB();
-    tpb_->SetMaterialPropertiesTable(opticalprops::TPB());
+    tpb_->SetMaterialPropertiesTable(materialprops::TPB());
 
     //ITO coating
     ito_ = materials::ITO();
-    ito_->SetMaterialPropertiesTable(opticalprops::ITO());
+    ito_->SetMaterialPropertiesTable(materialprops::ITO());
   }
 
 
@@ -296,7 +296,7 @@ namespace nexus {
   {
     G4Material* cathode_mat =
       materials::FakeDielectric(gas_, "cathode_mat");
-    cathode_mat->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_,
+    cathode_mat->SetMaterialPropertiesTable(materialprops::FakeGrid(pressure_,
                                                                    temperature_,
                                                                    cathode_transparency_,
                                                                    grid_thickn_));
@@ -394,7 +394,7 @@ namespace nexus {
 
     // Building the GATE
     G4Material* gate_mat = materials::FakeDielectric(gas_, "gate_mat");
-    gate_mat->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_,
+    gate_mat->SetMaterialPropertiesTable(materialprops::FakeGrid(pressure_,
                                                                 temperature_,
                                                                 gate_transparency_,
                                                                 grid_thickn_,
@@ -467,7 +467,7 @@ namespace nexus {
     // Building the ANODE grid corresponding to "run7" and "run8" configuration
     else {
       G4Material* anode_mat = materials::FakeDielectric(gas_, "anode_mat");
-      anode_mat->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_,
+      anode_mat->SetMaterialPropertiesTable(materialprops::FakeGrid(pressure_,
                                                                    temperature_,
                                                                    anode_transparency_,
                                                                    grid_thickn_,
@@ -569,7 +569,7 @@ namespace nexus {
     lt_drift_opsur->SetModel(unified);
     lt_drift_opsur->SetFinish(ground);
     lt_drift_opsur->SetSigmaAlpha(0.1);
-    lt_drift_opsur->SetMaterialPropertiesTable(opticalprops::PTFE());
+    lt_drift_opsur->SetMaterialPropertiesTable(materialprops::PTFE());
     new G4LogicalSkinSurface("LIGHT_TUBE_DRIFT",
                              light_tube_drift_logic, lt_drift_opsur);
 
@@ -578,7 +578,7 @@ namespace nexus {
     lt_buff_opsur->SetModel(unified);
     lt_buff_opsur->SetFinish(ground);
     lt_buff_opsur->SetSigmaAlpha(0.1);
-    lt_buff_opsur->SetMaterialPropertiesTable(opticalprops::PTFE());
+    lt_buff_opsur->SetMaterialPropertiesTable(materialprops::PTFE());
     new G4LogicalSkinSurface("LIGHT_TUBE_BUFFER",
                              light_tube_buff_logic, lt_buff_opsur);
 

--- a/source/geometries/NextDemoSiPMBoard.cc
+++ b/source/geometries/NextDemoSiPMBoard.cc
@@ -17,7 +17,7 @@
 #include "MaterialsList.h"
 #include "SiPMSensl.h"
 #include "Next100SiPM.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "BoxPointSamplerLegacy.h"
 #include "Visibilities.h"
 
@@ -209,7 +209,7 @@ void NextDemoSiPMBoard::Construct()
   // Adding the optical surface
   G4OpticalSurface* mask_opsurf =
     new G4OpticalSurface(mask_name, unified, ground, dielectric_metal);
-  mask_opsurf->SetMaterialPropertiesTable(opticalprops::PTFE());
+  mask_opsurf->SetMaterialPropertiesTable(materialprops::PTFE());
   new G4LogicalSkinSurface(mask_name + "_OPSURF", mask_logic, mask_opsurf);
 
   new G4PVPlacement(nullptr, G4ThreeVector(0., 0., mask_posz), mask_logic,
@@ -219,7 +219,7 @@ void NextDemoSiPMBoard::Construct()
   /// Mask Holes
   G4String coating_name = "BOARD_COATING";
   G4Material* tpb = materials::TPB();
-    tpb->SetMaterialPropertiesTable(opticalprops::TPB());
+    tpb->SetMaterialPropertiesTable(materialprops::TPB());
   G4OpticalSurface* coating_opsurf =
     new G4OpticalSurface(coating_name + "_OPSURF", glisur, ground,
                          dielectric_dielectric, .01);

--- a/source/geometries/NextDemoVessel.cc
+++ b/source/geometries/NextDemoVessel.cc
@@ -9,7 +9,7 @@
 #include "NextDemoVessel.h"
 
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 
 #include <G4GenericMessenger.hh>
 #include <G4UnitsTable.hh>
@@ -104,7 +104,7 @@ void NextDemoVessel::Construct()
   G4String gas_name = "GAS";
 
   G4Material* gas_material = materials::GXe(gas_pressure_, gas_temperature_);
-  gas_material->SetMaterialPropertiesTable(opticalprops::GXe(gas_pressure_,
+  gas_material->SetMaterialPropertiesTable(materialprops::GXe(gas_pressure_,
                                                              gas_temperature_,
                                                              sc_yield_,
                                                              e_lifetime_));

--- a/source/geometries/NextElDB.cc
+++ b/source/geometries/NextElDB.cc
@@ -8,7 +8,7 @@
 
 #include "NextElDB.h"
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "SiPM11.h"
 
 #include <G4Box.hh>
@@ -81,7 +81,7 @@ namespace nexus {
       new G4Box("DB_WLS_COATING", dbo_x/2., dbo_y/2., coating_thickn/2.);
 
     G4Material* TPB = materials::TPB();
-    TPB->SetMaterialPropertiesTable(opticalprops::TPB());
+    TPB->SetMaterialPropertiesTable(materialprops::TPB());
 
     G4LogicalVolume* coating_logic =
       new G4LogicalVolume(coating_solid, TPB, "DB_WLS_COATING");
@@ -122,7 +122,7 @@ namespace nexus {
     dboard_opsur->SetModel(unified);
     dboard_opsur->SetFinish(ground);
     dboard_opsur->SetSigmaAlpha(0.1);
-    dboard_opsur->SetMaterialPropertiesTable(opticalprops::PTFE());
+    dboard_opsur->SetMaterialPropertiesTable(materialprops::PTFE());
 
     new G4LogicalSkinSurface("DB", board_logic, dboard_opsur);
 

--- a/source/geometries/NextFlex.cc
+++ b/source/geometries/NextFlex.cc
@@ -16,7 +16,7 @@
 #include "NextFlexTrackingPlane.h"
 
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "XenonProperties.h"
 #include "CylinderPointSampler.h"
 #include "Visibilities.h"
@@ -164,7 +164,7 @@ void NextFlex::DefineMaterials()
     "Unknown xenon gas type. Valid options are naturalXe, enrichedXe or depletedXe.");
 
   xenon_gas_->
-    SetMaterialPropertiesTable(opticalprops::GXe(gas_pressure_,
+    SetMaterialPropertiesTable(materialprops::GXe(gas_pressure_,
                                                               gas_temperature_,
                                                               sc_yield_,
                                                               e_lifetime_));

--- a/source/geometries/NextFlexEnergyPlane.cc
+++ b/source/geometries/NextFlexEnergyPlane.cc
@@ -9,7 +9,7 @@
 #include "NextFlexEnergyPlane.h"
 
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "XenonProperties.h"
 #include "PmtR11410.h"
 #include "IonizationSD.h"
@@ -151,11 +151,11 @@ void NextFlexEnergyPlane::DefineMaterials()
 
   // Sapphire
   sapphire_mat_ = materials::Sapphire();
-  sapphire_mat_->SetMaterialPropertiesTable(opticalprops::Sapphire());
+  sapphire_mat_->SetMaterialPropertiesTable(materialprops::Sapphire());
 
   // Optical coupler
   optical_pad_mat_ = materials::OpticalSilicone();
-  optical_pad_mat_->SetMaterialPropertiesTable(opticalprops::OptCoupler());
+  optical_pad_mat_->SetMaterialPropertiesTable(materialprops::OptCoupler());
 
 
   // UV shifting material
@@ -164,11 +164,11 @@ void NextFlexEnergyPlane::DefineMaterials()
   }
   else if (wls_matName_ == "TPB") {
     wls_mat_ = materials::TPB();
-    wls_mat_->SetMaterialPropertiesTable(opticalprops::TPB());
+    wls_mat_->SetMaterialPropertiesTable(materialprops::TPB());
   }
   else if (wls_matName_ == "TPH") {
     wls_mat_ = materials::TPH();
-    wls_mat_->SetMaterialPropertiesTable(opticalprops::TPH());
+    wls_mat_->SetMaterialPropertiesTable(materialprops::TPH());
   }
   else {
     G4Exception("[NextFlexEnergyPlane]", "DefineMaterials()", FatalException,
@@ -268,7 +268,7 @@ void NextFlexEnergyPlane::BuildTeflon()
   G4OpticalSurface* teflon_optSurf =
     new G4OpticalSurface(teflon_name, unified, ground, dielectric_metal);
 
-  teflon_optSurf->SetMaterialPropertiesTable(opticalprops::PTFE());
+  teflon_optSurf->SetMaterialPropertiesTable(materialprops::PTFE());
 
   new G4LogicalSkinSurface(teflon_name, teflon_logic, teflon_optSurf);
 

--- a/source/geometries/NextFlexFieldCage.cc
+++ b/source/geometries/NextFlexFieldCage.cc
@@ -9,7 +9,7 @@
 #include "NextFlexFieldCage.h"
 
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "XenonProperties.h"
 #include "IonizationSD.h"
 #include "UniformElectricDriftField.h"
@@ -300,11 +300,11 @@ void NextFlexFieldCage::DefineMaterials()
   }
   else if (wls_mat_name_ == "TPB") {
     wls_mat_ = materials::TPB();
-    wls_mat_->SetMaterialPropertiesTable(opticalprops::TPB());
+    wls_mat_->SetMaterialPropertiesTable(materialprops::TPB());
   }
   else if (wls_mat_name_ == "TPH") {
     wls_mat_ = materials::TPH();
-    wls_mat_->SetMaterialPropertiesTable(opticalprops::TPH());
+    wls_mat_->SetMaterialPropertiesTable(materialprops::TPH());
   }
   else {
     G4Exception("[NextFlexFieldCage]", "DefineMaterials()", FatalException,
@@ -313,17 +313,17 @@ void NextFlexFieldCage::DefineMaterials()
 
   // Meshes materials
   cathode_mat_ = materials::FakeDielectric(xenon_gas_, "cathode_mat");
-  cathode_mat_->SetMaterialPropertiesTable(opticalprops::FakeGrid(gas_pressure_,
+  cathode_mat_->SetMaterialPropertiesTable(materialprops::FakeGrid(gas_pressure_,
                 gas_temperature_, cathode_transparency_, cathode_thickness_,
                 gas_sc_yield_, gas_e_lifetime_));
 
   gate_mat_ = materials::FakeDielectric(xenon_gas_, "gate_mat");
-  gate_mat_->SetMaterialPropertiesTable(opticalprops::FakeGrid(gas_pressure_,
+  gate_mat_->SetMaterialPropertiesTable(materialprops::FakeGrid(gas_pressure_,
              gas_temperature_, gate_transparency_, gate_thickness_,
              gas_sc_yield_, 1000*ms, photoe_prob_));
 
   anode_mat_ = materials::FakeDielectric(xenon_gas_, "anode_mat");
-  anode_mat_->SetMaterialPropertiesTable(opticalprops::FakeGrid(gas_pressure_,
+  anode_mat_->SetMaterialPropertiesTable(materialprops::FakeGrid(gas_pressure_,
               gas_temperature_, anode_transparency_, anode_thickness_,
               gas_sc_yield_, 1000*ms, photoe_prob_));
 
@@ -331,15 +331,15 @@ void NextFlexFieldCage::DefineMaterials()
   // Fiber core material
   if (fiber_mat_name_ == "EJ280") {
     fiber_mat_ = materials::PVT();
-    fiber_mat_->SetMaterialPropertiesTable(opticalprops::EJ280());
+    fiber_mat_->SetMaterialPropertiesTable(materialprops::EJ280());
   }
   else if (fiber_mat_name_ == "EJ286") {
     fiber_mat_ = materials::PVT();   // Same base material than EJ280
-    fiber_mat_->SetMaterialPropertiesTable(opticalprops::EJ286());
+    fiber_mat_->SetMaterialPropertiesTable(materialprops::EJ286());
   }
   else if (fiber_mat_name_ == "Y11") {
     fiber_mat_ = materials::PS();
-    fiber_mat_->SetMaterialPropertiesTable(opticalprops::Y11());
+    fiber_mat_->SetMaterialPropertiesTable(materialprops::Y11());
   }
   else {
     G4Exception("[NextFlexFieldCage]", "DefineMaterials()", FatalException,
@@ -348,10 +348,10 @@ void NextFlexFieldCage::DefineMaterials()
 
   // Fiber cladding materials (inner: PMMA  outer: FPethylene)
   oClad_mat_ = materials::FPethylene();
-  oClad_mat_->SetMaterialPropertiesTable(opticalprops::FPethylene());
+  oClad_mat_->SetMaterialPropertiesTable(materialprops::FPethylene());
 
   iClad_mat_ = materials::PMMA();
-  iClad_mat_->SetMaterialPropertiesTable(opticalprops::PMMA());
+  iClad_mat_->SetMaterialPropertiesTable(materialprops::PMMA());
 }
 
 
@@ -666,7 +666,7 @@ void NextFlexFieldCage::BuildLightTube()
   // Adding the optical surface
   G4OpticalSurface* light_tube_optSurf =
     new G4OpticalSurface(light_tube_name, unified, ground, dielectric_metal);
-  light_tube_optSurf->SetMaterialPropertiesTable(opticalprops::PTFE());
+  light_tube_optSurf->SetMaterialPropertiesTable(materialprops::PTFE());
 
   new G4LogicalSkinSurface(light_tube_name, light_tube_logic, light_tube_optSurf);
 

--- a/source/geometries/NextFlexTrackingPlane.cc
+++ b/source/geometries/NextFlexTrackingPlane.cc
@@ -9,7 +9,7 @@
 #include "NextFlexTrackingPlane.h"
 
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "XenonProperties.h"
 #include "IonizationSD.h"
 #include "UniformElectricDriftField.h"
@@ -212,11 +212,11 @@ void NextFlexTrackingPlane::DefineMaterials()
   }
   else if (wls_mat_name_ == "TPB") {
     wls_mat_ = materials::TPB();
-    wls_mat_->SetMaterialPropertiesTable(opticalprops::TPB());
+    wls_mat_->SetMaterialPropertiesTable(materialprops::TPB());
   }
   else if (wls_mat_name_ == "TPH") {
     wls_mat_ = materials::TPH();
-    wls_mat_->SetMaterialPropertiesTable(opticalprops::TPH());
+    wls_mat_->SetMaterialPropertiesTable(materialprops::TPH());
   }
   else {
     G4Exception("[NextFlexTrackingPlane]", "DefineMaterials()", FatalException,
@@ -325,7 +325,7 @@ void NextFlexTrackingPlane::BuildTeflon()
   // Adding the teflon optical surface
   G4OpticalSurface* teflon_optSurf =
     new G4OpticalSurface(teflon_name, unified, ground, dielectric_metal);
-  teflon_optSurf->SetMaterialPropertiesTable(opticalprops::PTFE());
+  teflon_optSurf->SetMaterialPropertiesTable(materialprops::PTFE());
 
   new G4LogicalSkinSurface(teflon_name, teflon_logic, teflon_optSurf);
 
@@ -334,13 +334,13 @@ void NextFlexTrackingPlane::BuildTeflon()
   G4String teflon_wls_name = "TP_TEFLON_WLS";
 
   G4double teflon_wls_posZ = teflon_thickness_/2. - wls_thickness_/2.;
- 
+
   G4Tubs* teflon_wls_nh_solid =
     new G4Tubs(teflon_wls_name + "_NOHOLE", 0., diameter_/2.,
 	       wls_thickness_/2., 0, twopi);
 
   // Making the TEFLON_WLS holes (a little bit thicker to prevent subtraction problems)
-  G4Tubs* wls_hole_solid = 
+  G4Tubs* wls_hole_solid =
     new G4Tubs(teflon_wls_name + "_HOLE", 0., teflon_hole_diam_/2.,
 	       wls_thickness_/2. + 0.5*mm, 0, twopi);
 
@@ -348,12 +348,12 @@ void NextFlexTrackingPlane::BuildTeflon()
 
   for (G4int i=0; i<num_SiPMs_; i++){
     G4Transform3D wls_hole_transform = G4Transform3D(rotm, SiPM_positions_[i]);
-    wls_holes_solid->AddNode(*wls_hole_solid, wls_hole_transform); 
+    wls_holes_solid->AddNode(*wls_hole_solid, wls_hole_transform);
   }
   wls_holes_solid->Voxelize();
 
-  G4SubtractionSolid* teflon_wls_solid = 
-    new G4SubtractionSolid(teflon_wls_name, teflon_wls_nh_solid, wls_holes_solid);	  
+  G4SubtractionSolid* teflon_wls_solid =
+    new G4SubtractionSolid(teflon_wls_name, teflon_wls_nh_solid, wls_holes_solid);
 
   G4LogicalVolume* teflon_wls_logic =
     new G4LogicalVolume(teflon_wls_solid, wls_mat_, teflon_wls_name);
@@ -439,10 +439,10 @@ void NextFlexTrackingPlane::BuildSiPMs()
     sipm_pos.setZ(SiPM_pos_z);
     new G4PVPlacement(nullptr, sipm_pos, SiPM_logic, SiPM_logic->GetName(),
 		      mother_logic_, true, SiPM_id, sipm_verbosity_);
-    if (sipm_verbosity_) 
-      G4cout << "* TP_SiPM " << SiPM_id << " position: " 
+    if (sipm_verbosity_)
+      G4cout << "* TP_SiPM " << SiPM_id << " position: "
 	     << sipm_pos << G4endl;
-  }	  
+  }
 }
 
 

--- a/source/geometries/NextNewEnergyPlane.cc
+++ b/source/geometries/NextNewEnergyPlane.cc
@@ -8,7 +8,7 @@
 
 #include "NextNewEnergyPlane.h"
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "Visibilities.h"
 #include "CylinderPointSamplerLegacy.h"
 
@@ -120,7 +120,7 @@ namespace nexus {
     // // Material is vacuum
     // G4Material* vacuum =
     //   G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic");
-    // vacuum->SetMaterialPropertiesTable(opticalprops::Vacuum());
+    // vacuum->SetMaterialPropertiesTable(materialprops::Vacuum());
     //  G4LogicalVolume* axial_port_hole_logic = new G4LogicalVolume(axial_port_hole_solid,
     //			vacuum, "AXIAL_PORT_HOLE");
     //   G4LogicalVolume* axial_port_hole_logic = new G4LogicalVolume(axial_port_hole_solid,

--- a/source/geometries/NextNewFieldCage.cc
+++ b/source/geometries/NextNewFieldCage.cc
@@ -11,7 +11,7 @@
 #include "MaterialsList.h"
 #include "IonizationSD.h"
 #include "UniformElectricDriftField.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "IonizationSD.h"
 #include "XenonProperties.h"
 #include "CylinderPointSamplerLegacy.h"
@@ -288,16 +288,16 @@ namespace nexus {
     teflon_->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
     // TPB coating
     tpb_ = materials::TPB();
-    tpb_->SetMaterialPropertiesTable(opticalprops::TPB());
+    tpb_->SetMaterialPropertiesTable(materialprops::TPB());
     //ITO coating
     ito_ = materials::ITO();
-    ito_->SetMaterialPropertiesTable(opticalprops::ITO());
+    ito_->SetMaterialPropertiesTable(materialprops::ITO());
     // PEDOT coating
     pedot_ = materials::PEDOT();
-    pedot_->SetMaterialPropertiesTable(opticalprops::PEDOT());
+    pedot_->SetMaterialPropertiesTable(materialprops::PEDOT());
     // Quartz
     quartz_ =  materials::FusedSilica();
-    quartz_->SetMaterialPropertiesTable(opticalprops::FusedSilica());
+    quartz_->SetMaterialPropertiesTable(materialprops::FusedSilica());
   }
 
 
@@ -306,7 +306,7 @@ namespace nexus {
     ///// CATHODE //////
     G4Material* fgrid_mat =
       materials::FakeDielectric(gas_, "cath_grid_mat");
-    fgrid_mat->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_,
+    fgrid_mat->SetMaterialPropertiesTable(materialprops::FakeGrid(pressure_,
                                                                  temperature_,
                                                                  cathode_grid_transparency_,
                                                                  cathode_thickness_));
@@ -451,7 +451,7 @@ void NextNewFieldCage::BuildBuffer()
       materials::FakeDielectric(gas_, "el_grid_gate_mat");
     // We have to set the defaults explicitely because C++ doesn't support
     // named arguments
-    fgate_mat->SetMaterialPropertiesTable(opticalprops::FakeGrid(pressure_,
+    fgate_mat->SetMaterialPropertiesTable(materialprops::FakeGrid(pressure_,
                                                                  temperature_,
                                                                  gate_transparency_,
                                                                  grid_thickness_,
@@ -633,7 +633,7 @@ void NextNewFieldCage::BuildBuffer()
     reflector_opt_surf->SetModel(unified);
     reflector_opt_surf->SetFinish(ground);
     reflector_opt_surf->SetSigmaAlpha(0.01);
-    reflector_opt_surf->SetMaterialPropertiesTable(opticalprops::PTFE());
+    reflector_opt_surf->SetMaterialPropertiesTable(materialprops::PTFE());
     new G4LogicalSkinSurface("DRIFT_TUBE", drift_tube_logic,
     			     reflector_opt_surf);
 

--- a/source/geometries/NextNewKDB.cc
+++ b/source/geometries/NextNewKDB.cc
@@ -10,7 +10,7 @@
 #include "NextNewKDB.h"
 
 #include "SiPMSensl.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "BoxPointSamplerLegacy.h"
 #include "Visibilities.h"
 
@@ -134,7 +134,7 @@ namespace nexus {
     // Adding the optical surface
     G4OpticalSurface* mask_optSurf =
       new G4OpticalSurface("DICE_MASK_OPSURF", unified, ground, dielectric_metal);
-    mask_optSurf->SetMaterialPropertiesTable(opticalprops::PTFE());
+    mask_optSurf->SetMaterialPropertiesTable(materialprops::PTFE());
     new G4LogicalSkinSurface("DICE_MASK_OPSURF", mask_logic, mask_optSurf);
 
 

--- a/source/geometries/NextNewPmtEnclosure.cc
+++ b/source/geometries/NextNewPmtEnclosure.cc
@@ -9,7 +9,7 @@
 #include "NextNewPmtEnclosure.h"
 
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "CylinderPointSamplerLegacy.h"
 #include "Visibilities.h"
 #include "PmtR11410.h"
@@ -78,19 +78,19 @@ namespace nexus{
     // MATERIALS ///////////////////////////////////////////
 
     G4Material* sapphire = materials::Sapphire();
-    sapphire->SetMaterialPropertiesTable(opticalprops::Sapphire());
+    sapphire->SetMaterialPropertiesTable(materialprops::Sapphire());
 
     G4Material* vacuum = G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic");
-    vacuum->SetMaterialPropertiesTable(opticalprops::Vacuum());
+    vacuum->SetMaterialPropertiesTable(materialprops::Vacuum());
 
     G4Material* optical_coupler = materials::OpticalSilicone();
-    optical_coupler->SetMaterialPropertiesTable(opticalprops::OptCoupler());
+    optical_coupler->SetMaterialPropertiesTable(materialprops::OptCoupler());
 
     G4Material* tpb = materials::TPB();
-    tpb->SetMaterialPropertiesTable(opticalprops::TPB());
+    tpb->SetMaterialPropertiesTable(materialprops::TPB());
 
     G4Material* pedot = materials::PEDOT();
-    pedot->SetMaterialPropertiesTable(opticalprops::PEDOT());
+    pedot->SetMaterialPropertiesTable(materialprops::PEDOT());
 
     /////   ENCLOSURES  /////
     G4Tubs* enclosure_body =
@@ -201,7 +201,7 @@ namespace nexus{
     // Adding the PMT base
     G4Tubs* pmt_base_solid =
       new G4Tubs("PMT_BASE", 0., pmt_base_diam_/2., pmt_base_thickness_, 0.,twopi);
-    
+
     G4Material* kapton = G4NistManager::Instance()->FindOrBuildMaterial("G4_KAPTON");
     kapton->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 

--- a/source/geometries/NextNewTrackingPlane.cc
+++ b/source/geometries/NextNewTrackingPlane.cc
@@ -8,7 +8,7 @@
 
 #include "NextNewTrackingPlane.h"
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "Visibilities.h"
 #include "CylinderPointSamplerLegacy.h"
 #include "BoxPointSamplerLegacy.h"

--- a/source/geometries/NextNewVessel.cc
+++ b/source/geometries/NextNewVessel.cc
@@ -8,7 +8,7 @@
 
 #include "NextNewVessel.h"
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "Visibilities.h"
 #include "CalibrationSource.h"
 #include "CylinderPointSamplerLegacy.h"
@@ -365,7 +365,7 @@ void NextNewVessel::Construct()
 
 
     //// LOGICS //////
-    
+
     G4Material* steel_316_Ti = materials::Steel316Ti();
     steel_316_Ti->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
 
@@ -377,10 +377,10 @@ void NextNewVessel::Construct()
     G4Tubs* lateral_port_hole_solid =
       new G4Tubs("LATERAL_PORT_AIR_EXT", 0., port_tube_diam_/2.,
     		 (lat_nozzle_flange_high_ + lat_port_tube_out_)/2., 0., twopi);
-    
+
     G4Material* air_mat = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
     air_mat->SetMaterialPropertiesTable(new G4MaterialPropertiesTable());
-    
+
     G4LogicalVolume* lateral_port_hole_logic =
       new G4LogicalVolume(lateral_port_hole_solid, air_mat,
 			  "LATERAL_PORT_AIR_EXT");
@@ -411,23 +411,23 @@ void NextNewVessel::Construct()
 
     if (gas_ == "naturalXe") {
       vessel_gas_mat = materials::GXe(pressure_, temperature_);
-      vessel_gas_mat->SetMaterialPropertiesTable(opticalprops::GXe(pressure_, temperature_, sc_yield_, e_lifetime_));
+      vessel_gas_mat->SetMaterialPropertiesTable(materialprops::GXe(pressure_, temperature_, sc_yield_, e_lifetime_));
     } else if (gas_ == "enrichedXe") {
       vessel_gas_mat =  materials::GXeEnriched(pressure_, temperature_);
-      vessel_gas_mat->SetMaterialPropertiesTable(opticalprops::GXe(pressure_, temperature_, sc_yield_, e_lifetime_));
+      vessel_gas_mat->SetMaterialPropertiesTable(materialprops::GXe(pressure_, temperature_, sc_yield_, e_lifetime_));
     } else if  (gas_ == "depletedXe") {
       vessel_gas_mat =  materials::GXeDepleted(pressure_, temperature_);
-      vessel_gas_mat->SetMaterialPropertiesTable(opticalprops::GXe(pressure_, temperature_, sc_yield_, e_lifetime_));
+      vessel_gas_mat->SetMaterialPropertiesTable(materialprops::GXe(pressure_, temperature_, sc_yield_, e_lifetime_));
     } else if (gas_ == "Ar") {
       vessel_gas_mat =  materials::GAr(pressure_, temperature_);
-      vessel_gas_mat->SetMaterialPropertiesTable(opticalprops::GAr(sc_yield_, e_lifetime_));
+      vessel_gas_mat->SetMaterialPropertiesTable(materialprops::GAr(sc_yield_, e_lifetime_));
     } else if (gas_ == "ArXe") {
       vessel_gas_mat =  materials::GXeAr(pressure_, temperature_, xe_perc_);
-      vessel_gas_mat->SetMaterialPropertiesTable(opticalprops::GAr(sc_yield_, e_lifetime_));
+      vessel_gas_mat->SetMaterialPropertiesTable(materialprops::GAr(sc_yield_, e_lifetime_));
     } else if (gas_ == "XeHe") {
       vessel_gas_mat =  materials::GXeHe(pressure_, temperature_,
 					     xe_perc_, helium_mass_num_);
-      vessel_gas_mat->SetMaterialPropertiesTable(opticalprops::GXe(pressure_, temperature_, sc_yield_, e_lifetime_));
+      vessel_gas_mat->SetMaterialPropertiesTable(materialprops::GXe(pressure_, temperature_, sc_yield_, e_lifetime_));
     } else {
       G4Exception("[NextNewVessel]", "Construct()", FatalException,
 		  "Unknown kind of gas, valid options are: naturalXe, enrichedXe, depletedXe, Ar, ArXe, XeHe.");

--- a/source/geometries/PMT_QE_setup.cc
+++ b/source/geometries/PMT_QE_setup.cc
@@ -9,7 +9,7 @@
 #include "PMT_QE_setup.h"
 #include "MaterialsList.h"
 #include "SiPM11.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 
 #include <G4Box.hh>
 #include <G4Tubs.hh>
@@ -78,7 +78,7 @@ namespace nexus {
     G4Box* gas_solid = new G4Box("GAS", width/2., height/2., length_/2.);
 
     G4Material* gxe = materials::GXe(gxe_pressure);
-    gxe->SetMaterialPropertiesTable(opticalprops::GXe(gxe_pressure));
+    gxe->SetMaterialPropertiesTable(materialprops::GXe(gxe_pressure));
     // G4Material* air =
     //   G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
 
@@ -117,7 +117,7 @@ namespace nexus {
     // teflon_opsur->SetModel(unified);
     // teflon_opsur->SetFinish(ground);
     // teflon_opsur->SetSigmaAlpha(0.0000001); // it does not affect, because the reflection is totally lambertian.
-    // teflon_opsur->SetMaterialPropertiesTable(opticalprops::PTFE());
+    // teflon_opsur->SetMaterialPropertiesTable(materialprops::PTFE());
 
     // new G4LogicalSkinSurface("TEFLON_OPSURF", teflon_logic, teflon_opsur);
 

--- a/source/geometries/PmtR11410.cc
+++ b/source/geometries/PmtR11410.cc
@@ -8,7 +8,7 @@
 
 #include "PmtR11410.h"
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "SensorSD.h"
 #include "CylinderPointSamplerLegacy.h"
 #include "Visibilities.h"
@@ -126,7 +126,7 @@ namespace nexus {
                  0., twopi);
 
     G4Material* silica = materials::FusedSilica();
-    silica->SetMaterialPropertiesTable(opticalprops::FusedSilica());
+    silica->SetMaterialPropertiesTable(materialprops::FusedSilica());
     G4LogicalVolume* window_logic = new G4LogicalVolume(window_solid, silica, "PMT_WINDOW");
 
     G4double window_posz = front_body_gas_length/2. - window_thickness_/2.;

--- a/source/geometries/PmtR7378A.cc
+++ b/source/geometries/PmtR7378A.cc
@@ -9,7 +9,7 @@
 #include "PmtR7378A.h"
 
 #include "SensorSD.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "MaterialsList.h"
 #include "Visibilities.h"
 
@@ -72,7 +72,7 @@ namespace nexus {
 
     G4Material* quartz =
       G4NistManager::Instance()->FindOrBuildMaterial("G4_SILICON_DIOXIDE");
-    quartz->SetMaterialPropertiesTable(opticalprops::FusedSilica());
+    quartz->SetMaterialPropertiesTable(materialprops::FusedSilica());
 
     G4LogicalVolume* window_logic =
       new G4LogicalVolume(window_solid, quartz, "PMT_WINDOW");

--- a/source/geometries/SiPM11.cc
+++ b/source/geometries/SiPM11.cc
@@ -9,7 +9,7 @@
 #include "SiPM11.h"
 #include "SensorSD.h"
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "Visibilities.h"
 
 #include <G4Box.hh>
@@ -69,7 +69,7 @@ namespace nexus {
     G4Box* sipm_solid = new G4Box("SIPM11", sipm_x/2., sipm_y/2., sipm_z/2);
 
     G4Material* epoxy = materials::Epoxy();
-    epoxy->SetMaterialPropertiesTable(opticalprops::GlassEpoxy());
+    epoxy->SetMaterialPropertiesTable(materialprops::GlassEpoxy());
 
     G4LogicalVolume* sipm_logic =
       new G4LogicalVolume(sipm_solid, epoxy, "SIPM11");

--- a/source/geometries/SiPMSensl.cc
+++ b/source/geometries/SiPMSensl.cc
@@ -9,7 +9,7 @@
 #include "SiPMSensl.h"
 #include "SensorSD.h"
 #include "MaterialsList.h"
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "Visibilities.h"
 
 #include <G4Box.hh>
@@ -70,7 +70,7 @@ namespace nexus {
     G4Box* sipm_solid = new G4Box("SIPMSensl", sipm_x/2., sipm_y/2., sipm_z/2);
 
     G4Material* epoxy = materials::Epoxy();
-    epoxy->SetMaterialPropertiesTable(opticalprops::GlassEpoxy());
+    epoxy->SetMaterialPropertiesTable(materialprops::GlassEpoxy());
 
     G4LogicalVolume* sipm_logic =
       new G4LogicalVolume(sipm_solid, epoxy, "SIPMSensl");

--- a/source/materials/MaterialProperties.cc
+++ b/source/materials/MaterialProperties.cc
@@ -1,12 +1,12 @@
 // ----------------------------------------------------------------------------
-// nexus | OpticalMaterialProperties.cc
+// nexus | MaterialProperties.cc
 //
-// Optical properties of relevant materials.
+// Properties of relevant materials.
 //
 // The NEXT Collaboration
 // ----------------------------------------------------------------------------
 
-#include "OpticalMaterialProperties.h"
+#include "MaterialProperties.h"
 #include "XenonProperties.h"
 #include "SellmeierEquation.h"
 
@@ -16,7 +16,7 @@
 using namespace nexus;
 using namespace CLHEP;
 
-namespace opticalprops {
+namespace materialprops {
 
   G4MaterialPropertiesTable* Vacuum()
   {
@@ -114,7 +114,7 @@ namespace opticalprops {
 
     G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
 
-    G4MaterialPropertiesTable* fused_sil_pt = opticalprops::FusedSilica();
+    G4MaterialPropertiesTable* fused_sil_pt = materialprops::FusedSilica();
     mpt->AddProperty("RINDEX", fused_sil_pt->GetProperty("RINDEX"));
 
     // ABSORPTION LENGTH (Set to match the transparency)
@@ -735,7 +735,7 @@ namespace opticalprops {
     G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
 
     // PROPERTIES FROM XENON
-    G4MaterialPropertiesTable* xenon_pt = opticalprops::GXe(pressure, temperature, sc_yield, e_lifetime);
+    G4MaterialPropertiesTable* xenon_pt = materialprops::GXe(pressure, temperature, sc_yield, e_lifetime);
 
     mpt->AddProperty("RINDEX",        xenon_pt->GetProperty("RINDEX"));
     mpt->AddProperty("SCINTILLATIONCOMPONENT1", xenon_pt->GetProperty("SCINTILLATIONCOMPONENT1"));
@@ -820,6 +820,7 @@ namespace opticalprops {
        hc_ / (717.13442 * nm),  hc_ / (597.48892 * nm),  hc_ / (477.84343 * nm),
        hc_ / (418.02068 * nm),  hc_ / (358.19793 * nm),  hc_ / (293.94387 * nm)
     };
+
     std::vector<G4double> REFLECTIVITY = {
       .99088, .99082, .98925,
       .98623, .98611, .98163,
@@ -1004,11 +1005,11 @@ namespace opticalprops {
     G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
 
     // All Optical Material Properties from normal TPB ...
-    mpt->AddProperty("RINDEX",       opticalprops::TPB()->GetProperty("RINDEX"));
-    mpt->AddProperty("ABSLENGTH",    opticalprops::TPB()->GetProperty("ABSLENGTH"));
-    mpt->AddProperty("WLSABSLENGTH", opticalprops::TPB()->GetProperty("WLSABSLENGTH"));
-    mpt->AddProperty("WLSCOMPONENT", opticalprops::TPB()->GetProperty("WLSCOMPONENT"));
-    mpt->AddConstProperty("WLSTIMECONSTANT", opticalprops::TPB()->GetConstProperty("WLSTIMECONSTANT"));
+    mpt->AddProperty("RINDEX",       materialprops::TPB()->GetProperty("RINDEX"));
+    mpt->AddProperty("ABSLENGTH",    materialprops::TPB()->GetProperty("ABSLENGTH"));
+    mpt->AddProperty("WLSABSLENGTH", materialprops::TPB()->GetProperty("WLSABSLENGTH"));
+    mpt->AddProperty("WLSCOMPONENT", materialprops::TPB()->GetProperty("WLSCOMPONENT"));
+    mpt->AddConstProperty("WLSTIMECONSTANT", materialprops::TPB()->GetConstProperty("WLSTIMECONSTANT"));
 
     // Except WLS Quantum Efficiency
     mpt->AddConstProperty("WLSMEANNUMBERPHOTONS", wls_eff);

--- a/source/materials/MaterialProperties.cc
+++ b/source/materials/MaterialProperties.cc
@@ -529,6 +529,8 @@ namespace materialprops {
     // May 2023:
     // Updated scintillation decay and yields from:
     // Triplet Lifetime in Gaseous Argon. Michael Akashi-Ronquest et al.
+    // Fano factor from M. Kase et al., NIMA, Volume 227, Issue 2 Pages 311-317
+    // Ionization energy from https://www.nuclear-power.com/argon-affinity-electronegativity-ionization/
 
     G4MaterialPropertiesTable* mpt = new G4MaterialPropertiesTable();
 
@@ -589,6 +591,8 @@ namespace materialprops {
     mpt->AddConstProperty("SCINTILLATIONYIELD2", .864);
     mpt->AddConstProperty("RESOLUTIONSCALE",    1.0);
     mpt->AddConstProperty("ATTACHMENT",         e_lifetime, 1);
+    mpt->AddConstProperty("IONIZATIONENERGY",    15.8 * eV, 1);
+    mpt->AddConstProperty("FANOFACTOR",            .2,      1);
 
     return mpt;
   }
@@ -711,8 +715,8 @@ namespace materialprops {
     LXe_mpt->AddConstProperty("SCINTILLATIONYIELD1", .03);
     LXe_mpt->AddConstProperty("SCINTILLATIONYIELD2", .97);
     LXe_mpt->AddConstProperty("ATTACHMENT", 1000.*ms, 1);
-    mpt->AddConstProperty("IONIZATIONENERGY",    21.9 * eV, 1);
-    mpt->AddConstProperty("FANOFACTOR",               0.29, 1);
+    LXe_mpt->AddConstProperty("IONIZATIONENERGY",    21.9 * eV, 1);
+    LXe_mpt->AddConstProperty("FANOFACTOR",               0.29, 1);
 
     std::vector<G4double> abs_energy = {optPhotMinE_, optPhotMaxE_};
     std::vector<G4double> abs_length = {noAbsLength_, noAbsLength_};

--- a/source/materials/MaterialProperties.cc
+++ b/source/materials/MaterialProperties.cc
@@ -647,12 +647,14 @@ namespace materialprops {
 
     // CONST PROPERTIES
     mpt->AddConstProperty("SCINTILLATIONYIELD", sc_yield);
-    mpt->AddConstProperty("RESOLUTIONSCALE",    1.0);
-    mpt->AddConstProperty("SCINTILLATIONTIMECONSTANT1",   4.5  * ns);
-    mpt->AddConstProperty("SCINTILLATIONTIMECONSTANT2",   100. * ns);
+    mpt->AddConstProperty("RESOLUTIONSCALE",         1.0);
+    mpt->AddConstProperty("SCINTILLATIONTIMECONSTANT1",   4.5 * ns);
+    mpt->AddConstProperty("SCINTILLATIONTIMECONSTANT2", 100.  * ns);
     mpt->AddConstProperty("SCINTILLATIONYIELD1", .1);
     mpt->AddConstProperty("SCINTILLATIONYIELD2", .9);
     mpt->AddConstProperty("ATTACHMENT",         e_lifetime, 1);
+    mpt->AddConstProperty("IONIZATIONENERGY",    22.4 * eV, 1);
+    mpt->AddConstProperty("FANOFACTOR",                .15, 1);
 
     return mpt;
   }

--- a/source/materials/MaterialProperties.cc
+++ b/source/materials/MaterialProperties.cc
@@ -757,6 +757,9 @@ namespace materialprops {
     mpt->AddConstProperty("SCINTILLATIONYIELD1", xenon_pt->GetConstProperty("SCINTILLATIONYIELD1"));
     mpt->AddConstProperty("SCINTILLATIONYIELD2", xenon_pt->GetConstProperty("SCINTILLATIONYIELD2"));
     mpt->AddConstProperty("ATTACHMENT",         xenon_pt->GetConstProperty("ATTACHMENT"), 1);
+    mpt->AddConstProperty("IONIZATIONENERGY",   xenon_pt->GetConstProperty("IONIZATIONENERGY"), 1);
+    mpt->AddConstProperty("FANOFACTOR",         xenon_pt->GetConstProperty("FANOFACTOR"), 1);
+
 
     // ABSORPTION LENGTH
     G4double abs_length   = -thickness/log(transparency);

--- a/source/materials/MaterialProperties.cc
+++ b/source/materials/MaterialProperties.cc
@@ -669,7 +669,7 @@ namespace materialprops {
   G4MaterialPropertiesTable* LXe()
   {
     /// The time constants are taken from E. Hogenbirk et al 2018 JINST 13 P10031
-    /// Fano factor and ionization electron from Nobumiti et al., Phys. Rev. A 46, 1676
+    /// Ionization energy is taken from Takahashi et al., Phys. Rev. A 12, 1771
     G4MaterialPropertiesTable* LXe_mpt = new G4MaterialPropertiesTable();
 
     const G4int ri_entries = 200;
@@ -715,7 +715,7 @@ namespace materialprops {
     LXe_mpt->AddConstProperty("SCINTILLATIONYIELD1", .03);
     LXe_mpt->AddConstProperty("SCINTILLATIONYIELD2", .97);
     LXe_mpt->AddConstProperty("ATTACHMENT", 1000.*ms, 1);
-    LXe_mpt->AddConstProperty("IONIZATIONENERGY",    21.9 * eV, 1);
+    LXe_mpt->AddConstProperty("IONIZATIONENERGY",    15.6 * eV, 1);
     LXe_mpt->AddConstProperty("FANOFACTOR",               0.29, 1);
 
     std::vector<G4double> abs_energy = {optPhotMinE_, optPhotMaxE_};

--- a/source/materials/MaterialProperties.cc
+++ b/source/materials/MaterialProperties.cc
@@ -665,6 +665,7 @@ namespace materialprops {
   G4MaterialPropertiesTable* LXe()
   {
     /// The time constants are taken from E. Hogenbirk et al 2018 JINST 13 P10031
+    /// Fano factor and ionization electron from Nobumiti et al., Phys. Rev. A 46, 1676
     G4MaterialPropertiesTable* LXe_mpt = new G4MaterialPropertiesTable();
 
     const G4int ri_entries = 200;
@@ -710,6 +711,8 @@ namespace materialprops {
     LXe_mpt->AddConstProperty("SCINTILLATIONYIELD1", .03);
     LXe_mpt->AddConstProperty("SCINTILLATIONYIELD2", .97);
     LXe_mpt->AddConstProperty("ATTACHMENT", 1000.*ms, 1);
+    mpt->AddConstProperty("IONIZATIONENERGY",    21.9 * eV, 1);
+    mpt->AddConstProperty("FANOFACTOR",               0.29, 1);
 
     std::vector<G4double> abs_energy = {optPhotMinE_, optPhotMaxE_};
     std::vector<G4double> abs_length = {noAbsLength_, noAbsLength_};

--- a/source/materials/MaterialProperties.h
+++ b/source/materials/MaterialProperties.h
@@ -1,13 +1,13 @@
 // ----------------------------------------------------------------------------
-// nexus | OpticalMaterialProperties.h
+// nexus | MaterialProperties.h
 //
-// Optical properties of relevant materials.
+// Properties of relevant materials.
 //
 // The NEXT Collaboration
 // ----------------------------------------------------------------------------
 
-#ifndef OPTICAL_MATERIAL_PROPERTIES_H
-#define OPTICAL_MATERIAL_PROPERTIES_H
+#ifndef MATERIAL_PROPERTIES_H
+#define MATERIAL_PROPERTIES_H
 
 #include <globals.hh>
 
@@ -17,7 +17,7 @@
 class G4MaterialPropertiesTable;
 
 
-namespace opticalprops {
+namespace materialprops {
 
   using namespace CLHEP;
 
@@ -99,6 +99,6 @@ namespace opticalprops {
   constexpr G4double hc_ = h_Planck * c_light;
 
 
-} // end namespace opticalprops
+} // end namespace materialprops
 
 #endif

--- a/source/physics/IonizationClustering.cc
+++ b/source/physics/IonizationClustering.cc
@@ -109,10 +109,14 @@ namespace nexus {
     // and N is the average number of charges.
 
     // Fetch the W_i and F from the material properties table
+    G4String mat_name = track.GetMaterial()->GetName();
     G4MaterialPropertiesTable* mpt =
       track.GetMaterial()->GetMaterialPropertiesTable();
-    if (!mpt)
-      return G4VRestDiscreteProcess::PostStepDoIt(track, step);
+    if (!mpt) {
+      G4cout << "Material properties missing for material " << mat_name << G4endl;
+      G4Exception("[IonizationClustering]", "PostStepDoIt()", FatalException,
+		  "Material properties table not defined in material!");
+      }
 
     G4double ioni_energy = mpt->GetConstProperty("IONIZATIONENERGY");
     G4double fano_factor = mpt->GetConstProperty("FANOFACTOR");

--- a/source/physics/IonizationClustering.cc
+++ b/source/physics/IonizationClustering.cc
@@ -109,15 +109,13 @@ namespace nexus {
     // and N is the average number of charges.
 
     // Fetch the W_i and F from the material properties table
-    //G4MaterialPropertiesTable* mpt =
-    //  track.GetMaterial()->GetMaterialPropertiesTable();
-    //if (!mpt)
-    //  return G4VRestDiscreteProcess::PostStepDoIt(track, step);
+    G4MaterialPropertiesTable* mpt =
+      track.GetMaterial()->GetMaterialPropertiesTable();
+    if (!mpt)
+      return G4VRestDiscreteProcess::PostStepDoIt(track, step);
 
-    //G4double ioni_energy = mpt->GetConstProperty("IONIZATIONENERGY");
-    //G4double fano_factor = mpt->GetConstProperty("FANOFACTOR");
-    G4double ioni_energy = 22.4 * eV;
-    G4double fano_factor = .15;
+    G4double ioni_energy = mpt->GetConstProperty("IONIZATIONENERGY");
+    G4double fano_factor = mpt->GetConstProperty("FANOFACTOR");
 
     G4double mean = energy_dep / ioni_energy;
 

--- a/source/physics/IonizationClustering.cc
+++ b/source/physics/IonizationClustering.cc
@@ -109,11 +109,11 @@ namespace nexus {
     // and N is the average number of charges.
 
     // Fetch the W_i and F from the material properties table
-    G4String mat_name = track.GetMaterial()->GetName();
     G4MaterialPropertiesTable* mpt =
       track.GetMaterial()->GetMaterialPropertiesTable();
     if (!mpt) {
-      G4cout << "Material properties missing for material " << mat_name << G4endl;
+      G4cout << "Material properties missing for material "
+             << track.GetMaterial()->GetName() << G4endl;
       G4Exception("[IonizationClustering]", "PostStepDoIt()", FatalException,
 		  "Material properties table not defined in material!");
       }


### PR DESCRIPTION
This PR drops the `optical` part of the name of the OpticalMaterialProperties files and relative namespace. Since we use more properties that are not just optical (such as scintillation and TPB emission spectra, yield, attachment...) this seems more logical. 
Two more non-optical properties, namely the Fano factor and the ionization energy for gaseous xenon,  are added to the property table instead of being coded in the `IonizationClustering` class.
This PR closes #12.