### PR TITLE
Fix XeHe molar fraction material construction

### DIFF
--- a/source/geometries/Next100FieldCage.cc
+++ b/source/geometries/Next100FieldCage.cc
@@ -757,7 +757,8 @@ void Next100FieldCage::BuildELRegion()
       el_field->SetLightYield(ArgonELLightYield(ELelectric_field_, pressure_));
     }
     // Note, the XeHe adopts pure xenon scintillation yeild. This will need to be updated. 
-    else if (gas_->GetName() == "GXe" || gas_->GetName() == "GXeEnriched" || gas_->GetName() == "GXeDepleted" || gas_->GetName() == "GXeHe"){
+    else if (gas_->GetName() == "GXe" || gas_->GetName() == "GXeEnriched" ||
+             gas_->GetName() == "GXeDepleted" || gas_->GetName().find("GXeHe") == 0){
       el_field->SetLightYield(XenonELLightYield(ELelectric_field_, pressure_));
     } else {
       G4Exception("[Next100FieldCage]", "BuildELRegion()", FatalException,

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -73,7 +73,7 @@ namespace nexus {
     // Visibility
     visibility_(0),
     gas_("enrichedXe"),
-    xe_he_xe_type_("naturalXe"),
+    xe_he_type_("naturalXe"),
     helium_mass_num_(4),
     xe_perc_(100.),
     th_source_("no_source"),
@@ -105,10 +105,10 @@ namespace nexus {
     msg_->DeclareProperty("gas", gas_, "Gas being used");
     msg_->DeclareProperty("XePercentage", xe_perc_, "Percentage of xenon used in mixtures");
     msg_->DeclareProperty("helium_A", helium_mass_num_, "Mass number for helium used, 3 or 4");
-    G4GenericMessenger::Command& xe_he_xe_type_cmd =
-      msg_->DeclareProperty("XeHeXenonType", xe_he_xe_type_,
+    G4GenericMessenger::Command& xe_he_type_cmd =
+      msg_->DeclareProperty("XeHeXenonType", xe_he_type_,
                             "Xenon type used in XeHe mixtures.");
-    xe_he_xe_type_cmd.SetCandidates("naturalXe enrichedXe depletedXe");
+    xe_he_type_cmd.SetCandidates("naturalXe enrichedXe depletedXe");
 
     G4GenericMessenger::Command& pressure_cmd =
       msg_->DeclareProperty("pressure", pressure_, "Xenon pressure");
@@ -346,7 +346,7 @@ namespace nexus {
       vessel_gas_mat =  materials::GXeDepleted(pressure_, temperature_);
     } else if  (gas_ == "XeHe") {
       vessel_gas_mat = materials::GXeHe(pressure_, 300. * kelvin,
-					    xe_perc_, helium_mass_num_, xe_he_xe_type_);
+					    xe_perc_, helium_mass_num_, xe_he_type_);
     } else if  (gas_ == "GAr") {
       vessel_gas_mat = materials::GAr(pressure_, temperature_);
     } else {

--- a/source/geometries/Next100Vessel.cc
+++ b/source/geometries/Next100Vessel.cc
@@ -73,6 +73,7 @@ namespace nexus {
     // Visibility
     visibility_(0),
     gas_("enrichedXe"),
+    xe_he_xe_type_("naturalXe"),
     helium_mass_num_(4),
     xe_perc_(100.),
     th_source_("no_source"),
@@ -104,6 +105,10 @@ namespace nexus {
     msg_->DeclareProperty("gas", gas_, "Gas being used");
     msg_->DeclareProperty("XePercentage", xe_perc_, "Percentage of xenon used in mixtures");
     msg_->DeclareProperty("helium_A", helium_mass_num_, "Mass number for helium used, 3 or 4");
+    G4GenericMessenger::Command& xe_he_xe_type_cmd =
+      msg_->DeclareProperty("XeHeXenonType", xe_he_xe_type_,
+                            "Xenon type used in XeHe mixtures.");
+    xe_he_xe_type_cmd.SetCandidates("naturalXe enrichedXe depletedXe");
 
     G4GenericMessenger::Command& pressure_cmd =
       msg_->DeclareProperty("pressure", pressure_, "Xenon pressure");
@@ -341,7 +346,7 @@ namespace nexus {
       vessel_gas_mat =  materials::GXeDepleted(pressure_, temperature_);
     } else if  (gas_ == "XeHe") {
       vessel_gas_mat = materials::GXeHe(pressure_, 300. * kelvin,
-					    xe_perc_, helium_mass_num_);
+					    xe_perc_, helium_mass_num_, xe_he_xe_type_);
     } else if  (gas_ == "GAr") {
       vessel_gas_mat = materials::GAr(pressure_, temperature_);
     } else {

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -67,7 +67,8 @@ namespace nexus {
 
     // Type of gas being used
     G4String gas_;
-    G4String xe_he_xe_type_;
+    // Xenon type to mix with helium in XeHe gas.
+    G4String xe_he_type_;
     G4int helium_mass_num_;
     G4double xe_perc_;
 

--- a/source/geometries/Next100Vessel.h
+++ b/source/geometries/Next100Vessel.h
@@ -67,6 +67,7 @@ namespace nexus {
 
     // Type of gas being used
     G4String gas_;
+    G4String xe_he_xe_type_;
     G4int helium_mass_num_;
     G4double xe_perc_;
 

--- a/source/geometries/NextNewVessel.cc
+++ b/source/geometries/NextNewVessel.cc
@@ -106,6 +106,7 @@ namespace nexus {
     sc_yield_(25510. * 1/MeV),
     e_lifetime_(1000. * ms),
     gas_("naturalXe"),
+    xe_he_xe_type_("naturalXe"),
     xe_perc_(100.),
     helium_mass_num_(4),
     //   source_(false),
@@ -153,6 +154,10 @@ namespace nexus {
 			  "Percentage of xenon used in mixtures");
     msg_->DeclareProperty("helium_A", helium_mass_num_,
 			  "Mass number for helium used, 3 or 4");
+    G4GenericMessenger::Command& xe_he_xe_type_cmd =
+      msg_->DeclareProperty("XeHeXenonType", xe_he_xe_type_,
+                            "Xenon type used in XeHe mixtures.");
+    xe_he_xe_type_cmd.SetCandidates("naturalXe enrichedXe depletedXe");
 
     // msg_->DeclareProperty("source", source_, "Radioactive source being used");
     msg_->DeclareProperty("internal_calib_port", calib_port_, "Calibration port being used");
@@ -426,7 +431,7 @@ void NextNewVessel::Construct()
       vessel_gas_mat->SetMaterialPropertiesTable(opticalprops::GAr(sc_yield_, e_lifetime_));
     } else if (gas_ == "XeHe") {
       vessel_gas_mat =  materials::GXeHe(pressure_, temperature_,
-					     xe_perc_, helium_mass_num_);
+					     xe_perc_, helium_mass_num_, xe_he_xe_type_);
       vessel_gas_mat->SetMaterialPropertiesTable(opticalprops::GXe(pressure_, temperature_, sc_yield_, e_lifetime_));
     } else {
       G4Exception("[NextNewVessel]", "Construct()", FatalException,

--- a/source/geometries/NextNewVessel.cc
+++ b/source/geometries/NextNewVessel.cc
@@ -106,7 +106,7 @@ namespace nexus {
     sc_yield_(25510. * 1/MeV),
     e_lifetime_(1000. * ms),
     gas_("naturalXe"),
-    xe_he_xe_type_("naturalXe"),
+    xe_he_type_("naturalXe"),
     xe_perc_(100.),
     helium_mass_num_(4),
     //   source_(false),
@@ -154,10 +154,10 @@ namespace nexus {
 			  "Percentage of xenon used in mixtures");
     msg_->DeclareProperty("helium_A", helium_mass_num_,
 			  "Mass number for helium used, 3 or 4");
-    G4GenericMessenger::Command& xe_he_xe_type_cmd =
-      msg_->DeclareProperty("XeHeXenonType", xe_he_xe_type_,
+    G4GenericMessenger::Command& xe_he_type_cmd =
+      msg_->DeclareProperty("XeHeXenonType", xe_he_type_,
                             "Xenon type used in XeHe mixtures.");
-    xe_he_xe_type_cmd.SetCandidates("naturalXe enrichedXe depletedXe");
+    xe_he_type_cmd.SetCandidates("naturalXe enrichedXe depletedXe");
 
     // msg_->DeclareProperty("source", source_, "Radioactive source being used");
     msg_->DeclareProperty("internal_calib_port", calib_port_, "Calibration port being used");
@@ -431,7 +431,7 @@ void NextNewVessel::Construct()
       vessel_gas_mat->SetMaterialPropertiesTable(opticalprops::GAr(sc_yield_, e_lifetime_));
     } else if (gas_ == "XeHe") {
       vessel_gas_mat =  materials::GXeHe(pressure_, temperature_,
-					     xe_perc_, helium_mass_num_, xe_he_xe_type_);
+					     xe_perc_, helium_mass_num_, xe_he_type_);
       vessel_gas_mat->SetMaterialPropertiesTable(opticalprops::GXe(pressure_, temperature_, sc_yield_, e_lifetime_));
     } else {
       G4Exception("[NextNewVessel]", "Construct()", FatalException,

--- a/source/geometries/NextNewVessel.h
+++ b/source/geometries/NextNewVessel.h
@@ -114,6 +114,7 @@ namespace nexus {
 
     // Gas being used
     G4String gas_;
+    G4String xe_he_xe_type_;
     G4double xe_perc_;
     G4int helium_mass_num_;
 

--- a/source/geometries/NextNewVessel.h
+++ b/source/geometries/NextNewVessel.h
@@ -114,7 +114,8 @@ namespace nexus {
 
     // Gas being used
     G4String gas_;
-    G4String xe_he_xe_type_;
+    // Xenon type to mix with helium in XeHe gas.
+    G4String xe_he_type_;
     G4double xe_perc_;
     G4int helium_mass_num_;
 

--- a/source/geometries/NextTonScale.cc
+++ b/source/geometries/NextTonScale.cc
@@ -34,7 +34,7 @@ REGISTER_CLASS(NextTonScale, GeometryBase)
 NextTonScale::NextTonScale():
   GeometryBase(),
   msg_(nullptr),
-  gas_("naturalXe"), xe_he_xe_type_("naturalXe"),
+  gas_("naturalXe"), xe_he_type_("naturalXe"),
   gas_pressure_(15.*bar), gas_temperature_(300.*kelvin),
   detector_diam_(0.), detector_length_(0.),
   tank_size_(0.), tank_thickn_(1.*cm), water_thickn_(3.*m),
@@ -460,7 +460,7 @@ void NextTonScale::DefineGas()
     xenon_gas_ = materials::GXeDepleted(gas_pressure_, gas_temperature_);
   else if (gas_ == "XeHe")
     xenon_gas_ = materials::GXeHe(gas_pressure_, gas_temperature_,
-				      xe_perc_, helium_mass_num_, xe_he_xe_type_);
+				      xe_perc_, helium_mass_num_, xe_he_type_);
   else
     G4Exception("[NextTonScale]", "DefineGas()", FatalException,
     "Unknown xenon gas type. Valid options are naturalXe, enrichedXe, depletedXe or XeHe.");
@@ -546,10 +546,10 @@ void NextTonScale::DefineConfigurationParameters()
 			  "Mass number for helium used, 3 or 4");
   type_helium_cmd.SetParameterName("helium_A", false);
 
-  G4GenericMessenger::Command& xe_he_xe_type_cmd =
-    msg_->DeclareProperty("XeHeXenonType", xe_he_xe_type_,
+  G4GenericMessenger::Command& xe_he_type_cmd =
+    msg_->DeclareProperty("XeHeXenonType", xe_he_type_,
                           "Xenon type used in XeHe mixtures.");
-  xe_he_xe_type_cmd.SetCandidates("naturalXe enrichedXe depletedXe");
+  xe_he_type_cmd.SetCandidates("naturalXe enrichedXe depletedXe");
 
 
   // Geometry visibilities /////////////////////////////////

--- a/source/geometries/NextTonScale.cc
+++ b/source/geometries/NextTonScale.cc
@@ -34,7 +34,8 @@ REGISTER_CLASS(NextTonScale, GeometryBase)
 NextTonScale::NextTonScale():
   GeometryBase(),
   msg_(nullptr),
-  gas_("naturalXe"), gas_pressure_(15.*bar), gas_temperature_(300.*kelvin),
+  gas_("naturalXe"), xe_he_xe_type_("naturalXe"),
+  gas_pressure_(15.*bar), gas_temperature_(300.*kelvin),
   detector_diam_(0.), detector_length_(0.),
   tank_size_(0.), tank_thickn_(1.*cm), water_thickn_(3.*m),
   vessel_thickn_(1.5*mm), ics_thickn_(12.*cm), endcap_hollow_(20.*cm),
@@ -459,10 +460,10 @@ void NextTonScale::DefineGas()
     xenon_gas_ = materials::GXeDepleted(gas_pressure_, gas_temperature_);
   else if (gas_ == "XeHe")
     xenon_gas_ = materials::GXeHe(gas_pressure_, gas_temperature_,
-				      xe_perc_, helium_mass_num_);
+				      xe_perc_, helium_mass_num_, xe_he_xe_type_);
   else
     G4Exception("[NextTonScale]", "DefineGas()", FatalException,
-    "Unknown xenon gas type. Valid options are naturalXe, enrichedXe or depletedXe.");
+    "Unknown xenon gas type. Valid options are naturalXe, enrichedXe, depletedXe or XeHe.");
 }
 
 
@@ -544,6 +545,11 @@ void NextTonScale::DefineConfigurationParameters()
     msg_->DeclareProperty("helium_A", helium_mass_num_,
 			  "Mass number for helium used, 3 or 4");
   type_helium_cmd.SetParameterName("helium_A", false);
+
+  G4GenericMessenger::Command& xe_he_xe_type_cmd =
+    msg_->DeclareProperty("XeHeXenonType", xe_he_xe_type_,
+                          "Xenon type used in XeHe mixtures.");
+  xe_he_xe_type_cmd.SetCandidates("naturalXe enrichedXe depletedXe");
 
 
   // Geometry visibilities /////////////////////////////////

--- a/source/geometries/NextTonScale.h
+++ b/source/geometries/NextTonScale.h
@@ -48,7 +48,8 @@ namespace nexus {
     G4Material* xenon_gas_;
 
     G4String gas_;
-    G4String xe_he_xe_type_;
+    // Xenon type to mix with helium in XeHe gas.
+    G4String xe_he_type_;
     G4double gas_pressure_, gas_temperature_;
     G4double detector_diam_, detector_length_;
     G4double tank_size_, tank_thickn_, water_thickn_;

--- a/source/geometries/NextTonScale.h
+++ b/source/geometries/NextTonScale.h
@@ -48,6 +48,7 @@ namespace nexus {
     G4Material* xenon_gas_;
 
     G4String gas_;
+    G4String xe_he_xe_type_;
     G4double gas_pressure_, gas_temperature_;
     G4double detector_diam_, detector_length_;
     G4double tank_size_, tank_thickn_, water_thickn_;

--- a/source/materials/MaterialsList.cc
+++ b/source/materials/MaterialsList.cc
@@ -22,6 +22,58 @@ using namespace nexus;
 using namespace CLHEP;
 
 namespace materials {
+    std::vector<std::pair<int, double>> NaturalXenonIsotopicComposition()
+    {
+      return {
+        {124, 0.0952*perCent}, {126, 0.089*perCent}, {128, 1.9102*perCent},
+        {129, 26.4006*perCent}, {130, 4.071*perCent},
+        {131, 21.2324*perCent}, {132, 26.9086*perCent},
+        {134, 10.4357*perCent}, {136, 8.8573*perCent}
+      };
+    }
+
+    std::vector<std::pair<int, double>> EnrichedXenonIsotopicComposition()
+    {
+      return {
+        {129, 0.0656392*perCent}, {130, 0.0656392*perCent},
+        {131, 0.234361*perCent}, {132, 0.708251*perCent},
+        {134, 8.6645*perCent}, {136, 90.2616*perCent}
+      };
+    }
+
+    std::vector<std::pair<int, double>> DepletedXenonIsotopicComposition()
+    {
+      return {
+        {124, 0.102*perCent}, {126, 0.201*perCent},
+        {128, 3.065*perCent}, {129, 24.900*perCent},
+        {130, 5.361*perCent}, {131, 23.280*perCent},
+        {132, 30.666*perCent}, {134, 9.822*perCent},
+        {136, 2.602*perCent}
+      };
+    }
+
+    std::vector<std::pair<int, double>> XenonIsotopicComposition(G4String xe_type)
+    {
+      if (xe_type == "naturalXe") return NaturalXenonIsotopicComposition();
+      if (xe_type == "enrichedXe") return EnrichedXenonIsotopicComposition();
+      if (xe_type == "depletedXe") return DepletedXenonIsotopicComposition();
+
+      G4Exception("[MaterialsList]", "XenonIsotopicComposition()", FatalException,
+                  "Unknown xenon type. Valid options are naturalXe, enrichedXe, or depletedXe.");
+      return NaturalXenonIsotopicComposition();
+    }
+
+    G4String XenonTypeLabel(G4String xe_type)
+    {
+      if (xe_type == "naturalXe") return "Natural";
+      if (xe_type == "enrichedXe") return "Enriched";
+      if (xe_type == "depletedXe") return "Depleted";
+
+      G4Exception("[MaterialsList]", "XenonTypeLabel()", FatalException,
+                  "Unknown xenon type. Valid options are naturalXe, enrichedXe, or depletedXe.");
+      return "Natural";
+    }
+
     // Calculation of Compressibilty factor from https://next.ific.uv.es/DocDB/0011/001183/001/GasDensity_2021-04-23.pdf
     G4double CompressibilityFactor(G4double pressure, G4double temperature) {
         double T_r = temperature/(289.733*kelvin);
@@ -61,11 +113,8 @@ namespace materials {
     }
 
   G4Material* GXe(G4double pressure, G4double temperature) {
-    std::vector<std::pair<int, double>> isotopicComposition = {
-      {124, 0.095*perCent}, {126, 0.089*perCent}, {128, 1.910*perCent},
-      {129, 26.401*perCent}, {130, 4.071*perCent}, {131, 21.232*perCent},
-      {132, 26.909*perCent}, {134,10.436*perCent}, {136, 8.857*perCent}
-    };
+    std::vector<std::pair<int, double>> isotopicComposition =
+      NaturalXenonIsotopicComposition();
 
     G4double gas_density = CalculateGasDensityFromIsotopicComposition(pressure, temperature, isotopicComposition);
     G4Material* mat = GXe_bydensity(gas_density, temperature, pressure);
@@ -87,10 +136,8 @@ namespace materials {
   }
   
   G4Material* GXeEnriched(G4double pressure, G4double temperature) {
-    std::vector<std::pair<int, double>> isotopicComposition = {
-      {129, 0.0656392*perCent}, {130, 0.0656392*perCent}, {131, 0.234361*perCent},
-      {132, 0.708251*perCent}, {134, 8.6645*perCent}, {136, 90.2616*perCent}
-    };
+    std::vector<std::pair<int, double>> isotopicComposition =
+      EnrichedXenonIsotopicComposition();
 
     G4double gas_density = CalculateGasDensityFromIsotopicComposition(pressure, temperature, isotopicComposition);
     G4Material* mat = GXeEnriched_bydensity(gas_density, temperature, pressure, isotopicComposition);
@@ -127,10 +174,8 @@ namespace materials {
   }
 
   G4Material* GXeDepleted(G4double pressure, G4double temperature) {
-    std::vector<std::pair<int, double>> isotopicComposition = {
-      {124, 0.102*perCent}, {126, 0.201*perCent}, {128, 3.065*perCent}, {129, 24.900*perCent}, {130, 5.361*perCent},
-      {131, 23.280*perCent}, {132, 30.666*perCent}, {134, 9.822*perCent}, {136, 2.602*perCent}
-    };
+    std::vector<std::pair<int, double>> isotopicComposition =
+      DepletedXenonIsotopicComposition();
 
     G4double gas_density = CalculateGasDensityFromIsotopicComposition(pressure, temperature, isotopicComposition);
     G4Material* mat = GXeDepleted_bydensity(gas_density, temperature, pressure, isotopicComposition);
@@ -215,10 +260,8 @@ namespace materials {
 
     G4Material* mat = G4Material::GetMaterial(name, false);
 
-    std::vector<std::pair<int, double>> isotopicComposition = {
-      {124, 0.0952*perCent}, {126, 0.089*perCent}, {128, 1.9102*perCent}, {129, 26.4006*perCent},
-      {130, 4.071*perCent}, {131, 21.2324*perCent}, {132, 26.9086*perCent}, {134, 10.4357*perCent}, {136, 8.8573*perCent}
-    };
+    std::vector<std::pair<int, double>> isotopicComposition =
+      NaturalXenonIsotopicComposition();
 
     if (mat == 0) {
 
@@ -269,15 +312,13 @@ namespace materials {
 
   G4Material* GXeHe(G4double pressure,
           G4double temperature,
-          G4double percXe, G4int mass_num)
+          G4double percXe, G4int mass_num, G4String xe_type)
   {
-    G4String name = "GXeHe";
+    G4String xenon_label = XenonTypeLabel(xe_type);
+    G4String name = "GXeHe" + xenon_label;
 
-    // This Xe/He material currently uses enriched xenon.
-    std::vector<std::pair<int, double>> isotopicComposition = {
-      {129, 0.0656392*perCent}, {130, 0.0656392*perCent}, {131, 0.234361*perCent},
-      {132, 0.708251*perCent}, {134, 8.6645*perCent}, {136, 90.2616*perCent}
-    };
+    std::vector<std::pair<int, double>> isotopicComposition =
+      XenonIsotopicComposition(xe_type);
 
     G4Material* mat = G4Material::GetMaterial(name, false);
 
@@ -305,13 +346,13 @@ namespace materials {
         2, kStateGas, temperature, pressure);
 
 
-      G4Element* enrichedXe = new G4Element("GXeEnriched", "enrichedXe", isotopicComposition.size());
+      G4Element* xenon = new G4Element(name + "Xe", "Xe", isotopicComposition.size());
       for (const auto& isotopeInfo : isotopicComposition) {
             int massNumber = isotopeInfo.first;
             double abundance = isotopeInfo.second;
             G4String isotopeName = "Xe" + std::to_string(massNumber);
             G4Isotope* isotope = new G4Isotope(isotopeName, 54, massNumber, XenonMassPerMole(massNumber));
-            enrichedXe->AddIsotope(isotope, abundance); 
+            xenon->AddIsotope(isotope, abundance);
         }
       G4Element * Helium = new G4Element("Helium", "Helium", 1);
       G4Isotope * He     = new G4Isotope("He", 2, mass_num,
@@ -319,7 +360,7 @@ namespace materials {
       Helium->AddIsotope(He, 100 * perCent);
 
       mat->AddElement(Helium, he_mass_fraction);
-      mat->AddElement(enrichedXe, xe_mass_fraction);
+      mat->AddElement(xenon, xe_mass_fraction);
 
 
     }

--- a/source/materials/MaterialsList.cc
+++ b/source/materials/MaterialsList.cc
@@ -220,13 +220,27 @@ namespace materials {
       {130, 4.071*perCent}, {131, 21.2324*perCent}, {132, 26.9086*perCent}, {134, 10.4357*perCent}, {136, 8.8573*perCent}
     };
 
-    G4double GXeNatural_density = CalculateGasDensityFromIsotopicComposition(pressure, temperature, isotopicComposition);
-
     if (mat == 0) {
 
+      G4double xe_molar_fraction = percXe * perCent;
+      if (xe_molar_fraction < 0. || xe_molar_fraction > 1.) {
+        G4Exception("[MaterialsList]", "GXeAr()", FatalException,
+                    "Xe percentage for GXeAr must be between 0 and 100.");
+      }
+
+      G4double ar_molar_fraction = 1. - xe_molar_fraction;
+      G4double xe_molar_mass = AverageXenonMolarMass(isotopicComposition);
+      G4double ar_molar_mass = 39.962383123 * g/mole;
+      G4double mixture_molar_mass =
+        xe_molar_fraction * xe_molar_mass + ar_molar_fraction * ar_molar_mass;
+
+      G4double xe_mass_fraction =
+        xe_molar_fraction * xe_molar_mass / mixture_molar_mass;
+      G4double ar_mass_fraction =
+        ar_molar_fraction * ar_molar_mass / mixture_molar_mass;
+
       mat = new G4Material(name,
-        (1-(percXe/100.))*ArgonDensity(pressure) +
-        percXe/100.*GXeNatural_density,
+        CalculateGasDensityFromMolarMass(pressure, temperature, mixture_molar_mass),
         2, kStateGas, temperature, pressure);
 
       G4Element* NaturalXe = new G4Element("GXeNatural", "Xe", isotopicComposition.size());
@@ -241,10 +255,10 @@ namespace materials {
         }
 
 
-      G4Element* NaturalAr  = new G4Element("Argon", "Ar", 18, 39.962383123*g/mole);
+      G4Element* NaturalAr  = new G4Element("Argon", "Ar", 18, ar_molar_mass);
 
-      mat->AddElement(NaturalAr, (100-percXe)*perCent);
-      mat->AddElement(NaturalXe, percXe*perCent);
+      mat->AddElement(NaturalAr, ar_mass_fraction);
+      mat->AddElement(NaturalXe, xe_mass_fraction);
     }
 
       return mat;
@@ -259,6 +273,7 @@ namespace materials {
   {
     G4String name = "GXeHe";
 
+    // This Xe/He material currently uses enriched xenon.
     std::vector<std::pair<int, double>> isotopicComposition = {
       {129, 0.0656392*perCent}, {130, 0.0656392*perCent}, {131, 0.234361*perCent},
       {132, 0.708251*perCent}, {134, 8.6645*perCent}, {136, 90.2616*perCent}

--- a/source/materials/MaterialsList.cc
+++ b/source/materials/MaterialsList.cc
@@ -31,24 +31,33 @@ namespace materials {
         return z;
     }
 
+    G4double AverageXenonMolarMass(const std::vector<std::pair<int, double>>& isotopicComposition)
+    {
+      G4double average_molar_mass = 0.;
+
+      for (const auto& iso : isotopicComposition) {
+        G4int mass_number = iso.first;
+        G4double abundance = iso.second;
+        average_molar_mass += XenonMassPerMole(mass_number) * abundance;
+      }
+
+      return average_molar_mass;
+    }
+
+    G4double CalculateGasDensityFromMolarMass(G4double pressure, G4double temperature,
+                                              G4double molar_mass)
+    {
+      const G4double R = 8.314 * joule/(mole*kelvin); // Ideal gas constant
+      G4double z = CompressibilityFactor(pressure, temperature);
+      return pressure * molar_mass / (z * R * temperature);
+    }
+
     // Function to calculate gas density based on Xe isotopic composition
     G4double CalculateGasDensityFromIsotopicComposition(G4double pressure, G4double temperature,
-     const std::vector<std::pair<int, double>>& isotopicComposition)
-      {
-        const double R = 8.314*joule/(mole*kelvin); // Ideal gas constant
-        double average_molar_mass = 0.0;
-
-        for (const auto& iso : isotopicComposition) {
-            int mass_number = iso.first;
-            double percentage = iso.second;
-            double molar_mass = XenonMassPerMole(mass_number);
-            average_molar_mass += molar_mass * percentage;
-        }
-
-
-        double z = CompressibilityFactor(pressure, temperature);
-        double density = (pressure * average_molar_mass) / (z * R * temperature);
-        return density;
+      const std::vector<std::pair<int, double>>& isotopicComposition)
+    {
+      return CalculateGasDensityFromMolarMass(pressure, temperature,
+        AverageXenonMolarMass(isotopicComposition));
     }
 
   G4Material* GXe(G4double pressure, G4double temperature) {
@@ -255,18 +264,29 @@ namespace materials {
       {132, 0.708251*perCent}, {134, 8.6645*perCent}, {136, 90.2616*perCent}
     };
 
-    G4double GXeEnriched_density = CalculateGasDensityFromIsotopicComposition(pressure, temperature, isotopicComposition);
-
     G4Material* mat = G4Material::GetMaterial(name, false);
 
     if (mat == 0) {
 
-      G4double prop_xe = percXe * perCent;
-      G4double prop_he = 1. - prop_xe;
+      G4double xe_molar_fraction = percXe * perCent;
+      if (xe_molar_fraction < 0. || xe_molar_fraction > 1.) {
+        G4Exception("[MaterialsList]", "GXeHe()", FatalException,
+                    "Xe percentage for GXeHe must be between 0 and 100.");
+      }
+
+      G4double he_molar_fraction = 1. - xe_molar_fraction;
+      G4double xe_molar_mass = AverageXenonMolarMass(isotopicComposition);
+      G4double he_molar_mass = HeliumMassPerMole(mass_num);
+      G4double mixture_molar_mass =
+        xe_molar_fraction * xe_molar_mass + he_molar_fraction * he_molar_mass;
+
+      G4double xe_mass_fraction =
+        xe_molar_fraction * xe_molar_mass / mixture_molar_mass;
+      G4double he_mass_fraction =
+        he_molar_fraction * he_molar_mass / mixture_molar_mass;
 
       mat = new G4Material(name,
-        prop_xe * GXeEnriched_density
-        + prop_he * HeliumDensity(pressure),
+        CalculateGasDensityFromMolarMass(pressure, temperature, mixture_molar_mass),
         2, kStateGas, temperature, pressure);
 
 
@@ -283,8 +303,8 @@ namespace materials {
                 HeliumMassPerMole(mass_num));
       Helium->AddIsotope(He, 100 * perCent);
 
-      mat->AddElement(Helium, prop_he);
-      mat->AddElement(enrichedXe, prop_xe);
+      mat->AddElement(Helium, he_mass_fraction);
+      mat->AddElement(enrichedXe, xe_mass_fraction);
 
 
     }

--- a/source/materials/MaterialsList.h
+++ b/source/materials/MaterialsList.h
@@ -9,6 +9,7 @@
 #ifndef MATERIALS_LIST_H
 #define MATERIALS_LIST_H
 
+#include <G4String.hh>
 #include <globals.hh>
 #include <vector>
 
@@ -53,11 +54,12 @@ namespace materials {
   G4Material* GXeAr(G4double pressure=STP_Pressure,
 			              G4double temperature=STP_Temperature, G4double percXe=0.);
 
-  // Mixture enriched Xe+He. percXe is interpreted as a molar percentage.
+  // Mixture Xe+He. percXe is interpreted as a molar percentage.
   G4Material* GXeHe(G4double pressure=STP_Pressure,
                     G4double temperature=STP_Temperature,
 			              G4double percXe=98,
-			              G4int mass_num=4);
+			              G4int mass_num=4,
+                    G4String xe_type="naturalXe");
 
 
   // Stainless Steel (grade 304L)

--- a/source/materials/MaterialsList.h
+++ b/source/materials/MaterialsList.h
@@ -49,11 +49,11 @@ namespace materials {
   // Argon
   G4Material* GAr(G4double pressure=STP_Pressure,
 			            G4double temperature=STP_Temperature);
-  // Mixture Xe+Ar
+  // Mixture Xe+Ar. percXe is interpreted as a molar percentage.
   G4Material* GXeAr(G4double pressure=STP_Pressure,
 			              G4double temperature=STP_Temperature, G4double percXe=0.);
 
-  // Mixture Xe+He
+  // Mixture enriched Xe+He. percXe is interpreted as a molar percentage.
   G4Material* GXeHe(G4double pressure=STP_Pressure,
                     G4double temperature=STP_Temperature,
 			              G4double percXe=98,


### PR DESCRIPTION
Fixes a bug in the creation of the Xe/He mixture, identified by @martinperezmaneiro 

G4Material::AddElement interprets the numeric fraction argument as a mass fraction. GXeHe was using the requested Xe percentage directly, which made 85/15 Xe/He become 85/15 by mass rather than by molar fraction.

Compute the enriched-xenon molar mass, form the Xe/He mixture molar mass from the requested molar fractions, and derive the mass fractions passed to Geant4 from those molar fractions. Use the same mixture molar mass for the gas density calculation so the material density and composition are internally consistent.