### PR TITLE
Add NEXT100 generator for events on cathode surface

### DIFF
--- a/source/geometries/Next100.cc
+++ b/source/geometries/Next100.cc
@@ -239,6 +239,7 @@ namespace nexus {
     else if ((region == "CENTER") ||
              (region == "ACTIVE") ||
              (region == "CATHODE_RING") ||
+             (region == "CATHODE_SURF") ||
              (region == "BUFFER") ||
              (region == "XENON") ||
              (region == "LIGHT_TUBE") ||

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -480,13 +480,13 @@ void Next100FieldCage::BuildCathode()
                                            GetCoordOrigin().y(),
                                            cathode_zpos_));
 
-  // Generate in a 1 micron thick disk in front of cathode
+  // Generate in a small 1 micron thick disk in front of cathode
   cathode_surf_gen_ =
     new CylinderPointSampler(0.0, cathode_int_diam_/2.,
-                             1.0*micrometer,0., twopi, nullptr,
+                             0.5*micrometer,0., twopi, nullptr,
                              G4ThreeVector(GetCoordOrigin().x(),
                                            GetCoordOrigin().y(),
-                                           cathode_grid_zpos - grid_thickn_ - 1*micrometer));
+                                           cathode_grid_zpos - grid_thickn_ - 1.0*micrometer));
 
 
   /// Visibilities

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -480,6 +480,14 @@ void Next100FieldCage::BuildCathode()
                                            GetCoordOrigin().y(),
                                            cathode_zpos_));
 
+  // Generate in a 1 micron thick disk in front of cathode
+  cathode_surf_gen_ =
+    new CylinderPointSampler(0.0, cathode_int_diam_/2.,
+                             1.0*micrometer,0., twopi, nullptr,
+                             G4ThreeVector(GetCoordOrigin().x(),
+                                           GetCoordOrigin().y(),
+                                           cathode_grid_zpos - grid_thickn_ - 1*micrometer));
+
 
   /// Visibilities
   G4VisAttributes cathode_col = nexus::DarkGrey();
@@ -1079,6 +1087,7 @@ Next100FieldCage::~Next100FieldCage()
   delete hdpe_gen_;
   delete ring_gen_;
   delete cathode_gen_;
+  delete cathode_surf_gen_;
   delete gate_gen_;
   delete anode_gen_;
   delete holder_gen_;
@@ -1107,6 +1116,10 @@ G4ThreeVector Next100FieldCage::GenerateVertex(const G4String& region) const
 
   else if (region == "CATHODE_RING") {
     vertex = cathode_gen_->GenerateVertex(VOLUME);
+  }
+
+  else if (region == "CATHODE_SURF"){
+    vertex = cathode_surf_gen_->GenerateVertex(VOLUME);
   }
 
   else if (region == "BUFFER") {

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -486,7 +486,7 @@ void Next100FieldCage::BuildCathode()
                              0.5*micrometer,0., twopi, nullptr,
                              G4ThreeVector(GetCoordOrigin().x(),
                                            GetCoordOrigin().y(),
-                                           cathode_grid_zpos - grid_thickn_ - 1.0*micrometer));
+                                           cathode_grid_zpos - grid_thickn_ - 0.5*micrometer));
 
 
   /// Visibilities

--- a/source/geometries/Next100FieldCage.h
+++ b/source/geometries/Next100FieldCage.h
@@ -112,6 +112,7 @@ namespace nexus {
     CylinderPointSampler* hdpe_gen_;
     CylinderPointSampler* ring_gen_;
     CylinderPointSampler* cathode_gen_;
+    CylinderPointSampler* cathode_surf_gen_;
     CylinderPointSampler* gate_gen_;
     CylinderPointSampler* anode_gen_;
     CylinderPointSampler* holder_gen_;

--- a/source/geometries/Next100InnerElements.cc
+++ b/source/geometries/Next100InnerElements.cc
@@ -103,6 +103,7 @@ namespace nexus {
     if ((region == "CENTER") ||
         (region == "ACTIVE") ||
         (region == "CATHODE_RING") ||
+        (region == "CATHODE_SURF") ||
         (region == "BUFFER") ||
         (region == "XENON")  ||
         (region == "S2_PMT_LT") ||


### PR DESCRIPTION
This PR adds a generator to make events in a 1 micron thickness, 1 micron in front of the cathode mesh. This is for modelling the plated-out Rn events. 

According to the geometry, the cathode mesh sits at `z = 1187.37 mm`. 100k test events were generated with the following coordinates:

var | initial_x | initial_y | initial_z
-- |-- | -- | --
min| -482.316803 | -482.406372 | 1187.302979
max| 482.427917 | 482.360321 | 1187.305054

The z positions are just in front of the cathode mesh surface. 

<img width="841" alt="image" src="https://github.com/user-attachments/assets/9173990d-f85f-4485-9e0b-f288404bea8a" />





