### PR TITLE
Update NEXT100 TPB thickness

### DIFF
--- a/source/geometries/Next100EnergyPlane.cc
+++ b/source/geometries/Next100EnergyPlane.cc
@@ -57,7 +57,7 @@ namespace nexus {
 
     sapphire_window_thickn_ (6. * mm),
     optical_pad_thickn_ (1.0 * mm),
-    tpb_thickn_ (1.*micrometer),
+    tpb_thickn_ (5.4*micrometer),
 
     pmt_stand_out_ (2. * mm), // length that PMTs stand out of copper, in the front
     pmt_base_diam_ (46.8 * mm),

--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -92,7 +92,7 @@ Next100FieldCage::Next100FieldCage(G4double grid_thickn):
   num_drift_rings_ (48),
   num_buffer_rings_ (4),
 
-  tpb_thickn_ (1 * micrometer),
+  tpb_thickn_ (3.5 * micrometer),
   overlap_    (0.001*mm), //defined for G4UnionSolids to ensure a common volume within the two joined solids
   // Diffusion constants
   drift_transv_diff_ (1. * mm/sqrt(cm)),

--- a/source/geometries/Next100SiPM.cc
+++ b/source/geometries/Next100SiPM.cc
@@ -33,7 +33,7 @@ Next100SiPM::Next100SiPM():
   mother_depth_       (0),
   naming_order_       (0),
   time_binning_       (1.0 * us),
-  coating_thickn_     (2. * micrometer),
+  coating_thickn_     (3. * micrometer),
   visibility_         (true)
 {
 }

--- a/source/geometries/Next100SiPMBoard.cc
+++ b/source/geometries/Next100SiPMBoard.cc
@@ -131,7 +131,7 @@ void Next100SiPMBoard::Construct()
   // WLS COATING /////////////////////////////////////////////////////
 
   G4String mask_wls_name = "SIPM_BOARD_MASK_WLS";
-  G4double wls_thickness = 1. * um;
+  G4double wls_thickness = 4.1 * um;
   G4double mask_wls_zpos = mask_thickness_/2. - wls_thickness/2.;
 
   G4Box* mask_wls_solid_vol =


### PR DESCRIPTION
Based on https://next.ific.uv.es/cgi-bin/DocDB/private/ShowDocument?docid=1775 the TPB thickness should be closer to 3-4 microns.  3.5 micron is input as an average. 