### PR TITLE
Delay full simulation until deposited energy is known

### DIFF
--- a/macros/NEXT100.init.mac
+++ b/macros/NEXT100.init.mac
@@ -22,6 +22,8 @@
 /nexus/RegisterRunAction DefaultRunAction
 /nexus/RegisterEventAction DefaultEventAction
 /nexus/RegisterTrackingAction DefaultTrackingAction
+/nexus/RegisterStackingAction DefaultStackingAction
+/nexus/RegisterSteppingAction DefaultSteppingAction
 
 /nexus/RegisterMacro macros/NEXT100.config.mac
 /nexus/RegisterDelayedMacro macros/physics/Bi214.mac

--- a/source/actions/DefaultEventAction.cc
+++ b/source/actions/DefaultEventAction.cc
@@ -28,7 +28,7 @@ namespace nexus {
 REGISTER_CLASS(DefaultEventAction, G4UserEventAction)
 
   DefaultEventAction::DefaultEventAction():
-    G4UserEventAction(), nevt_(0), nupdate_(10), energy_min_(0.), energy_max_(DBL_MAX)
+    G4UserEventAction(), nevt_(0), nupdate_(10), energy_min_(0.), energy_max_(DBL_MAX), energy_evt_(0)
   {
     msg_ = new G4GenericMessenger(this, "/Actions/DefaultEventAction/");
 
@@ -67,6 +67,7 @@ REGISTER_CLASS(DefaultEventAction, G4UserEventAction)
       G4cout << " >> Event no. " << nevt_  << G4endl;
       if (nevt_  == (10 * nupdate_)) nupdate_ *= 10;
     }
+    energy_evt_ = 0;
   }
 
 

--- a/source/actions/DefaultEventAction.h
+++ b/source/actions/DefaultEventAction.h
@@ -33,11 +33,19 @@ namespace nexus {
     /// Hook at the end of the event loop
     void EndOfEventAction(const G4Event*);
 
+    // At some point this should converge with the calculations done in EndOfEventAction
+    void AddToEventEnergy(G4double e) { energy_evt_ += e; }
+    bool IsDepositedEnergyInRange() {
+      return (energy_evt_ >= energy_min_) &&
+             (energy_evt_ <  energy_max_);
+    }
+
   private:
     G4GenericMessenger* msg_;
     G4int nevt_, nupdate_;
     G4double energy_min_;
     G4double energy_max_;
+    G4double energy_evt_;
   };
 
 } // namespace nexus

--- a/source/actions/DefaultStackingAction.cc
+++ b/source/actions/DefaultStackingAction.cc
@@ -10,7 +10,10 @@
 
 #include "DefaultStackingAction.h"
 #include "FactoryBase.h"
+#include "IonizationElectron.h"
 
+#include <G4OpticalPhoton.hh>
+#include <G4Track.hh>
 
 using namespace nexus;
 
@@ -29,9 +32,15 @@ DefaultStackingAction::~DefaultStackingAction()
 
 
 G4ClassificationOfNewTrack
-DefaultStackingAction::ClassifyNewTrack(const G4Track* /*track*/)
+DefaultStackingAction::ClassifyNewTrack(const G4Track* track)
 {
-  return fUrgent;
+  static auto opticalphoton = G4OpticalPhoton::Definition();
+  static auto ielectron     = IonizationElectron::Definition();
+  auto pdef = track->GetParticleDefinition();
+
+  return (pdef == opticalphoton) || (pdef == ielectron) ?
+    G4ClassificationOfNewTrack::fWaiting                :
+    G4ClassificationOfNewTrack::fUrgent                 ;
 }
 
 

--- a/source/actions/DefaultStackingAction.cc
+++ b/source/actions/DefaultStackingAction.cc
@@ -9,10 +9,12 @@
 
 
 #include "DefaultStackingAction.h"
+#include "DefaultEventAction.h"
 #include "FactoryBase.h"
 #include "IonizationElectron.h"
 
 #include <G4OpticalPhoton.hh>
+#include <G4EventManager.hh>
 #include <G4Track.hh>
 
 using namespace nexus;
@@ -47,7 +49,14 @@ DefaultStackingAction::ClassifyNewTrack(const G4Track* track)
 
 void DefaultStackingAction::NewStage()
 {
-  return;
+  /// At this point, tracks in the waiting stack have already been moved
+  /// to the urgent stack, so if the deposited energy does not fall in
+  /// the specified range, we clear them
+  static auto event_action =
+    static_cast<DefaultEventAction*>(G4EventManager::GetEventManager() -> GetUserEventAction());
+
+  if (!event_action -> IsDepositedEnergyInRange())
+    stackManager -> ClearUrgentStack();
 }
 
 

--- a/source/actions/DefaultStackingAction.h
+++ b/source/actions/DefaultStackingAction.h
@@ -28,6 +28,9 @@ namespace nexus {
     virtual G4ClassificationOfNewTrack ClassifyNewTrack(const G4Track*);
     virtual void NewStage();
     virtual void PrepareNewEvent();
+
+  private:
+    unsigned stage_;
   };
 
 } // end namespace nexus

--- a/source/actions/DefaultSteppingAction.cc
+++ b/source/actions/DefaultSteppingAction.cc
@@ -1,0 +1,56 @@
+// ----------------------------------------------------------------------------
+// nexus | DefaultSteppingAction.cc
+//
+// This class is the default stepping action of the NEXT simulation.
+// It adds the deposited energy to the accumulator in the event action
+//
+// The NEXT Collaboration
+// ----------------------------------------------------------------------------
+
+#include "DefaultSteppingAction.h"
+#include "DefaultEventAction.h"
+#include "FactoryBase.h"
+#include "IonizationElectron.h"
+
+#include <G4OpticalPhoton.hh>
+#include <G4ParticleDefinition.hh>
+#include <G4EventManager.hh>
+#include <G4Step.hh>
+
+using namespace nexus;
+
+REGISTER_CLASS(DefaultSteppingAction, G4UserSteppingAction)
+
+DefaultSteppingAction::DefaultSteppingAction() : G4UserSteppingAction()
+{
+}
+
+DefaultSteppingAction::~DefaultSteppingAction()
+{
+}
+
+bool IsSensitive(const G4String &s) {
+  return (s == "ACTIVE") ? true :
+         (s == "BUFFER") ? true :
+         (s == "EL_GAP")
+    ;
+}
+
+void DefaultSteppingAction::UserSteppingAction(const G4Step* step)
+{
+  auto track = step->GetTrack();
+  // Do nothing if the track is an optical photon or an ionization electron
+  if (track->GetDefinition() ==    G4OpticalPhoton::Definition() ||
+      track->GetDefinition() == IonizationElectron::Definition() )
+    return;
+
+
+  auto  pre_vol_name = step-> GetPreStepPoint()->GetTouchable()->GetVolume()->GetName();
+  if (!IsSensitive(pre_vol_name)) return;
+
+  auto post_vol_name = step->GetPostStepPoint()->GetTouchable()->GetVolume()->GetName();
+  if (!IsSensitive(post_vol_name)) return;
+
+  static auto event_action = static_cast<DefaultEventAction*>(G4EventManager::GetEventManager()->GetUserEventAction());
+  event_action->AddToEventEnergy(step->GetTotalEnergyDeposit());
+}

--- a/source/actions/DefaultSteppingAction.h
+++ b/source/actions/DefaultSteppingAction.h
@@ -1,0 +1,33 @@
+// ----------------------------------------------------------------------------
+// nexus | DefaultSteppingAction.h
+//
+// This class is the default stepping action of the NEXT simulation.
+// It adds the deposited energy to the accumulator in the event action
+//
+// The NEXT Collaboration
+// ----------------------------------------------------------------------------
+
+#ifndef DEFAULTSTEPPINGACTION_H_
+#define DEFAULTSTEPPINGACTION_H_
+
+#include <G4UserSteppingAction.hh>
+
+class G4Step;
+
+
+namespace nexus {
+
+  class DefaultSteppingAction: public G4UserSteppingAction
+  {
+  public:
+    /// Constructor
+    DefaultSteppingAction();
+    /// Destructor
+    ~DefaultSteppingAction();
+
+    void UserSteppingAction(const G4Step*) override;
+  };
+
+}
+
+#endif // DEFAULTSTEPPINGACTION_H_


### PR DESCRIPTION
Full simulation is computationally very expensive. The main reason is light tracking, as a large number of optical photons can be produced per event. Moreover, nexus is capable of disregarding (not saving) events depending on their energy. However, this is criterion is only checked at the end of the full event simulation, which includes the propagation of photons. This can result in a long simulation that ends up being thrown away.

In this PR we introduce a stacking action that delays the propagation of photons (and ionization electrons, which turn will only produce more optical photons) until all particles that can deposit energy are tracked. The result is a two-stage simulation similar to what we have in what we call fast-sim:
- a (fast) first stage in which the "main" particles are tracked, which allows to compute the deposited energy
- a (slow) second stage in which optical photons are produced[^1] and tracked

with the second stage performed only when the event meets the deposited energy criterion.

[^1]: S1 photons are actually produced in the first stage, but not tracked immediately. S2 photons are generated during the second stage, when the ionization electrons delayed from the first stage are tracked.