### PR TITLE
Fix distance between dice boards

### DIFF
--- a/source/geometries/Next100TrackingPlane.cc
+++ b/source/geometries/Next100TrackingPlane.cc
@@ -32,7 +32,7 @@ Next100TrackingPlane::Next100TrackingPlane():
   GeometryBase(),
   copper_plate_diameter_  (1340.*mm),
   copper_plate_thickness_ ( 145.*mm),
-  distance_board_board_   (   1.*mm),
+  distance_board_board_   (   2.*mm),
 
   visibility_(true),
   sipm_board_geom_(new Next100SiPMBoard),


### PR DESCRIPTION
The difference in sipm x-positions between adjacent dices was not the same as within a board (15.55 mm). The geometry was previously tweaked in #170 and #219, but somewhere along the way we forgot to ensure the distances were correct.