### PR TITLE
Work around Geant4 limitations for reading int64

### DIFF
--- a/source/persistency/PersistencyManager.cc
+++ b/source/persistency/PersistencyManager.cc
@@ -53,7 +53,7 @@ PersistencyManagerBase(), msg_(0), output_file_("nexus_out"), ready_(false),
   msg_->DeclareProperty("output_file", output_file_, "Path of output file.");
   msg_->DeclareProperty("event_type", event_type_,
                         "Type of event: bb0nu, bb2nu, background.");
-  msg_->DeclareProperty("start_id", start_id_,
+  msg_->DeclareMethod  ("start_id", &PersistencyManager::SetStartID,
                         "Starting event ID for this job.");
   msg_->DeclareProperty("save_strings", save_str_,
                         "True if volume, process... names are saved as strings.");

--- a/source/persistency/PersistencyManager.h
+++ b/source/persistency/PersistencyManager.h
@@ -71,6 +71,7 @@ namespace nexus {
 
     G4int FindStringIDInMap(std::map<G4String, G4int>& vmap, G4String vol, G4int& counter);
 
+    void SetStartID(G4String& s);
 
   private:
     G4GenericMessenger* msg_; ///< User configuration messenger
@@ -127,7 +128,8 @@ namespace nexus {
   { return false; }
   inline G4bool PersistencyManager::Retrieve(G4VPhysicalVolume*&)
   { return false; }
-
+  inline void PersistencyManager::SetStartID(G4String& s)
+  { start_id_ = atoll(s); }
 } // namespace nexus
 
 #endif


### PR DESCRIPTION
The following command
`/nexus/persistency/start_id <a number greater than 2**32-1> `
throws an exception. This comes from a (stupid) limitation in Geant4 that doesn't allow parsing 64-bit integers from values passed by commands. We work around this limitation by using a function from the standard library to parse this number.
