### PR TITLE
Reduce PTFE reflectivity by 4 percent

### DIFF
--- a/source/materials/OpticalMaterialProperties.cc
+++ b/source/materials/OpticalMaterialProperties.cc
@@ -777,7 +777,7 @@ namespace opticalprops {
       6. * eV,       7.2 * eV,  optPhotMaxE_
     };
     std::vector<G4double> REFLECTIVITY = {
-      .98,  .98,  .98,  .98,
+      .94,  .94,  .94,  .94,
       .72,  .72,  .72
     };
     mpt->AddProperty("REFLECTIVITY", ENERGIES, REFLECTIVITY);


### PR DESCRIPTION
Based on studies with alpha particles, the PTFE reflectivity is better matched in NEXT-100 to 94%.
https://next.ific.uv.es/cgi-bin/DocDB/private/ShowDocument?docid=1739

