### PR TITLE
Add configurable drift velocities

### DIFF
--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -162,11 +162,13 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   msg_->DeclareProperty("drift_v", drift_v_,
                         "The active volume drift velocity");
   drift_vel_cmd.SetParameterName("drift_v", true);
+  drift_vel_cmd.SetRange("drift_v>=0.");
 
   G4GenericMessenger::Command&  EL_drift_vel_cmd =
   msg_->DeclareProperty("EL_drift_v", EL_drift_v_,
                         "The EL region drift velocity");
   EL_drift_vel_cmd.SetParameterName("EL_drift_v", true);
+  EL_drift_vel_cmd.SetRange("EL_drift_v>=0.");
 
   msg_->DeclareProperty("elfield", elfield_,
                         "True if the EL field is on (full simulation), "

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -99,6 +99,9 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   drift_long_diff_ (.3 * mm/sqrt(cm)),
   ELtransv_diff_ (0. * mm/sqrt(cm)),
   ELlong_diff_ (0. * mm/sqrt(cm)),
+  // Drift velocities
+  drift_v_(1. * mm/microsecond),
+  EL_drift_v_(2.5 * mm/microsecond),
   // EL electric field
   elfield_ (0),
   ELelectric_field_ (34.5*kilovolt/cm),
@@ -154,6 +157,16 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
                         "Longitudinal diffusion in the EL region");
   ELlong_diff_cmd.SetParameterName("ELlong_diff", true);
   ELlong_diff_cmd.SetUnitCategory("Diffusion");
+
+  G4GenericMessenger::Command&  drift_vel_cmd =
+  msg_->DeclareProperty("drift_v", drift_v_,
+                        "The active volume drift velocity");
+  drift_vel_cmd.SetParameterName("drift_v", true);
+
+  G4GenericMessenger::Command&  EL_drift_vel_cmd =
+  msg_->DeclareProperty("EL_drift_v", EL_drift_v_,
+                        "The EL region drift velocity");
+  EL_drift_vel_cmd.SetParameterName("EL_drift_v", true);
 
   msg_->DeclareProperty("elfield", elfield_,
                         "True if the EL field is on (full simulation), "
@@ -329,7 +342,7 @@ void Next100FieldCage::BuildActive()
   G4double global_active_zpos = active_zpos_ - GetCoordOrigin().z();
   field->SetCathodePosition(global_active_zpos + active_length_/2.);
   field->SetAnodePosition(global_active_zpos - active_length_/2.);
-  field->SetDriftVelocity(1. * mm/microsecond);
+  field->SetDriftVelocity(drift_v_);
   field->SetTransverseDiffusion(drift_transv_diff_);
   field->SetLongitudinalDiffusion(drift_long_diff_);
   field->SetLifetime(e_lifetime_);
@@ -721,7 +734,7 @@ void Next100FieldCage::BuildELRegion()
     G4double global_el_gap_zpos = el_gap_zpos_ - GetCoordOrigin().z();
     el_field->SetCathodePosition(global_el_gap_zpos + el_gap_length_/2. + grid_thickn_);
     el_field->SetAnodePosition  (global_el_gap_zpos - el_gap_length_/2. - grid_thickn_);
-    el_field->SetDriftVelocity(2.5 * mm/microsecond);
+    el_field->SetDriftVelocity(EL_drift_v_);
     el_field->SetTransverseDiffusion(ELtransv_diff_);
     el_field->SetLongitudinalDiffusion(ELlong_diff_);
     el_field->SetLightYield(XenonELLightYield(ELelectric_field_, pressure_));

--- a/source/geometries/Next100FieldCage.h
+++ b/source/geometries/Next100FieldCage.h
@@ -70,6 +70,9 @@ namespace nexus {
     G4double drift_transv_diff_, drift_long_diff_;
     G4double ELtransv_diff_; ///< transversal diffusion in the EL gap
     G4double ELlong_diff_; ///< longitudinal diffusion in the EL gap
+    // Drift Velocities
+    G4double drift_v_;
+    G4double EL_drift_v_;
     // Electric field
     G4bool elfield_;
     G4double ELelectric_field_; ///< electric field in the EL region

--- a/source/geometries/NextDemoFieldCage.cc
+++ b/source/geometries/NextDemoFieldCage.cc
@@ -84,6 +84,8 @@ namespace nexus {
     drift_long_diff_ (.3 * mm/sqrt(cm)),
     ELtransv_diff_ (1. * mm / sqrt(cm)),
     ELlong_diff_ (0.5 * mm / sqrt(cm)),
+    drift_v_(1. * mm/microsecond),
+    EL_drift_v_(2.5 * mm/microsecond),
     elfield_(0),
     ELelectric_field_ (23.2857 * kilovolt / cm),
     // EL gap generation disk parameters
@@ -137,6 +139,18 @@ namespace nexus {
                             "Longitudinal diffusion in the EL region");
     ELlong_diff_cmd.SetParameterName("ELlong_diff", true);
     ELlong_diff_cmd.SetUnitCategory("Diffusion");
+
+    G4GenericMessenger::Command&  drift_vel_cmd =
+    msg_->DeclareProperty("drift_v", drift_v_,
+                          "The active volume drift velocity");
+    drift_vel_cmd.SetParameterName("drift_v", true);
+    drift_vel_cmd.SetRange("drift_v>=0.");
+
+    G4GenericMessenger::Command&  EL_drift_vel_cmd =
+    msg_->DeclareProperty("EL_drift_v", EL_drift_v_,
+                          "The EL region drift velocity");
+    EL_drift_vel_cmd.SetParameterName("EL_drift_v", true);
+    EL_drift_vel_cmd.SetRange("EL_drift_v>=0.");
 
     msg_->DeclareProperty("elfield", elfield_,
                           "True if the EL field is on (full simulation), false if it's not (parametrized simulation).");
@@ -277,7 +291,7 @@ namespace nexus {
     G4double global_active_zpos = active_zpos_ - GetELzCoord();
     field->SetCathodePosition(global_active_zpos + active_length_/2.);
     field->SetAnodePosition(global_active_zpos - active_length_/2.);
-    field->SetDriftVelocity(1.*mm/microsecond);
+    field->SetDriftVelocity(drift_v_);
     field->SetTransverseDiffusion(drift_transv_diff_);
     field->SetLongitudinalDiffusion(drift_long_diff_);
     field->SetLifetime(e_lifetime_);
@@ -383,7 +397,7 @@ namespace nexus {
       G4double global_el_gap_zpos = el_gap_zpos - GetELzCoord();
       el_field->SetCathodePosition(global_el_gap_zpos + el_gap_length/2.);
       el_field->SetAnodePosition(global_el_gap_zpos - el_gap_length/2.);
-      el_field->SetDriftVelocity(2.5*mm/microsecond);
+      el_field->SetDriftVelocity(EL_drift_v_);
       el_field->SetTransverseDiffusion(ELtransv_diff_);
       el_field->SetLongitudinalDiffusion(ELlong_diff_);
       el_field->SetLightYield(XenonELLightYield(ELelectric_field_, pressure_));

--- a/source/geometries/NextDemoFieldCage.h
+++ b/source/geometries/NextDemoFieldCage.h
@@ -112,6 +112,8 @@ namespace nexus {
     G4double cathode_grid_zpos_;
     G4double drift_transv_diff_, drift_long_diff_;
     G4double ELtransv_diff_, ELlong_diff_;
+    G4double drift_v_;
+    G4double EL_drift_v_;
     G4bool elfield_;
     G4double ELelectric_field_;
 

--- a/source/geometries/NextFlexFieldCage.cc
+++ b/source/geometries/NextFlexFieldCage.cc
@@ -50,6 +50,7 @@ NextFlexFieldCage::NextFlexFieldCage():
   active_length_           (116. * cm),          // Distance GATE - CATHODE (meshes not included)
   drift_transv_diff_       (1. * mm/sqrt(cm)),   // Drift field transversal diffusion
   drift_long_diff_         (.3 * mm/sqrt(cm)),   // Drift field longitudinal diffusion
+  drift_v_                 (1. * mm/microsecond),// Active volume drift velocity
   cathode_transparency_    (0.95),               // Cathode transparency
   buffer_length_           (280. * mm),          // Distance CATHODE - sapphire window surfaces
   el_gap_length_           (10. * mm),           // Distance ANODE - GATE (meshes included)
@@ -57,6 +58,7 @@ NextFlexFieldCage::NextFlexFieldCage():
   el_field_int_            (16.0 * kilovolt/cm), // EL field intensity
   el_transv_diff_          (0. * mm/sqrt(cm)),   // EL field transversal diffusion
   el_long_diff_            (0. * mm/sqrt(cm)),   // EL field longitudinal diffusion
+  EL_drift_v_              (2.5 * mm/microsecond),// EL drift velocity
   anode_transparency_      (0.95),               // Anode transparency
   gate_transparency_       (0.95),               // Gate transparency
   photoe_prob_             (0),                  // OpticalPhotoElectric Probability
@@ -155,6 +157,11 @@ void NextFlexFieldCage::DefineConfigurationParameters()
   drift_long_diff_cmd.SetParameterName("drift_long_diff", false);
   drift_long_diff_cmd.SetUnitCategory("Diffusion");
 
+  G4GenericMessenger::Command&  drift_vel_cmd =
+  msg_->DeclareProperty("drift_v", drift_v_,
+                        "The active volume drift velocity");
+  drift_vel_cmd.SetParameterName("drift_v", true);
+  drift_vel_cmd.SetRange("drift_v>=0.");
 
   // FIELD_CAGE dimensions
   G4GenericMessenger::Command& buffer_length_cmd =
@@ -191,6 +198,12 @@ void NextFlexFieldCage::DefineConfigurationParameters()
                           "Longitudinal diffusion in the EL region");
   el_long_diff_cmd.SetParameterName("el_long_diff", false);
   el_long_diff_cmd.SetUnitCategory("Diffusion");
+
+  G4GenericMessenger::Command&  EL_drift_vel_cmd =
+  msg_->DeclareProperty("EL_drift_v", EL_drift_v_,
+                        "The EL region drift velocity");
+  EL_drift_vel_cmd.SetParameterName("EL_drift_v", true);
+  EL_drift_vel_cmd.SetRange("EL_drift_v>=0.");
 
   // TRANSPARENCIES
   msg_->DeclareProperty("cathode_transparency", cathode_transparency_,
@@ -417,7 +430,7 @@ void NextFlexFieldCage::BuildActive()
   UniformElectricDriftField* field = new UniformElectricDriftField();
   field->SetCathodePosition(active_length_);
   field->SetAnodePosition(0.);
-  field->SetDriftVelocity(1. * mm/microsecond);
+  field->SetDriftVelocity(drift_v_);
   field->SetTransverseDiffusion(drift_transv_diff_);
   field->SetLongitudinalDiffusion(drift_long_diff_);
   field->SetLifetime(gas_e_lifetime_);
@@ -538,7 +551,7 @@ void NextFlexFieldCage::BuildELgap()
     UniformElectricDriftField* el_field = new UniformElectricDriftField();
     el_field->SetCathodePosition(el_gap_posZ + el_gap_length_/2.);
     el_field->SetAnodePosition  (el_gap_posZ - el_gap_length_/2.);
-    el_field->SetDriftVelocity  (2.5 * mm/microsecond);
+    el_field->SetDriftVelocity  (EL_drift_v_);
     el_field->SetTransverseDiffusion(el_transv_diff_);
     el_field->SetLongitudinalDiffusion(el_long_diff_);
     el_field->SetLightYield(yield);

--- a/source/geometries/NextFlexFieldCage.h
+++ b/source/geometries/NextFlexFieldCage.h
@@ -106,6 +106,7 @@ namespace nexus {
     // ACTIVE
     G4double active_diam_,       active_length_;
     G4double drift_transv_diff_, drift_long_diff_;
+    G4double drift_v_;
 
     // CATHODE
     G4double cathode_thickness_, cathode_transparency_;
@@ -119,6 +120,7 @@ namespace nexus {
     G4bool   el_field_on_;
     G4double el_field_int_;
     G4double el_transv_diff_, el_long_diff_;
+    G4double EL_drift_v_;
     G4double anode_thickness_, anode_transparency_;
     G4double gate_thickness_,  gate_transparency_;
     G4double photoe_prob_;

--- a/source/geometries/NextNewFieldCage.cc
+++ b/source/geometries/NextNewFieldCage.cc
@@ -73,6 +73,9 @@ namespace nexus {
     ELlong_diff_(0. * mm/sqrt(cm)),
     drift_transv_diff_(1. * mm/sqrt(cm)),
     drift_long_diff_(.3 * mm/sqrt(cm)),
+    // Drift velocities
+    drift_v_(1. * mm/microsecond),
+    EL_drift_v_(2.5 * mm/microsecond),
     //
     ELelectric_field_(34.5 * kilovolt/cm), // it corresponds to 2.3 kV/cm/bar at 15 bar
     // Visibility
@@ -153,6 +156,18 @@ namespace nexus {
 			    "Longitudinal diffusion in the drift region");
     drift_long_diff_cmd.SetParameterName("drift_long_diff", true);
     drift_long_diff_cmd.SetUnitCategory("Diffusion");
+
+    G4GenericMessenger::Command&  drift_vel_cmd =
+    msg_->DeclareProperty("drift_v", drift_v_,
+                          "The active volume drift velocity");
+    drift_vel_cmd.SetParameterName("drift_v", true);
+    drift_vel_cmd.SetRange("drift_v>=0.");
+
+    G4GenericMessenger::Command&  EL_drift_vel_cmd =
+    msg_->DeclareProperty("EL_drift_v", EL_drift_v_,
+                          "The EL region drift velocity");
+    EL_drift_vel_cmd.SetParameterName("EL_drift_v", true);
+    EL_drift_vel_cmd.SetRange("EL_drift_v>=0.");
 
     G4GenericMessenger::Command& El_field_cmd =
       msg_->DeclareProperty("EL_field", ELelectric_field_,
@@ -357,7 +372,7 @@ namespace nexus {
     // electrodes are at the end of active region
     field->SetCathodePosition(-(active_posz_ - active_length_/2.) + GetELzCoord());
     field->SetAnodePosition(-(active_posz_ + active_length_/2.) + GetELzCoord());
-    field->SetDriftVelocity(1. * mm/microsecond);
+    field->SetDriftVelocity(drift_v_);
     field->SetTransverseDiffusion(drift_transv_diff_);
     field->SetLongitudinalDiffusion(drift_long_diff_);
     field->SetLifetime(e_lifetime_);
@@ -436,7 +451,7 @@ void NextNewFieldCage::BuildBuffer()
       UniformElectricDriftField* el_field = new UniformElectricDriftField();
       el_field->SetCathodePosition(-(el_gap_z_pos_ - el_gap_length_/2.) + GetELzCoord());
       el_field->SetAnodePosition(-(el_gap_z_pos_ + el_gap_length_/2.) + GetELzCoord());
-      el_field->SetDriftVelocity(2.5 * mm/microsecond);
+      el_field->SetDriftVelocity(EL_drift_v_);
       el_field->SetTransverseDiffusion(ELtransv_diff_);
       el_field->SetLongitudinalDiffusion(ELlong_diff_);
       el_field->SetLightYield(XenonELLightYield(ELelectric_field_, pressure_));

--- a/source/geometries/NextNewFieldCage.h
+++ b/source/geometries/NextNewFieldCage.h
@@ -104,6 +104,10 @@ namespace nexus {
     G4double drift_transv_diff_;
     G4double drift_long_diff_;
 
+    // Drift Velocities
+    G4double drift_v_;
+    G4double EL_drift_v_;
+
     // Electric field in the EL gap
     G4double ELelectric_field_;
 


### PR DESCRIPTION
The NEXT100 drift velocities for the active and EL region were not configurable. This PR enables this option. 